### PR TITLE
feat: improve memory dump serialization and web_fetch capabilities

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -239,18 +239,13 @@ def _dump_memory(session_id: str):
             )
             return
 
-        # Prepare export data
+        # Prepare export data - use to_dict() for proper serialization including tool_calls
         export_data = {
             "session_id": session_id,
             "exported_at": datetime.now().isoformat(),
             "stats": session_data["stats"],
-            "system_messages": [
-                {"role": msg.role, "content": msg.content}
-                for msg in session_data["system_messages"]
-            ],
-            "messages": [
-                {"role": msg.role, "content": msg.content} for msg in session_data["messages"]
-            ],
+            "system_messages": [msg.to_dict() for msg in session_data["system_messages"]],
+            "messages": [msg.to_dict() for msg in session_data["messages"]],
             "summaries": [
                 {
                     "summary": s.summary,
@@ -259,9 +254,7 @@ def _dump_memory(session_id: str):
                     "compressed_tokens": s.compressed_tokens,
                     "compression_ratio": s.compression_ratio,
                     "token_savings": s.token_savings,
-                    "preserved_messages": [
-                        {"role": msg.role, "content": msg.content} for msg in s.preserved_messages
-                    ],
+                    "preserved_messages": [msg.to_dict() for msg in s.preserved_messages],
                     "metadata": s.metadata,
                 }
                 for s in session_data["summaries"]

--- a/memory/store.py
+++ b/memory/store.py
@@ -220,7 +220,14 @@ class MemoryStore:
         }
 
         # Add new format fields if present
-        if hasattr(message, "tool_calls") and message.tool_calls:
+        # For assistant messages, always include tool_calls (even if None) for completeness
+        if message.role == "assistant":
+            result["tool_calls"] = (
+                message.tool_calls
+                if (hasattr(message, "tool_calls") and message.tool_calls)
+                else None
+            )
+        elif hasattr(message, "tool_calls") and message.tool_calls:
             result["tool_calls"] = message.tool_calls
 
         if hasattr(message, "tool_call_id") and message.tool_call_id:


### PR DESCRIPTION
- Fix memory dump to include tool_calls and tool_call_id fields
  - interactive.py: use msg.to_dict() instead of manual dict creation
  - memory/store.py: always include tool_calls for assistant messages

- Add URL caching to web_fetch (5min TTL, 100 entries max)
  - New use_cache parameter (default: true)
  - Cache hit indicated in metadata

- Add structured link extraction to web_fetch
  - Extract links with href, text, and type (internal/external/anchor/mailto/tel)
  - Max 50 links per page, added to metadata.links

- Add tests for tool_calls/tool_call_id serialization