### PR TITLE
fix: resolve asyncio issues from phase 1-2 migration

### DIFF
--- a/agent/plan_execute_agent.py
+++ b/agent/plan_execute_agent.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import re
-from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Optional, Tuple
 
 from llm import LLMMessage
@@ -51,15 +50,9 @@ class PlanExecuteAgent(BaseAgent):
     def __init__(self, *args, **kwargs):
         """Initialize the enhanced plan-execute agent."""
         super().__init__(*args, **kwargs)
-        self._executor = ThreadPoolExecutor(max_workers=self.MAX_PARALLEL_STEPS)
         self._exploration_results: Optional[ExplorationResult] = None
         self._current_plan: Optional[ExecutionPlan] = None
         self._failure_count = 0
-
-    def __del__(self):
-        """Clean up thread pool executor."""
-        if hasattr(self, "_executor"):
-            self._executor.shutdown(wait=False)
 
     async def run(self, task: str) -> str:
         """Execute the four-phase agent loop.

--- a/interactive.py
+++ b/interactive.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from prompt_toolkit import prompt
+from prompt_toolkit import PromptSession
 from prompt_toolkit.styles import Style
 
 from config import Config
@@ -47,12 +47,15 @@ async def run_interactive_mode(agent, mode: str):
         }
     )
 
+    # Create async prompt session
+    session = PromptSession(style=prompt_style)
+
     conversation_count = 0
 
     while True:
         try:
-            # Get user input using prompt_toolkit for better Unicode support
-            user_input = prompt([("class:prompt", "You: ")], style=prompt_style).strip()
+            # Get user input using prompt_toolkit's async API for better Unicode support
+            user_input = (await session.prompt_async([("class:prompt", "You: ")])).strip()
 
             # Handle empty input
             if not user_input:


### PR DESCRIPTION
- Fix interactive.py: use PromptSession.prompt_async() instead of sync prompt() to avoid nested asyncio.run() conflict
- Remove unused ThreadPoolExecutor from PlanExecuteAgent after migration to asyncio.TaskGroup for parallel execution