### PR TITLE
feat: --task mode outputs raw result only

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ import argparse
 import asyncio
 import warnings
 
+from rich.console import Console
+
 from agent.agent import ReActAgent
 from config import Config
 from interactive import run_interactive_mode, run_model_setup_mode
@@ -21,7 +23,7 @@ from tools.shell_background import BackgroundTaskManager, ShellTaskStatusTool
 from tools.smart_edit import SmartEditTool
 from tools.web_fetch import WebFetchTool
 from tools.web_search import WebSearchTool
-from utils import get_log_file_path, setup_logger, terminal_ui
+from utils import setup_logger, terminal_ui
 from utils.runtime import ensure_runtime_dirs
 
 warnings.filterwarnings("ignore", message="Pydantic serializer warnings.*", category=UserWarning)
@@ -221,38 +223,13 @@ def main():
         # Single-turn mode: execute one task and exit
         task = args.task
 
-        # Display header and config
-        terminal_ui.print_header(
-            "🤖 Agentic Loop System", subtitle="Intelligent AI Agent with Tool-Calling Capabilities"
-        )
-
-        # Get current model info for display
-        model_info = agent.get_current_model_info()
-        if model_info:
-            model_display = model_info["model_id"]
-            provider_display = model_info["provider"].upper()
-        else:
-            model_display = "NOT CONFIGURED"
-            provider_display = "UNKNOWN"
-
-        config_dict = {
-            "LLM Provider": provider_display,
-            "Model": model_display,
-            "Task": task if len(task) < 100 else task[:97] + "...",
-        }
-        if args.resume:
-            config_dict["Resumed Session"] = agent.memory.session_id or "N/A"
-        terminal_ui.print_config(config_dict)
+        # Quiet mode: suppress all Rich UI output, print raw result only
+        terminal_ui.console = Console(quiet=True)
 
         # Run agent
         result = await agent.run(task)
 
-        terminal_ui.print_final_answer(result)
-
-        # Show log file location
-        log_file = get_log_file_path()
-        if log_file:
-            terminal_ui.print_log_location(log_file)
+        print(result)
 
     asyncio.run(_run())
 

--- a/utils/tui/progress.py
+++ b/utils/tui/progress.py
@@ -260,6 +260,8 @@ class AsyncSpinner:
 
     async def __aenter__(self) -> "AsyncSpinner":
         """Async context manager entry."""
+        if self.console.quiet:
+            return self
         self._start_time = time.time()
         self._running = True
         self._live = Live(


### PR DESCRIPTION
## Summary
- Suppress all Rich UI output (header, config panel, final-answer panel, log location) in `--task` single-turn mode by setting `terminal_ui.console` to `Console(quiet=True)`
- Print the agent result as plain text via `print(result)`, making it suitable for piping and scripting
- Skip `AsyncSpinner` startup when the console is in quiet mode to avoid unnecessary rendering

## Test plan
- [ ] `./scripts/dev.sh check` passes (precommit + typecheck + tests)
- [ ] `python main.py --task "Calculate 1+1"` outputs only the plain-text result with no Rich panels or formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)