### PR TITLE
fix: improve compression UX with TUI spinner

### DIFF
--- a/memory/compressor.py
+++ b/memory/compressor.py
@@ -416,7 +416,7 @@ Original messages ({count} messages, ~{tokens} tokens):
         orphaned_indices = list(pending_tool_uses.values())
 
         if orphaned_indices:
-            logger.warning(
+            logger.debug(
                 f"Found {len(orphaned_indices)} orphaned tool_use without matching tool_result - "
                 f"these will be preserved to wait for results"
             )

--- a/memory/manager.py
+++ b/memory/manager.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from config import Config
 from llm.content_utils import content_has_tool_calls
 from llm.message_types import LLMMessage
+from utils import terminal_ui
+from utils.tui.progress import AsyncSpinner
 
 from .compressor import WorkingMemoryCompressor
 from .short_term import ShortTermMemory
@@ -299,13 +301,14 @@ class MemoryManager:
             if self._todo_context_provider:
                 todo_context = self._todo_context_provider()
 
-            # Perform compression
-            compressed = await self.compressor.compress(
-                messages,
-                strategy=strategy,
-                target_tokens=self._calculate_target_tokens(),
-                todo_context=todo_context,
-            )
+            # Perform compression with TUI spinner
+            async with AsyncSpinner(terminal_ui.console, "Compressing memory..."):
+                compressed = await self.compressor.compress(
+                    messages,
+                    strategy=strategy,
+                    target_tokens=self._calculate_target_tokens(),
+                    todo_context=todo_context,
+                )
 
             # Track compression results
             self.compression_count += 1


### PR DESCRIPTION
## Summary
- Downgraded orphaned `tool_use` log from `warning` to `debug` — this is a normal occurrence during compression, not an error, and was cluttering user-visible output.
- Added `AsyncSpinner` TUI display in `MemoryManager.compress()` so users see a "Compressing memory..." spinner while compression runs, instead of the UI appearing frozen.

## Test plan
- [x] All 298 tests pass (2 skipped)
- [x] `./scripts/dev.sh check` passes (precommit + typecheck + tests)
- [ ] Manual smoke test: run a long conversation that triggers compression, verify spinner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)