### PR TITLE
refactor: rename AgenticLoop → aloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,8 +155,7 @@ data/
 # Claude Code local rules/state (project-local)
 .claude/
 
-# Tool caches
-.AgenticLoop/
+# Tool caches (legacy; now under .aloop/cache)
 
 # Spyder project settings
 .spyderproject

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AgenticLoop — Agent Instructions
+# aloop — Agent Instructions
 
 This file defines the **operational workflow** for making changes in this repo (how to set up, run, test, format, build, and publish). Keep it short, specific, and executable; link to docs for long explanations.
 
@@ -22,10 +22,10 @@ pre-commit install
 
 **IMPORTANT**: Every change must be developed on a new branch using a git worktree, then merged into `main` via pull request.
 
-1. Create a worktree with a new branch: `git worktree add ../AgenticLoop-<branch-name> -b <branch-name>`
+1. Create a worktree with a new branch: `git worktree add ../aloop-<branch-name> -b <branch-name>`
 2. Work in the worktree directory, commit changes there.
 3. Push the branch and open a PR to merge into `main`.
-4. After the PR is merged, clean up: `git worktree remove ../AgenticLoop-<branch-name>`
+4. After the PR is merged, clean up: `git worktree remove ../aloop-<branch-name>`
 
 Never commit directly to `main`. All changes go through PR review.
 
@@ -35,12 +35,12 @@ Worktrees don't automatically share `.venv`. To avoid re-running bootstrap for e
 
 ```bash
 # main checkout
-cd /path/to/AgenticLoop
+cd /path/to/aloop
 ./scripts/bootstrap.sh
 
-# each worktree (example: ../AgenticLoop-my-branch)
-cd /path/to/AgenticLoop-my-branch
-ln -s ../AgenticLoop/.venv .venv
+# each worktree (example: ../aloop-my-branch)
+cd /path/to/aloop-my-branch
+ln -s ../aloop/.venv .venv
 # Point the editable install at *this* worktree (fast; doesn't reinstall deps).
 ./scripts/dev.sh install
 ./scripts/dev.sh check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage Docker build for AgenticLoop
+# Multi-stage Docker build for aloop
 
 FROM python:3.12-slim AS base
 
@@ -30,5 +30,5 @@ ENTRYPOINT ["python", "main.py"]
 CMD ["--help"]
 
 # Usage:
-# Build: docker build -t AgenticLoop .
-# Run: docker run -it --rm -e ANTHROPIC_API_KEY=your_key AgenticLoop --task "Hello"
+# Build: docker build -t aloop .
+# Run: docker run -it --rm -e ANTHROPIC_API_KEY=your_key aloop --task "Hello"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ agent itself, not by a hardcoded workflow. Simple architecture, emergent capabil
 Prerequisites: Python 3.12+ and [uv](https://github.com/astral-sh/uv).
 
 ```bash
-git clone https://github.com/luohaha/AgenticLoop.git
-cd AgenticLoop
+git clone https://github.com/luohaha/aloop.git
+cd aloop
 ./scripts/bootstrap.sh
 ```
 
@@ -132,7 +132,7 @@ aloop --resume a1b2c3d4
 ## Project Structure
 
 ```
-AgenticLoop/
+aloop/
 ├── main.py                 # Entry point (argparse)
 ├── cli.py                  # CLI wrapper (`aloop` entry point)
 ├── interactive.py          # Interactive session, model setup, TUI

--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Command-line interface for AgenticLoop."""
+"""Command-line interface for aloop."""
 
 import os
 import sys

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ _CONFIG_FILE = os.path.join(_RUNTIME_DIR, "config")
 
 # Default configuration template
 _DEFAULT_CONFIG = """\
-# AgenticLoop Configuration
+# aloop Configuration
 #
 # NOTE: Model configuration lives in `.aloop/models.yaml`.
 # This file controls non-model runtime settings only.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,4 +1,4 @@
-# Extending AgenticLoop
+# Extending aloop
 
 ## Adding Tools
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -16,11 +16,11 @@ aloop --help
 ./scripts/dev.sh build
 ```
 
-Creates `dist/agentic_loop-*.whl` and `dist/agentic_loop-*.tar.gz`.
+Creates `dist/aloop-*.whl` and `dist/aloop-*.tar.gz`.
 
 Test locally:
 ```bash
-pip install dist/agentic_loop-*.whl
+pip install dist/aloop-*.whl
 aloop --task "Calculate 1+1"
 ```
 
@@ -30,7 +30,7 @@ aloop --task "Calculate 1+1"
 
 ```bash
 ./scripts/dev.sh publish --test
-pip install --index-url https://test.pypi.org/simple/ AgenticLoop
+pip install --index-url https://test.pypi.org/simple/ aloop
 ```
 
 ### Production PyPI
@@ -46,7 +46,7 @@ pip install --index-url https://test.pypi.org/simple/ AgenticLoop
 ### Build
 
 ```bash
-docker build -t agentic-loop:latest .
+docker build -t aloop:latest .
 ```
 
 ### Run
@@ -57,21 +57,21 @@ Mount `.aloop/` to provide model configuration:
 # Interactive mode
 docker run -it --rm \
   -v $(pwd)/.aloop:/app/.aloop \
-  agentic-loop
+  aloop
 
 # Single task
 docker run --rm \
   -v $(pwd)/.aloop:/app/.aloop \
-  agentic-loop --task "Calculate 1+1"
+  aloop --task "Calculate 1+1"
 ```
 
 ### Publish
 
 ```bash
-docker tag agentic-loop:latest yourusername/agentic-loop:0.1.0
-docker tag agentic-loop:latest yourusername/agentic-loop:latest
-docker push yourusername/agentic-loop:0.1.0
-docker push yourusername/agentic-loop:latest
+docker tag aloop:latest yourusername/aloop:0.1.0
+docker tag aloop:latest yourusername/aloop:latest
+docker push yourusername/aloop:0.1.0
+docker push yourusername/aloop:latest
 ```
 
 ## Release Checklist
@@ -89,5 +89,5 @@ docker push yourusername/agentic-loop:latest
 | Method | Command |
 |--------|---------|
 | Local dev | `./scripts/bootstrap.sh` |
-| Docker | `docker run agentic-loop --task "..."` |
-| From source | `pip install git+https://github.com/luohaha/AgenticLoop.git` |
+| Docker | `docker run aloop --task "..."` |
+| From source | `pip install git+https://github.com/luohaha/aloop.git` |

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,4 +1,4 @@
-"""Memory management system for AgenticLoop framework.
+"""Memory management system for aloop framework.
 
 This module provides intelligent memory management with automatic compression,
 token tracking, cost optimization, and YAML-based persistence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "AgenticLoop"
+name = "aloop"
 version = "0.1.0"
 description = "General AI Agent System"
 readme = "README.md"
@@ -56,10 +56,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/luohaha/AgenticLoop"
-Documentation = "https://github.com/luohaha/AgenticLoop#readme"
-Repository = "https://github.com/luohaha/AgenticLoop"
-Issues = "https://github.com/luohaha/AgenticLoop/issues"
+Homepage = "https://github.com/luohaha/aloop"
+Documentation = "https://github.com/luohaha/aloop#readme"
+Repository = "https://github.com/luohaha/aloop"
+Issues = "https://github.com/luohaha/aloop/issues"
 
 [project.scripts]
 aloop = "cli:main"

--- a/rfc/001-enhanced-plan-execute-agent.md
+++ b/rfc/001-enhanced-plan-execute-agent.md
@@ -2,7 +2,7 @@
 
 - **Status**: Implemented
 - **Created**: 2025-01-24
-- **Author**: AgenticLoop Team
+- **Author**: aloop Team
 
 ## Abstract
 

--- a/rfc/002-tool-result-handling.md
+++ b/rfc/002-tool-result-handling.md
@@ -2,7 +2,7 @@
 
 - **Status**: Draft
 - **Created**: 2025-01-24
-- **Author**: AgenticLoop Team
+- **Author**: aloop Team
 
 ## Abstract
 
@@ -22,7 +22,7 @@ Different systems handle this challenge in different ways:
 
 ### 1.2 The Current Approach
 
-AgenticLoop currently uses a centralized `ToolResultProcessor` that:
+aloop currently uses a centralized `ToolResultProcessor` that:
 
 1. Receives raw tool outputs after execution
 2. Checks if output exceeds tool-specific thresholds
@@ -351,4 +351,4 @@ This aligns with the broader principle: let each component do one thing well. To
 
 1. Claude Code tool implementation and error handling patterns
 2. OpenAI function calling best practices
-3. AgenticLoop RFC 001: Four-Phase Agent Architecture
+3. aloop RFC 001: Four-Phase Agent Architecture

--- a/rfc/003-asyncio-migration.md
+++ b/rfc/003-asyncio-migration.md
@@ -2,11 +2,11 @@
 
 - **Status**: Draft
 - **Created**: 2026-01-24
-- **Author**: AgenticLoop Team
+- **Author**: aloop Team
 
 ## Abstract
 
-This RFC proposes an incremental migration of AgenticLoop to an **asyncio-first** runtime. The goal is to make the agent loop, tool execution, LLM calls, and persistence **non-blocking**, enabling safe concurrency, cancellation, and predictable timeouts — while **preserving existing user-visible behavior**.
+This RFC proposes an incremental migration of aloop to an **asyncio-first** runtime. The goal is to make the agent loop, tool execution, LLM calls, and persistence **non-blocking**, enabling safe concurrency, cancellation, and predictable timeouts — while **preserving existing user-visible behavior**.
 
 ## Reader Guide
 
@@ -78,7 +78,7 @@ This RFC intentionally aligns with patterns proven in production agent runtimes:
 **Shared design theme**
 - Keep orchestration and tool side effects behind clear boundaries, and prefer deterministic, structured progress reporting over free-form prints.
 
-Implication for AgenticLoop:
+Implication for aloop:
 - Keep orchestration async-first and structured.
 - Prefer producing deterministic, structured progress (even if initially only used internally by the CLI/TUI).
 - Prefer explicit lifecycle management for long-lived resources (LLM sessions, DB connections, subprocess handles).

--- a/rfc/005-timer-notify.md
+++ b/rfc/005-timer-notify.md
@@ -5,7 +5,7 @@
 
 ## Problem Statement
 
-AgenticLoop currently has no way for an agent to schedule delayed or periodic tasks, nor to send notifications to users outside the terminal. This limits the agent to purely synchronous, on-demand interactions.
+aloop currently has no way for an agent to schedule delayed or periodic tasks, nor to send notifications to users outside the terminal. This limits the agent to purely synchronous, on-demand interactions.
 
 Two common use cases motivate this RFC:
 
@@ -49,7 +49,7 @@ Sends an email via the [Resend](https://resend.com) HTTP API. Uses `httpx` (alre
 
 **Configuration** (`.aloop/config`):
 - `RESEND_API_KEY`: Resend API key
-- `NOTIFY_EMAIL_FROM`: Sender address (e.g. `AgenticLoop <onboarding@resend.dev>`)
+- `NOTIFY_EMAIL_FROM`: Sender address (e.g. `aloop <onboarding@resend.dev>`)
 
 ## Alternatives Considered
 

--- a/rfc/006-multi-model-v2.md
+++ b/rfc/006-multi-model-v2.md
@@ -4,7 +4,7 @@ Status: **Completed** (2026-01-30)
 
 ## Problem Statement
 
-AgenticLoop historically behaves like a single-model app. Users need to:
+aloop historically behaves like a single-model app. Users need to:
 - Configure multiple models (different providers / endpoints / keys)
 - Switch the active model in interactive mode
 - Keep secrets out of git by default

--- a/rfc/006-ralph-loop.md
+++ b/rfc/006-ralph-loop.md
@@ -10,7 +10,7 @@ Add an outer verification loop ("Ralph Loop") that checks whether the inner ReAc
 
 ## Problem Statement
 
-Task completion in AgenticLoop is entirely LLM-driven: the inner ReAct loop terminates when the model emits `StopReason.STOP`. This means the model alone decides when it is "done," with no independent check that the answer is correct or complete. For complex tasks the model may stop prematurely — producing a partial answer, missing a subtask, or satisfying a surface reading of the prompt while missing deeper intent.
+Task completion in aloop is entirely LLM-driven: the inner ReAct loop terminates when the model emits `StopReason.STOP`. This means the model alone decides when it is "done," with no independent check that the answer is correct or complete. For complex tasks the model may stop prematurely — producing a partial answer, missing a subtask, or satisfying a surface reading of the prompt while missing deeper intent.
 
 An outer loop that independently verifies completion and injects corrective feedback addresses this gap without adding complexity to the inner loop itself.
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Bootstrap a local dev environment for AgenticLoop.
+Bootstrap a local dev environment for aloop.
 
 Creates/uses `.venv` and installs `.[dev]`.
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-AgenticLoop dev workflow helper.
+aloop dev workflow helper.
 
 Usage:
   ./scripts/dev.sh <command> [args...]
@@ -89,7 +89,7 @@ case "$cmd" in
   build)
     source ./scripts/_env.sh
 
-    echo "🔨 Building AgenticLoop package..."
+    echo "🔨 Building aloop package..."
 
     echo "Cleaning previous builds..."
     rm -rf build/ dist/ *.egg-info
@@ -105,7 +105,7 @@ case "$cmd" in
 
     echo ""
     echo "Next steps:"
-    echo "  1. Test locally: pip install dist/agentic_loop-*.whl"
+    echo "  1. Test locally: pip install dist/aloop-*.whl"
     echo "  2. Upload to PyPI: twine upload dist/*"
     ;;
   publish)

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # Tests
 
-This directory contains test files for the AgenticLoop project.
+This directory contains test files for the aloop project.
 
 ## Test Files
 

--- a/test/test_notify_integration.py
+++ b/test/test_notify_integration.py
@@ -25,8 +25,8 @@ def notify_tool():
 async def test_send_real_email(notify_tool):
     result = await notify_tool.execute(
         recipient="luoyixin6688@gmail.com",
-        subject="AgenticLoop NotifyTool Test",
-        body="This is a test email sent from the AgenticLoop NotifyTool integration test.",
+        subject="aloop NotifyTool Test",
+        body="This is a test email sent from the aloop NotifyTool integration test.",
     )
     print(result)
     assert "sent successfully" in result

--- a/tools/code_navigator.py
+++ b/tools/code_navigator.py
@@ -148,7 +148,7 @@ class CodeNavigatorTool(BaseTool):
     """Navigate code using AST analysis - fast and accurate, multi-language support."""
 
     def __init__(self):
-        self.cache_dir = Path(".AgenticLoop/cache")
+        self.cache_dir = Path(".aloop/cache")
         self.symbol_cache = {}  # {symbol_name: [(file, line, type, info)]}
         self.cache_loaded = False
         self._tree_sitter_available = HAS_TREE_SITTER

--- a/tools/web_fetch.py
+++ b/tools/web_fetch.py
@@ -449,7 +449,7 @@ class WebFetchTool(BaseTool):
         self, url: str, format: str, timeout: float
     ) -> tuple[httpx.Response, bytes, list[str]]:
         headers = {
-            "User-Agent": "Mozilla/5.0 (compatible; AgenticLoop/1.0)",
+            "User-Agent": "Mozilla/5.0 (compatible; aloop/1.0)",
             "Accept": ACCEPT_HEADERS.get(format, "*/*"),
             "Accept-Language": "en-US,en;q=0.9",
         }

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -59,7 +59,7 @@ def setup_logger(
     log_path.mkdir(exist_ok=True, parents=True)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    log_file = log_path / f"agentic_loop_{timestamp}.log"
+    log_file = log_path / f"aloop_{timestamp}.log"
     _log_file_path = str(log_file)
 
     file_handler = logging.FileHandler(log_file, encoding="utf-8")

--- a/utils/runtime.py
+++ b/utils/runtime.py
@@ -1,4 +1,4 @@
-"""Runtime directory management for AgenticLoop.
+"""Runtime directory management for aloop.
 
 All runtime data is stored under .aloop/ directory:
 - config: Configuration file (created by config.py on first import)

--- a/utils/tui/__init__.py
+++ b/utils/tui/__init__.py
@@ -1,4 +1,4 @@
-"""TUI (Terminal User Interface) package for AgenticLoop.
+"""TUI (Terminal User Interface) package for aloop.
 
 This package provides a modern, professional terminal UI with:
 - Theme support (dark/light modes)


### PR DESCRIPTION
## Summary

- Unify project name from "AgenticLoop" to "aloop" across the entire codebase
- Update PyPI package name, GitHub URLs, docstrings, comments, User-Agent strings, log filename prefix, cache directory path, documentation, RFCs, Dockerfile, and scripts
- No functional changes — CLI command (`aloop`) and runtime directory (`.aloop/`) already used the short name

## Test plan

- [x] `grep -ri "AgenticLoop" --include="*.py" --include="*.md" --include="*.toml" --include="*.sh"` returns zero matches
- [x] `grep -ri "agentic_loop" --include="*.py" --include="*.md" --include="*.sh"` returns zero matches
- [x] `./scripts/dev.sh check` passes (precommit + typecheck + 298 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)