### PR TITLE
feat: fall back to vi when $EDITOR/$VISUAL are unset

### DIFF
--- a/utils/tui/model_ui.py
+++ b/utils/tui/model_ui.py
@@ -49,6 +49,10 @@ async def open_in_editor(path: str) -> tuple[bool, bool]:
             return False, False
         return (await proc.wait()) == 0, True
 
+    if shutil.which("vi"):
+        proc = await asyncio.create_subprocess_exec("vi", path)
+        return (await proc.wait()) == 0, True
+
     if shutil.which("code"):
         # Don't use `-w` here; we prefer to return to the TUI after the file is saved
         # (and auto-reloaded), without requiring the user to close the editor tab.


### PR DESCRIPTION
## Summary
- When `$EDITOR` and `$VISUAL` are both unset, the `open_in_editor` fallback chain now tries `vi` before VS Code / `xdg-open`
- Ensures a usable terminal editor is available on headless Linux systems out of the box
- `vi` is blocking (`waited=True`), matching the behavior of `$EDITOR`

## Test plan
- [ ] Verify on Linux without `$EDITOR`/`$VISUAL` set: `/model edit` opens `vi`
- [ ] Verify `$EDITOR` still takes priority when set
- [ ] Verify VS Code / macOS `open` / `xdg-open` fallbacks still work after `vi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)