### PR TITLE
refactor: move runtime directory from .aloop/ to ~/.aloop/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Change impact reminders:
 - Config changes → update `docs/configuration.md`
 - Workflow scripts → update `AGENTS.md`, `docs/packaging.md`
 
-Run a quick smoke task (requires a configured provider in `.aloop/models.yaml`):
+Run a quick smoke task (requires a configured provider in `~/.aloop/models.yaml`):
 
 ```bash
 python main.py --task "Calculate 1+1"
@@ -147,7 +147,7 @@ Unified entrypoint: `./scripts/dev.sh format`
 
 ## Docs Pointers
 
-- Configuration & `.aloop/models.yaml`: `docs/configuration.md`
+- Configuration & `~/.aloop/models.yaml`: `docs/configuration.md`
 - Packaging & release checklist: `docs/packaging.md`
 - Extending tools/agents: `docs/extending.md`
 - Memory system: `docs/memory-management.md`
@@ -155,7 +155,7 @@ Unified entrypoint: `./scripts/dev.sh format`
 
 ## Safety & Secrets
 
-- Never commit `.aloop/config` or API keys.
+- Never commit `~/.aloop/config` or API keys.
 - Avoid running destructive shell commands; keep file edits scoped and reversible.
 - Publishing/releasing steps require explicit human intent (see `docs/packaging.md`).
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd aloop
 
 ### 1. Configure Models
 
-On first run, `.aloop/models.yaml` is created with a template. Edit it to add your provider and API key:
+On first run, `~/.aloop/models.yaml` is created with a template. Edit it to add your provider and API key:
 
 ```yaml
 models:
@@ -67,7 +67,7 @@ aloop --resume a1b2c3d4
 | `--task TEXT` | `-t` | Run a single task and exit |
 | `--model ID` | `-m` | LiteLLM model ID to use |
 | `--resume [ID]` | `-r` | Resume a session (`latest` if no ID given) |
-| `--verbose` | `-v` | Enable verbose logging to `.aloop/logs/` |
+| `--verbose` | `-v` | Enable verbose logging to `~/.aloop/logs/` |
 
 ## Interactive Commands
 
@@ -80,7 +80,7 @@ aloop --resume a1b2c3d4
 | `/stats` | Show memory and token usage statistics |
 | `/resume [id]` | List or resume a previous session |
 | `/model` | Pick a model (arrow keys + Enter) |
-| `/model edit` | Open `.aloop/models.yaml` in editor (auto-reload on save) |
+| `/model edit` | Open `~/.aloop/models.yaml` in editor (auto-reload on save) |
 | `/theme` | Toggle dark/light theme |
 | `/verbose` | Toggle thinking display |
 | `/compact` | Toggle compact output |
@@ -105,7 +105,7 @@ aloop --resume a1b2c3d4
 
 **Memory compression**: When context grows past a token threshold, older messages are compressed via LLM summarization. Recent messages are kept at full fidelity. Strategies: `sliding_window` (default), `selective`, `deletion`.
 
-**Session persistence**: Conversations are saved as YAML files under `.aloop/sessions/`. Resume with `--resume` or `/resume`.
+**Session persistence**: Conversations are saved as YAML files under `~/.aloop/sessions/`. Resume with `--resume` or `/resume`.
 
 ## Tools
 
@@ -136,7 +136,7 @@ aloop/
 ├── main.py                 # Entry point (argparse)
 ├── cli.py                  # CLI wrapper (`aloop` entry point)
 ├── interactive.py          # Interactive session, model setup, TUI
-├── config.py               # Runtime config (.aloop/config)
+├── config.py               # Runtime config (~/.aloop/config)
 ├── agent/
 │   ├── base.py             # BaseAgent (ReAct + Ralph loops)
 │   ├── agent.py            # LoopAgent
@@ -146,7 +146,7 @@ aloop/
 │   └── todo.py             # Todo list data structure
 ├── llm/
 │   ├── litellm_adapter.py  # LiteLLM adapter (100+ providers)
-│   ├── model_manager.py    # Model config from .aloop/models.yaml
+│   ├── model_manager.py    # Model config from ~/.aloop/models.yaml
 │   ├── retry.py            # Retry with exponential backoff
 │   └── message_types.py    # LLMMessage, LLMResponse, ToolCall
 ├── memory/
@@ -170,7 +170,7 @@ aloop/
 
 ## Configuration
 
-Runtime settings live in `.aloop/config` (auto-created). Key settings:
+Runtime settings live in `~/.aloop/config` (auto-created). Key settings:
 
 | Setting | Default | Description |
 |---------|---------|-------------|

--- a/config.py
+++ b/config.py
@@ -5,14 +5,14 @@ import random
 
 # Define path constants directly to avoid circular imports with utils
 # (utils.terminal_ui imports Config, and utils.runtime is in the utils package)
-_RUNTIME_DIR = ".aloop"
+_RUNTIME_DIR = os.path.join(os.path.expanduser("~"), ".aloop")
 _CONFIG_FILE = os.path.join(_RUNTIME_DIR, "config")
 
 # Default configuration template
 _DEFAULT_CONFIG = """\
 # aloop Configuration
 #
-# NOTE: Model configuration lives in `.aloop/models.yaml`.
+# NOTE: Model configuration lives in `~/.aloop/models.yaml`.
 # This file controls non-model runtime settings only.
 
 TOOL_TIMEOUT=600
@@ -44,7 +44,7 @@ def _load_config(path: str) -> dict[str, str]:
 
 
 def _ensure_config():
-    """Ensure .aloop/config exists, create with defaults if not."""
+    """Ensure ~/.aloop/config exists, create with defaults if not."""
     if not os.path.exists(_CONFIG_FILE):
         os.makedirs(_RUNTIME_DIR, exist_ok=True)
         with open(_CONFIG_FILE, "w", encoding="utf-8") as f:
@@ -71,8 +71,8 @@ class Config:
     All configuration is centralized here. Access config values directly via Config.XXX.
     """
 
-    # Model configuration is handled by `.aloop/models.yaml` via ModelManager.
-    # `.aloop/config` controls non-model runtime settings only.
+    # Model configuration is handled by `~/.aloop/models.yaml` via ModelManager.
+    # `~/.aloop/config` controls non-model runtime settings only.
     TOOL_TIMEOUT = float(_cfg.get("TOOL_TIMEOUT", "600"))
 
     # Agent Configuration
@@ -98,7 +98,7 @@ class Config:
 
     # Logging Configuration
     # Note: Logging is now controlled via --verbose flag
-    # LOG_DIR is now .aloop/logs/ (see utils.runtime)
+    # LOG_DIR is now ~/.aloop/logs/ (see utils.runtime)
     LOG_LEVEL = _cfg.get("LOG_LEVEL", "DEBUG").upper()
 
     # TUI Configuration
@@ -141,6 +141,6 @@ class Config:
         Raises:
             ValueError: If required configuration is missing
         """
-        # Model configuration is handled by `.aloop/models.yaml` via ModelManager.
-        # `.aloop/config` is used for non-model runtime settings only.
+        # Model configuration is handled by `~/.aloop/models.yaml` via ModelManager.
+        # `~/.aloop/config` is used for non-model runtime settings only.
         return

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 ## Model Configuration
 
-Models are configured in `.aloop/models.yaml` (auto-created on first run, gitignored).
+Models are configured in `~/.aloop/models.yaml` (auto-created on first run).
 
 ```yaml
 models:
@@ -39,11 +39,11 @@ The model ID (key under `models`) uses the LiteLLM `provider/model` format. See 
 
 **Interactive**:
 - `/model` -- pick from configured models (arrow keys + Enter)
-- `/model edit` -- open `.aloop/models.yaml` in your editor (auto-reload on save)
+- `/model edit` -- open `~/.aloop/models.yaml` in your editor (auto-reload on save)
 
 ## Runtime Settings
 
-Settings live in `.aloop/config` (KEY=VALUE format, auto-created with defaults).
+Settings live in `~/.aloop/config` (KEY=VALUE format, auto-created with defaults).
 
 ### Agent
 
@@ -119,6 +119,6 @@ models:
 
 ## Security
 
-- `.aloop/models.yaml` is gitignored. Never commit API keys.
-- Set file permissions to `0600` on Unix: `chmod 600 .aloop/models.yaml`
+- `~/.aloop/models.yaml` contains API keys. Never commit them to version control.
+- Set file permissions to `0600` on Unix: `chmod 600 ~/.aloop/models.yaml`
 - Rotate API keys regularly.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -48,7 +48,7 @@ Type your request and press Enter twice to submit. The agent will think, use too
 /help                    Show available commands
 /stats                   Show token usage and cost
 /model                   Pick a different model
-/model edit              Edit .aloop/models.yaml in your editor
+/model edit              Edit ~/.aloop/models.yaml in your editor
 /theme                   Toggle dark/light theme
 /verbose                 Toggle thinking display
 /compact                 Toggle compact output
@@ -127,7 +127,7 @@ async def main():
     mm = ModelManager()
     profile = mm.get_current_model()
     if not profile:
-        raise RuntimeError("No models configured. Edit .aloop/models.yaml.")
+        raise RuntimeError("No models configured. Edit ~/.aloop/models.yaml.")
 
     llm = LiteLLMAdapter(
         model=profile.model_id,
@@ -150,12 +150,12 @@ if __name__ == "__main__":
 
 ## Troubleshooting
 
-**Task not completing**: Increase `MAX_ITERATIONS` in `.aloop/config` (default: 1000).
+**Task not completing**: Increase `MAX_ITERATIONS` in `~/.aloop/config` (default: 1000).
 
-**High token usage**: Memory compression is enabled by default. Adjust `MEMORY_COMPRESSION_THRESHOLD` in `.aloop/config` to trigger compression earlier. Switch to a cheaper model with `--model` or `/model`.
+**High token usage**: Memory compression is enabled by default. Adjust `MEMORY_COMPRESSION_THRESHOLD` in `~/.aloop/config` to trigger compression earlier. Switch to a cheaper model with `--model` or `/model`.
 
-**API errors**: Verify your API key in `.aloop/models.yaml`. Test with a simple task: `aloop --task "Calculate 1+1"`.
+**API errors**: Verify your API key in `~/.aloop/models.yaml`. Test with a simple task: `aloop --task "Calculate 1+1"`.
 
-**Rate limits**: Automatic retry with exponential backoff is built in. Configure `RETRY_MAX_ATTEMPTS` in `.aloop/config` (default: 3).
+**Rate limits**: Automatic retry with exponential backoff is built in. Configure `RETRY_MAX_ATTEMPTS` in `~/.aloop/config` (default: 3).
 
-**Verbose output for debugging**: Use `--verbose` to log detailed info to `.aloop/logs/`.
+**Verbose output for debugging**: Use `--verbose` to log detailed info to `~/.aloop/logs/`.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -103,7 +103,7 @@ class MyAgent(BaseAgent):
 
 ## Adding LLM Providers
 
-Most providers work out of the box via LiteLLM. Just add them to `.aloop/models.yaml`:
+Most providers work out of the box via LiteLLM. Just add them to `~/.aloop/models.yaml`:
 
 ```yaml
 models:

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -12,7 +12,7 @@ Components:
 
 ## Configuration
 
-All settings go in `.aloop/config`:
+All settings go in `~/.aloop/config`:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -86,7 +86,7 @@ Conversations are automatically saved as YAML files when `agent.run()` completes
 ### Directory Structure
 
 ```
-.aloop/sessions/
+~/.aloop/sessions/
 ├── .index.yaml                    # UUID-to-directory mapping (auto-managed)
 ├── 2025-01-31_a1b2c3d4/
 │   └── session.yaml

--- a/llm/model_manager.py
+++ b/llm/model_manager.py
@@ -110,7 +110,7 @@ class ModelProfile:
 class ModelManager:
     """Manages multiple models with YAML persistence."""
 
-    CONFIG_PATH = ".aloop/models.yaml"
+    CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".aloop", "models.yaml")
 
     def __init__(self, config_path: str | None = None):
         self.config_path = config_path or self.CONFIG_PATH

--- a/utils/runtime.py
+++ b/utils/runtime.py
@@ -1,6 +1,6 @@
 """Runtime directory management for aloop.
 
-All runtime data is stored under .aloop/ directory:
+All runtime data is stored under ~/.aloop/ directory:
 - config: Configuration file (created by config.py on first import)
 - sessions/: YAML-based session persistence
 - logs/: Log files (only created with --verbose)
@@ -9,14 +9,14 @@ All runtime data is stored under .aloop/ directory:
 
 import os
 
-RUNTIME_DIR = ".aloop"
+RUNTIME_DIR = os.path.join(os.path.expanduser("~"), ".aloop")
 
 
 def get_runtime_dir() -> str:
     """Get the runtime directory path.
 
     Returns:
-        Path to .aloop directory
+        Path to ~/.aloop directory
     """
     return RUNTIME_DIR
 
@@ -25,7 +25,7 @@ def get_config_file() -> str:
     """Get the configuration file path.
 
     Returns:
-        Path to .aloop/config
+        Path to ~/.aloop/config
     """
     return os.path.join(RUNTIME_DIR, "config")
 
@@ -34,7 +34,7 @@ def get_sessions_dir() -> str:
     """Get the sessions directory path.
 
     Returns:
-        Path to .aloop/sessions/
+        Path to ~/.aloop/sessions/
     """
     return os.path.join(RUNTIME_DIR, "sessions")
 
@@ -43,7 +43,7 @@ def get_log_dir() -> str:
     """Get the log directory path.
 
     Returns:
-        Path to .aloop/logs/
+        Path to ~/.aloop/logs/
     """
     return os.path.join(RUNTIME_DIR, "logs")
 
@@ -52,7 +52,7 @@ def get_history_file() -> str:
     """Get the command history file path.
 
     Returns:
-        Path to .aloop/history
+        Path to ~/.aloop/history
     """
     return os.path.join(RUNTIME_DIR, "history")
 
@@ -61,10 +61,10 @@ def ensure_runtime_dirs(create_logs: bool = False) -> None:
     """Ensure runtime directories exist.
 
     Creates:
-    - .aloop/sessions/
-    - .aloop/logs/ (only if create_logs=True)
+    - ~/.aloop/sessions/
+    - ~/.aloop/logs/ (only if create_logs=True)
 
-    Note: .aloop/config is created by config.py on first import.
+    Note: ~/.aloop/config is created by config.py on first import.
 
     Args:
         create_logs: Whether to create the logs directory (for --verbose mode)


### PR DESCRIPTION
## Summary

- Move runtime directory from CWD-relative `.aloop/` to home-directory `~/.aloop/`, centralizing all config, sessions, logs, and history in one place
- Update `utils/runtime.py`, `config.py`, and `llm/model_manager.py` path definitions
- Update all documentation references (README, CLAUDE.md, docs/)

## Test plan

- [x] `./scripts/dev.sh check` passes (298 tests, precommit, typecheck)
- [ ] Smoke test: `python main.py --task "Calculate 1+1"` creates/uses `~/.aloop/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)