### PR TITLE
feat: add graceful Ctrl+C interrupt for long-running tool calls

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -33,6 +33,9 @@ class ToolExecutor:
             else:
                 result = await self.tools[tool_name].execute(**tool_input)
             return str(result)
+        except asyncio.CancelledError:
+            # Re-raise CancelledError to allow proper cleanup
+            raise
         except TimeoutError:
             return f"Error: Tool '{tool_name}' timed out after {timeout}s"
         except Exception as e:

--- a/memory/short_term.py
+++ b/memory/short_term.py
@@ -75,3 +75,14 @@ class ShortTermMemory:
             Number of messages in short-term memory
         """
         return len(self.messages)
+
+    def remove_last(self, count: int = 1) -> None:
+        """Remove the last N messages (newest) from memory.
+
+        This is useful for rolling back incomplete exchanges (e.g., after interruption).
+
+        Args:
+            count: Number of messages to remove from the end (default: 1)
+        """
+        for _ in range(min(count, len(self.messages))):
+            self.messages.pop()

--- a/test/memory/test_short_term.py
+++ b/test/memory/test_short_term.py
@@ -371,3 +371,69 @@ class TestShortTermMemoryBehavior:
 
         stm.add_message(LLMMessage(role="user", content="5"))
         assert stm.count() == 1
+
+
+class TestShortTermMemoryRemoveLast:
+    """Test remove_last functionality."""
+
+    def test_remove_last_single_message(self):
+        """Test removing the last message."""
+        stm = ShortTermMemory(max_size=5)
+        msg1 = LLMMessage(role="user", content="First")
+        msg2 = LLMMessage(role="user", content="Second")
+
+        stm.add_message(msg1)
+        stm.add_message(msg2)
+
+        stm.remove_last(1)
+
+        assert stm.count() == 1
+        assert stm.get_messages() == [msg1]
+
+    def test_remove_last_multiple_messages(self):
+        """Test removing multiple messages from the end."""
+        stm = ShortTermMemory(max_size=5)
+        msg1 = LLMMessage(role="user", content="First")
+        msg2 = LLMMessage(role="assistant", content="Second")
+        msg3 = LLMMessage(role="user", content="Third")
+
+        stm.add_message(msg1)
+        stm.add_message(msg2)
+        stm.add_message(msg3)
+
+        stm.remove_last(2)
+
+        assert stm.count() == 1
+        assert stm.get_messages() == [msg1]
+
+    def test_remove_last_more_than_available(self):
+        """Test removing more messages than available."""
+        stm = ShortTermMemory(max_size=5)
+        msg1 = LLMMessage(role="user", content="First")
+        msg2 = LLMMessage(role="user", content="Second")
+
+        stm.add_message(msg1)
+        stm.add_message(msg2)
+
+        stm.remove_last(5)
+
+        assert stm.count() == 0
+
+    def test_remove_last_from_empty(self):
+        """Test removing from empty memory (should not crash)."""
+        stm = ShortTermMemory(max_size=5)
+
+        stm.remove_last(1)
+
+        assert stm.count() == 0
+
+    def test_remove_last_zero_count(self):
+        """Test removing zero messages."""
+        stm = ShortTermMemory(max_size=5)
+        msg = LLMMessage(role="user", content="Message")
+
+        stm.add_message(msg)
+        stm.remove_last(0)
+
+        assert stm.count() == 1
+        assert stm.get_messages() == [msg]


### PR DESCRIPTION
## Summary

Implements a graceful interruption mechanism for interactive mode that allows users to press **Ctrl+C** to cancel long-running tool executions without exiting the program.

### Key Features

- **Graceful cancellation**: Press Ctrl+C to interrupt tool execution
- **No program exit**: Returns to prompt after interruption
- **Clean memory state**: Automatically removes incomplete tool_calls to prevent API errors
- **Preserved user input**: User message is kept so agent can see the original question

### Implementation

1. **asyncio.Task wrapper**: Wraps `agent.run()` in a cancellable task
2. **SIGINT handler**: Custom signal handler calls `task.cancel()` instead of raising
3. **Memory rollback**: `rollback_incomplete_exchange()` removes incomplete assistant messages
4. **Error propagation**: `CancelledError` properly propagates through tool executor

### Technical Details

When a task is interrupted:
1. SIGINT handler cancels the current asyncio.Task
2. CancelledError propagates through the call stack
3. Interactive loop catches it and calls rollback
4. Assistant message with tool_calls is removed (user message preserved)
5. Control returns to input prompt

### Testing

Added 11 new tests covering:
- `ShortTermMemory.remove_last()` functionality (5 tests)
- `MemoryManager.rollback_incomplete_exchange()` scenarios (6 tests)

All tests pass: **310 passed, 2 skipped**

### Example Usage

```bash
python main.py --mode interactive

> Search the entire codebase for all Python files
[Executing search...]
^C  # Press Ctrl+C
Interrupting...
Task interrupted by user.

> What is 1 + 1?  # Continue with new question
2
```

### Fixes

Resolves the issue where interrupting tool execution would leave incomplete tool_calls in memory, causing API errors on the next turn:
```
litellm.BadRequestError: an assistant message with 'tool_calls' must be followed by tool messages
```

🤖 Generated with Claude Code