### PR TITLE
refactor: remove emoji and redundant text from tool outputs

### DIFF
--- a/tools/code_navigator.py
+++ b/tools/code_navigator.py
@@ -354,7 +354,7 @@ WHEN TO USE GREP INSTEAD:
                                 "line": start_line,
                                 "end_line": end_line,
                                 "signature": signature,
-                                "docstring": "(tree-sitter: no docstring extraction)",
+                                "docstring": "(no docstring)",
                                 "decorators": [],
                                 "language": lang,
                             }
@@ -412,7 +412,7 @@ WHEN TO USE GREP INSTEAD:
                                 "line": start_line,
                                 "bases": [],
                                 "methods": [],
-                                "docstring": "(tree-sitter: no docstring extraction)",
+                                "docstring": "(no docstring)",
                                 "decorators": [],
                                 "language": lang,
                             }
@@ -494,7 +494,7 @@ WHEN TO USE GREP INSTEAD:
         output_parts = [f"Found {len(results)} function(s) named '{name}':\n"]
         for r in results:
             lang_tag = f" [{r.get('language', 'python')}]" if r.get("language") else ""
-            output_parts.append(f"📍 {r['file']}:{r['line']}{lang_tag}")
+            output_parts.append(f"{r['file']}:{r['line']}{lang_tag}")
             if r.get("decorators"):
                 output_parts.append(f"   Decorators: {', '.join(r['decorators'])}")
             output_parts.append(f"   {r['signature']}")
@@ -570,7 +570,7 @@ WHEN TO USE GREP INSTEAD:
         output_parts = [f"Found {len(results)} class(es) named '{name}':\n"]
         for r in results:
             lang_tag = f" [{r.get('language', 'python')}]" if r.get("language") else ""
-            output_parts.append(f"📍 {r['file']}:{r['line']}{lang_tag}")
+            output_parts.append(f"{r['file']}:{r['line']}{lang_tag}")
             output_parts.append(
                 f"   class {name}({', '.join(r['bases']) if r['bases'] else 'object'})"
             )
@@ -746,7 +746,7 @@ WHEN TO USE GREP INSTEAD:
 
         # Imports
         if structure["imports"]:
-            output_parts.append("📦 IMPORTS:")
+            output_parts.append("IMPORTS:")
             for imp in structure["imports"][:20]:
                 if imp.get("type") == "import":
                     line = f"   Line {imp['line']}: import {imp['name']}"
@@ -765,7 +765,7 @@ WHEN TO USE GREP INSTEAD:
 
         # Classes
         if structure["classes"]:
-            output_parts.append("📘 CLASSES:")
+            output_parts.append("CLASSES:")
             for cls in structure["classes"]:
                 bases_str = f"({', '.join(cls['bases'])})" if cls.get("bases") else ""
                 output_parts.append(f"   Line {cls['line']}: class {cls['name']}{bases_str}")
@@ -783,7 +783,7 @@ WHEN TO USE GREP INSTEAD:
 
         # Functions
         if structure["functions"]:
-            output_parts.append("🔧 FUNCTIONS:")
+            output_parts.append("FUNCTIONS:")
             for func in structure["functions"]:
                 if lang == "python":
                     output_parts.append(
@@ -915,7 +915,7 @@ WHEN TO USE GREP INSTEAD:
 
         for r in unique_results:
             lang_tag = f" [{r.get('language', 'python')}]" if r.get("language") else ""
-            output_parts.append(f"📍 {r['file']}:{r['line']}{lang_tag}")
+            output_parts.append(f"{r['file']}:{r['line']}{lang_tag}")
             context = str(r["context"])
             if len(context) > 80:
                 context = context[:80] + "..."

--- a/tools/smart_edit.py
+++ b/tools/smart_edit.py
@@ -47,8 +47,6 @@ class SmartEditTool(BaseTool):
     def description(self) -> str:
         return """Intelligent code editing tool with fuzzy matching and preview.
 
-This is the RECOMMENDED tool for editing code (prefer over edit_file).
-
 Features:
 - Fuzzy matching: Automatically handles whitespace/indentation differences
 - Diff preview: Shows exactly what will change
@@ -281,15 +279,15 @@ IMPORTANT:
         try:
             async with aiofiles.open(path, "w", encoding="utf-8") as f:
                 await f.write(new_content)
-            output_parts.append(f"✓ Successfully edited {path}")
+            output_parts.append(f"Successfully edited {path}")
             return "\n".join(output_parts)
         except Exception as e:
             # Rollback if writing failed
             if create_backup and backup_path and await aiofiles.os.path.exists(str(backup_path)):
                 await self._copy_file(backup_path, path)
-                output_parts.append(f"✗ Edit failed, restored from backup: {e}")
+                output_parts.append(f"Edit failed, restored from backup: {e}")
             else:
-                output_parts.append(f"✗ Edit failed: {e}")
+                output_parts.append(f"Edit failed: {e}")
             return "\n".join(output_parts)
 
     async def _smart_insert(
@@ -351,7 +349,7 @@ IMPORTANT:
 
         async with aiofiles.open(path, "w", encoding="utf-8") as f:
             await f.write(new_content)
-        output_parts.append(f"✓ Successfully inserted code {position} anchor in {path}")
+        output_parts.append(f"Successfully inserted code {position} anchor in {path}")
         return "\n".join(output_parts)
 
     async def _block_edit(
@@ -402,7 +400,7 @@ IMPORTANT:
 
         async with aiofiles.open(path, "w", encoding="utf-8") as f:
             await f.write(new_content)
-        output_parts.append(f"✓ Successfully edited lines {start_line}-{end_line} in {path}")
+        output_parts.append(f"Successfully edited lines {start_line}-{end_line} in {path}")
         return "\n".join(output_parts)
 
     def _fuzzy_find(self, target: str, text: str) -> Optional[Tuple[int, int, float]]:


### PR DESCRIPTION
## Summary
- Remove emoji prefixes (📍, 📦, 📘, 🔧, ✓, ✗) from `code_navigator` and `smart_edit` tool outputs
- Shorten docstring placeholder from "(tree-sitter: no docstring extraction)" to "(no docstring)"
- Remove obsolete "prefer over edit_file" reference since `edit_file` no longer exists

## Test plan
- [x] All 299 tests pass
- [x] Formatting checks pass (black, isort, ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)