### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-08
+
+### Changed
+
+- Rename project from `aloop` to `ouro` (Ouroboros)
+- PyPI package name is now `ouro-ai` (`pip install ouro-ai`)
+- CLI entry point renamed from `aloop` to `ouro`
+- Runtime directory moved from `~/.aloop/` to `~/.ouro/`
+- GitHub repository moved to `ouro-ai-labs/ouro`
+- Updated ASCII logo and SVG branding
+
 ## [0.1.2] - 2026-02-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ouro-ai"
-version = "0.1.2"
+version = "0.2.0"
 description = "General AI Agent System"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to `0.2.0`
- Update CHANGELOG.md with v0.2.0 release notes (rename aloop → ouro)

## After merge

```bash
git tag v0.2.0
git push origin v0.2.0
```

This will trigger the release workflow to publish `ouro-ai` v0.2.0 to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)