### PR TITLE
fix: Harbor Docker proxy support and install resilience

### DIFF
--- a/harbor-run.sh
+++ b/harbor-run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+# LLM API key (required)
+export OURO_API_KEY="${OURO_API_KEY:-}"
+
+# LLM API base URL (optional, for proxy/relay APIs)
+# export OURO_BASE_URL="https://your-proxy-api.com"
+
+# LLM request timeout in seconds (default: 600)
+# export OURO_TIMEOUT=600
+
+# Model to use
+MODEL="anthropic/kimi-k2-5-latest"
+
+# Dataset to evaluate
+DATASET="hello-world@1.0"
+
+# Agent setup timeout in seconds (default: 360, increase for slow networks)
+SETUP_TIMEOUT=600
+
+# ── Proxy  ─────────────────────────────────────────────────────────
+# Clash/proxy port on localhost. Set to empty to disable.
+PROXY_PORT="7890"
+
+if [ -n "$PROXY_PORT" ]; then
+    export http_proxy="http://127.0.0.1:${PROXY_PORT}"
+    export https_proxy="http://127.0.0.1:${PROXY_PORT}"
+    # Unset SOCKS proxy to avoid socksio dependency in harbor
+    unset all_proxy ALL_PROXY 2>/dev/null || true
+fi
+
+# ── Validation ───────────────────────────────────────────────────────────────
+if [ -z "$OURO_API_KEY" ]; then
+    echo "Error: OURO_API_KEY is not set. Export it or edit this script." >&2
+    exit 1
+fi
+
+# ── Run ──────────────────────────────────────────────────────────────────────
+harbor run \
+    --agent-import-path ouro_harbor.ouro_agent:OuroAgent \
+    --model "$MODEL" \
+    --agent-setup-timeout "$SETUP_TIMEOUT" \
+    --dataset "$DATASET" \
+    "$@"

--- a/ouro_harbor/install-ouro.sh.j2
+++ b/ouro_harbor/install-ouro.sh.j2
@@ -1,25 +1,59 @@
 #!/bin/bash
 set -euo pipefail
 
-# Clear proxy settings that may leak from the host into the container
-unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy no_proxy NO_PROXY 2>/dev/null || true
+# Rewrite proxy settings: replace 127.0.0.1/localhost with host.docker.internal
+# so the container can reach the host's proxy (e.g. Clash on the host).
+# Persist the rewrite in ~/.bashrc so ALL subsequent commands (including
+# Harbor's verifier step) inherit the corrected proxy vars.
+_rewrite_proxy() {
+    local val="$1"
+    echo "$val" | sed -e 's|://127\.0\.0\.1:|://host.docker.internal:|g' \
+                      -e 's|://localhost:|://host.docker.internal:|g'
+}
+
+for var in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy; do
+    if [ -n "${!var:-}" ]; then
+        new_val="$(_rewrite_proxy "${!var}")"
+        export "$var=$new_val"
+        echo "export $var=$new_val" >> ~/.bashrc
+    fi
+done
+
+# Retry helper: retry a command up to N times with a delay
+retry() {
+    local retries=$1; shift
+    local delay=$1; shift
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if (( attempt >= retries )); then
+            echo "Command failed after $retries attempts: $*" >&2
+            return 1
+        fi
+        echo "Attempt $attempt failed, retrying in ${delay}s..." >&2
+        sleep "$delay"
+        (( attempt++ ))
+    done
+}
 
 # Install system dependencies only if missing
 if ! command -v curl &>/dev/null || ! command -v git &>/dev/null; then
-    apt-get update
-    apt-get install -y --no-install-recommends curl git
+    retry 3 5 apt-get update
+    retry 3 5 apt-get install -y --no-install-recommends curl git ca-certificates
 fi
 
 # Install uv (Python package manager)
-curl -LsSf https://astral.sh/uv/install.sh | sh
+retry 3 5 bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source "$HOME/.local/bin/env"
 
 # Install ouro (pin to Python 3.12 — tree-sitter-languages lacks 3.14 wheels)
 {% if version %}
-uv tool install --python 3.12 ouro-ai=={{ version }}
+retry 3 5 uv tool install --python 3.12 ouro-ai=={{ version }}
 {% else %}
-uv tool install --python 3.12 ouro-ai
+retry 3 5 uv tool install --python 3.12 ouro-ai
 {% endif %}
 
 echo "INSTALL_SUCCESS"


### PR DESCRIPTION
## Summary
- Rewrite proxy env vars (`127.0.0.1` → `host.docker.internal`) in the install script and agent run commands so Docker containers can reach the host's proxy 
- Persist rewritten proxy vars in `~/.bashrc` so Harbor's verifier step also inherits them
- Add retry logic (3 attempts, 5s delay) for all network-dependent commands (`apt-get`, `curl`, `uv`)
- Include `ca-certificates` in `apt-get install --no-install-recommends` to fix curl SSL errors
- Add `harbor-run.sh` convenience script with proxy/env configuration

## Test plan
- [x] Verified `harbor run` with `hello-world@1.0` dataset scores Mean: 1.000
- [x] All 337 tests pass, `./scripts/dev.sh check` clean
- [ ] Test on a machine without proxy to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)