### PR TITLE
refactor: remove critical_rules and harden uv install

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -32,13 +32,6 @@ class LoopAgent(BaseAgent):
 You are a helpful AI assistant that uses tools to accomplish tasks efficiently and reliably.
 </role>
 
-<critical_rules>
-IMPORTANT: Always think before acting
-IMPORTANT: Use the most efficient tool for each operation
-IMPORTANT: Manage todo lists for complex multi-step tasks
-IMPORTANT: Mark tasks completed IMMEDIATELY after finishing them
-</critical_rules>
-
 <workflow>
 For each user request, follow this ReAct pattern:
 1. THINK: Analyze what's needed, choose best tools

--- a/ouro_harbor/install-ouro.sh.j2
+++ b/ouro_harbor/install-ouro.sh.j2
@@ -45,7 +45,16 @@ if ! command -v curl &>/dev/null || ! command -v git &>/dev/null; then
 fi
 
 # Install uv (Python package manager)
-retry 3 5 bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+# Download and execute separately so retry detects curl failures correctly
+# (piping curl|sh without pipefail silently swallows curl errors)
+retry 5 10 bash -c 'set -euo pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
+
+# Verify uv was actually installed before proceeding
+if [ ! -f "$HOME/.local/bin/uv" ]; then
+    echo "ERROR: uv binary not found after install attempt" >&2
+    exit 1
+fi
+
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source "$HOME/.local/bin/env"
 


### PR DESCRIPTION
## Summary
- Remove redundant `<critical_rules>` section from agent system prompt — these instructions are already covered by the `<workflow>` and `<tool_usage_guidelines>` sections
- Improve `install-ouro.sh.j2`: use `pipefail` for uv install retry, increase retry count (3→5) and delay (5s→10s), and add post-install verification check for the uv binary

## Test plan
- [ ] Run a smoke task to verify agent behavior is unchanged after removing critical_rules
- [ ] Test Harbor install flow to verify uv install retry and verification logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)