### PR TITLE
feat: support installing ouro from git branch in Harbor

### DIFF
--- a/harbor-run.sh
+++ b/harbor-run.sh
@@ -20,6 +20,9 @@ DATASET="terminal-bench-sample@2.0"
 # ouro version to install in container (empty = latest from PyPI)
 AGENT_VERSION="0.2.3"
 
+# ouro git branch to install from (overrides AGENT_VERSION if set)
+AGENT_BRANCH=""
+
 # Timeout multiplier (default setup=360s, so 2.0 → 720s). Increase for slow networks.
 TIMEOUT_MULTIPLIER=2.0
 
@@ -41,9 +44,11 @@ if [ -z "$OURO_API_KEY" ]; then
 fi
 
 # ── Run ──────────────────────────────────────────────────────────────────────
-VERSION_FLAG=()
-if [ -n "$AGENT_VERSION" ]; then
-    VERSION_FLAG=(--agent-version "$AGENT_VERSION")
+AGENT_KWARGS=()
+if [ -n "$AGENT_BRANCH" ]; then
+    AGENT_KWARGS+=(--agent-kwarg "branch=$AGENT_BRANCH")
+elif [ -n "$AGENT_VERSION" ]; then
+    AGENT_KWARGS+=(--agent-kwarg "version=$AGENT_VERSION")
 fi
 
 harbor run \
@@ -51,5 +56,5 @@ harbor run \
     --model "$MODEL" \
     --timeout-multiplier "$TIMEOUT_MULTIPLIER" \
     --dataset "$DATASET" \
-    "${VERSION_FLAG[@]}" \
+    "${AGENT_KWARGS[@]}" \
     "$@"

--- a/ouro_harbor/install-ouro.sh.j2
+++ b/ouro_harbor/install-ouro.sh.j2
@@ -59,7 +59,9 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source "$HOME/.local/bin/env"
 
 # Install ouro (pin to Python 3.12 — tree-sitter-languages lacks 3.14 wheels)
-{% if version %}
+{% if branch %}
+retry 3 5 uv tool install --python 3.12 "ouro-ai @ git+https://github.com/ouro-ai-labs/ouro.git@{{ branch }}"
+{% elif version %}
 retry 3 5 uv tool install --python 3.12 ouro-ai=={{ version }}
 {% else %}
 retry 3 5 uv tool install --python 3.12 ouro-ai


### PR DESCRIPTION
## Summary
- Fix `--agent-version` → `--agent-kwarg` for Harbor CLI compatibility
- Add `AGENT_BRANCH` config to `harbor-run.sh` (overrides `AGENT_VERSION` when set)
- Add `branch` template variable in `install-ouro.sh.j2` for git+https install

Priority: `branch` > `version` > latest PyPI

## Usage
```bash
# Pin to a release version (default)
AGENT_VERSION="0.2.3"  AGENT_BRANCH=""

# Install from a git branch
AGENT_BRANCH="my-feature"  # AGENT_VERSION is ignored
```

## Test plan
- [ ] Run `./harbor-run.sh` with `AGENT_VERSION="0.2.3"` — installs pinned version
- [ ] Run with `AGENT_BRANCH="main"` — installs from git

🤖 Generated with [Claude Code](https://claude.com/claude-code)