### PR TITLE
feat: add --verify flag to control Ralph Loop in task mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ ouro --resume a1b2c3d4
 | `--resume [ID]` | `-r` | Resume a session (`latest` if no ID given) |
 | `--login` | - | Open OAuth provider selector and login |
 | `--logout` | - | Open OAuth provider selector and logout |
+| `--verify` | | Enable self-verification (Ralph Loop) in `--task` mode |
 | `--verbose` | `-v` | Enable verbose logging to `~/.ouro/logs/` |
 
 ## Interactive Commands

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -162,7 +162,7 @@ When to use each approach:
 - Parallel workload → parallel_execute
 </complex_task_strategy>"""
 
-    async def run(self, task: str, verify: bool = True) -> str:
+    async def run(self, task: str, verify: bool = False) -> str:
         """Execute ReAct loop until task is complete.
 
         Args:

--- a/main.py
+++ b/main.py
@@ -210,6 +210,12 @@ def main():
         action="store_true",
         help="Logout from OAuth provider",
     )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        default=False,
+        help="Enable Ralph Loop verification (outer loop that retries on failure). Only applies to --task mode.",
+    )
 
     args = parser.parse_args()
 
@@ -348,7 +354,7 @@ def main():
         terminal_ui.console = Console(quiet=True)
 
         # Run agent
-        result = await agent.run(task)
+        result = await agent.run(task, verify=args.verify)
 
         print(result)
 


### PR DESCRIPTION
## Summary

- Add `--verify` CLI flag (default off) to explicitly enable Ralph Loop self-verification in `--task` mode. Previously `--task` always enabled the Ralph Loop.
- Change `agent.run()` default from `verify=True` to `verify=False`.
- Update README CLI Reference table with the new flag.
- Update tests to cover both `verify=True` and `verify=False` dispatch paths.

### Usage

```bash
# Plain ReAct loop (default)
ouro --task "Calculate 1+1"

# With Ralph Loop verification
ouro --task "Calculate 1+1" --verify
```

## Test plan

- [x] `test_run_defaults_to_react_loop`
- [x] `test_run_with_verify_dispatches_to_ralph_loop`
- [x] `test_run_with_verify_false_dispatches_to_react_loop`
- [x] All 10 tests in test_ralph_loop.py pass