### PR TITLE
fix(tui): single-line spinner to eliminate ghost artifacts

### DIFF
--- a/utils/tui/progress.py
+++ b/utils/tui/progress.py
@@ -2,15 +2,49 @@
 
 import time
 from contextlib import contextmanager
-from typing import Generator, Optional
+from typing import TYPE_CHECKING, Generator, Optional
 
 from rich import box
 from rich.console import Console
 from rich.live import Live
 from rich.panel import Panel
 from rich.spinner import Spinner as RichSpinner
+from rich.text import Text
 
 from utils.tui.theme import Theme
+
+if TYPE_CHECKING:
+    from rich.console import ConsoleOptions, RenderResult
+
+
+class _SpinnerLine:
+    """Single-line spinner renderable with dynamic text.
+
+    Recomputes title, message, and elapsed time on every render cycle so
+    that ``Live`` always shows current values.  Uses ``Text.from_markup``
+    for proper Rich styling and keeps output to a single line — avoiding
+    the ``Live(transient=True)`` ghost-line artifacts that multi-line
+    ``Panel`` renderables can trigger (Rich #1320).
+    """
+
+    def __init__(self, owner: "Spinner | AsyncSpinner") -> None:
+        self._owner = owner
+        self._spinner = RichSpinner("dots")
+
+    def __rich_console__(self, console: "Console", options: "ConsoleOptions") -> "RenderResult":
+        colors = Theme.get_colors()
+        parts = (
+            f"  [bold {colors.thinking_accent}]{self._owner.title}[/]"
+            f" [{colors.text_muted}]›[/{colors.text_muted}]"
+            f" {self._owner.message}"
+        )
+        start = self._owner._start_time
+        if start is not None:
+            elapsed = time.time() - start
+            parts += f"  [{colors.text_muted}]({elapsed:.1f}s)[/{colors.text_muted}]"
+        self._spinner.text = Text.from_markup(parts)
+        self._spinner.style = colors.primary
+        yield from self._spinner.__rich_console__(console, options)
 
 
 class Spinner:
@@ -24,6 +58,7 @@ class Spinner:
         console: Console,
         message: str = "Processing...",
         show_duration: bool = True,
+        title: str = "Thinking",
     ):
         """Initialize spinner.
 
@@ -31,38 +66,14 @@ class Spinner:
             console: Rich console instance
             message: Message to display with spinner
             show_duration: Whether to show elapsed time
+            title: Spinner title (e.g. "Thinking", "Working")
         """
         self.console = console
         self.message = message
         self.show_duration = show_duration
+        self.title = title
         self._start_time: Optional[float] = None
         self._live: Optional[Live] = None
-
-    def _render(self) -> Panel:
-        """Render the spinner panel.
-
-        Returns:
-            Rich Panel with spinner content
-        """
-        colors = Theme.get_colors()
-
-        # Build spinner text with optional duration
-        text = f"  {self.message}"
-        if self.show_duration and self._start_time is not None:
-            elapsed = time.time() - self._start_time
-            text += f"\n  └─ Duration: {elapsed:.1f}s"
-
-        # Create spinner with message
-        spinner = RichSpinner("dots", text=text, style=colors.primary)
-
-        return Panel(
-            spinner,
-            title=f"[{colors.thinking_accent}]Thinking[/{colors.thinking_accent}]",
-            title_align="left",
-            border_style=colors.text_muted,
-            box=box.ROUNDED,
-            padding=(0, 1),
-        )
 
     @contextmanager
     def __call__(self, message: Optional[str] = None) -> Generator[None, None, None]:
@@ -79,7 +90,7 @@ class Spinner:
 
         self._start_time = time.time()
         self._live = Live(
-            self._render(),
+            _SpinnerLine(self),
             console=self.console,
             refresh_per_second=10,
             transient=True,
@@ -99,8 +110,6 @@ class Spinner:
             message: New message to display
         """
         self.message = message
-        if self._live is not None:
-            self._live.update(self._render())
 
 
 class ProgressContext:
@@ -237,7 +246,7 @@ class AsyncSpinner:
         Args:
             console: Rich console instance
             message: Message to display
-            title: Panel title (e.g. "Thinking", "Working", "Verifying")
+            title: Spinner title (e.g. "Thinking", "Working", "Verifying")
         """
         self.console = console
         self.message = message
@@ -246,21 +255,6 @@ class AsyncSpinner:
         self._live: Optional[Live] = None
         self._running = False
 
-    def _render(self) -> Panel:
-        """Render the spinner panel."""
-        colors = Theme.get_colors()
-
-        spinner = RichSpinner("dots", text=f"  {self.message}", style=colors.primary)
-
-        return Panel(
-            spinner,
-            title=f"[{colors.thinking_accent}]{self.title}[/{colors.thinking_accent}]",
-            title_align="left",
-            border_style=colors.text_muted,
-            box=box.ROUNDED,
-            padding=(0, 1),
-        )
-
     async def __aenter__(self) -> "AsyncSpinner":
         """Async context manager entry."""
         if self.console.quiet:
@@ -268,7 +262,7 @@ class AsyncSpinner:
         self._start_time = time.time()
         self._running = True
         self._live = Live(
-            self._render(),
+            _SpinnerLine(self),
             console=self.console,
             refresh_per_second=10,
             transient=True,
@@ -291,5 +285,3 @@ class AsyncSpinner:
             message: New message
         """
         self.message = message
-        if self._live is not None and self._running:
-            self._live.update(self._render())


### PR DESCRIPTION
## Summary

Replace the 3-line `Panel` spinner with a single-line `_SpinnerLine` renderable. This fixes the ghost `╭─ Thinking ─╮` border line that Rich's `Live(transient=True)` sometimes leaves behind when clearing multi-line renderables (Rich [#1320](https://github.com/Textualize/rich/issues/1320)).

Also fixes two secondary issues:
- Elapsed timer was frozen at 0.0s (text baked at init time, never updated)
- Rich markup in spinner text was rendered as literal `[bold ...]` tags (`RichSpinner.text` treats strings as plain text)

## Scope

- Goals: Eliminate spinner ghost artifacts; live-updating elapsed time; proper styled text
- Non-goals: No changes to agent logic, tool execution, or memory compression

## Root Cause

Rich's `Live(transient=True)` clears previous output by moving cursor up `height` lines. When `height` is miscalculated (e.g., spinner Unicode chars render at unexpected width — Rich #1320), the top border of a 3-line Panel is left as a ghost:

```
╭─ Thinking ─────────╮        ← ghost (not cleared)
╭─ Thinking ─────────╮
│ ⠏   Processing...  │
╰────────────────────╯
```

Single-line output is immune: cursor-up-1 is the most basic operation and virtually never fails.

## Changes

| File | Change |
|------|--------|
| `utils/tui/progress.py` | Add `_SpinnerLine` renderable; remove `_render()` + `Panel` from `Spinner` and `AsyncSpinner` |

**Before**: `╭─ Thinking ─╮ │ ⠏ msg │ ╰────╯` (3 lines, ghost-prone)
**After**: `⠏  Thinking › Processing results...  (3.2s)` (1 line, reliable)

## Design: Transient vs Permanent UI

| Element | Nature | Rendering |
|---------|--------|-----------|
| Spinner (LLM call / tool exec) | Transient, disappears in seconds | **Single-line** + `Live(transient=True)` |
| Thinking content (`print_thinking`) | Permanent, stays in scroll history | **Panel** + `console.print()` |
| Tool calls (`print_tool_call`) | Permanent | **Panel** + `console.print()` |

## Invariants (Must Not Regress)

- [x] Agent loop behavior unchanged (only spinner display differs)
- [x] Tool execution order and parallelism unchanged
- [x] `update_message()` still works (next refresh reads new value)
- [x] `console.quiet` mode still skips spinner

## Acceptance Criteria

- [x] No ghost border lines from spinner
- [x] Elapsed time updates in real-time
- [x] Rich markup properly styled (bold title, muted separator)

## Test Plan

- [x] `./scripts/dev.sh check` — 418 passed, 1 skipped
- [x] Precommit (black, isort, ruff) passed
- [x] Typecheck: 0 issues

## Adversarial Review

- **What existing behavior could this break?** Display-only change; tests mock `AsyncSpinner` entirely so they're unaffected. `update_message()` API preserved.
- **Worst-case input/output size?** Spinner text is short constants, no risk.
- **Any secrets/logging risks?** No.
- **Any async/blocking I/O added on hot paths?** No. `_SpinnerLine.__rich_console__` is a pure render method.
- **What error message does the user see on failure?** N/A — spinners are transient UI.

## Docs / Compatibility

- [x] No docs update needed (internal UX fix)
- [x] No secrets committed; no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)