### PR TITLE
fix(bot): load skills registry in bot mode

### DIFF
--- a/bot/server.py
+++ b/bot/server.py
@@ -313,6 +313,7 @@ async def run_bot(model_id: str | None = None) -> None:
     Args:
         model_id: Optional model ID to use for agents.
     """
+    from agent.skills import SkillsRegistry, render_skills_section
     from bot.soul import load_soul
     from main import create_agent
 
@@ -331,10 +332,21 @@ async def run_bot(model_id: str | None = None) -> None:
     # Load bot personality (once, shared across all sessions)
     soul_content = load_soul()
 
+    # Bootstrap bundled skills and render skills section (once, shared across sessions)
+    skills_section: str | None = None
+    skills_registry = SkillsRegistry()
+    try:
+        await skills_registry.load()
+        skills_section = render_skills_section(list(skills_registry.skills.values()))
+    except Exception as e:
+        logger.warning("Failed to load skills registry: %s", e)
+
     def agent_factory() -> LoopAgent:
         agent = create_agent(model_id=model_id)
         if soul_content:
             agent.set_soul_section(soul_content)
+        if skills_section:
+            agent.set_skills_section(skills_section)
         return agent
 
     router = SessionRouter(agent_factory=agent_factory)


### PR DESCRIPTION
## Summary

Bot mode (`--bot`) was missing the `SkillsRegistry.load()` call, so bundled system skills (`skill-creator`, `skill-installer`) were not bootstrapped to `~/.ouro/skills/` and not injected into bot agents. This fix adds the same skills loading logic that interactive mode and `--task` mode already have.

## Scope

- Goals: bot mode agents get skills loaded, matching interactive/task mode behavior
- Non-goals: no changes to skills system itself

## Invariants (Must Not Regress)

- [ ] Interactive mode skills loading unchanged
- [ ] `--task` mode skills loading unchanged
- [ ] Bot server startup and channel routing unchanged
- [ ] Soul loading still works in bot mode

## Acceptance Criteria

- [ ] `SkillsRegistry.load()` is called during `run_bot()` startup
- [ ] Bundled skills are bootstrapped to `~/.ouro/skills/` when starting in bot mode
- [ ] Skills section is injected into every agent created by `agent_factory`

## Test Plan

- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)