### PR TITLE
fix(bot): reload skills from disk on new session creation

### DIFF
--- a/bot/server.py
+++ b/bot/server.py
@@ -90,7 +90,7 @@ class BotServer:
             return True
 
         if cmd == "/compact":
-            agent = self._router.get_or_create_agent(msg.channel, msg.conversation_id)
+            agent = await self._router.get_or_create_agent(msg.channel, msg.conversation_id)
             try:
                 result = await agent.memory.compress()
             except Exception:
@@ -172,7 +172,7 @@ class BotServer:
             if await self._handle_command(channel, msg):
                 return
 
-            agent = self._router.get_or_create_agent(msg.channel, msg.conversation_id)
+            agent = await self._router.get_or_create_agent(msg.channel, msg.conversation_id)
             lock = self._router.get_lock(msg.channel, msg.conversation_id)
 
             async with lock:
@@ -332,21 +332,26 @@ async def run_bot(model_id: str | None = None) -> None:
     # Load bot personality (once, shared across all sessions)
     soul_content = load_soul()
 
-    # Bootstrap bundled skills and render skills section (once, shared across sessions)
-    skills_section: str | None = None
-    skills_registry = SkillsRegistry()
+    # Bootstrap bundled skills (copies defaults to ~/.ouro/skills/ if needed)
     try:
-        await skills_registry.load()
-        skills_section = render_skills_section(list(skills_registry.skills.values()))
+        bootstrap_registry = SkillsRegistry()
+        await bootstrap_registry.load()
     except Exception as e:
-        logger.warning("Failed to load skills registry: %s", e)
+        logger.warning("Failed to bootstrap skills registry: %s", e)
 
-    def agent_factory() -> LoopAgent:
+    async def agent_factory() -> LoopAgent:
         agent = create_agent(model_id=model_id)
         if soul_content:
             agent.set_soul_section(soul_content)
-        if skills_section:
-            agent.set_skills_section(skills_section)
+        # Reload skills from disk each time so new sessions see newly installed skills
+        try:
+            registry = SkillsRegistry()
+            await registry.load()
+            section = render_skills_section(list(registry.skills.values()))
+            if section:
+                agent.set_skills_section(section)
+        except Exception as e:
+            logger.warning("Failed to load skills for new session: %s", e)
         return agent
 
     router = SessionRouter(agent_factory=agent_factory)

--- a/bot/session_router.py
+++ b/bot/session_router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from agent.agent import LoopAgent
 
@@ -25,12 +25,12 @@ class SessionRouter:
 
     def __init__(
         self,
-        agent_factory: Callable[[], LoopAgent],
+        agent_factory: Callable[[], LoopAgent] | Callable[[], Awaitable[LoopAgent]],
         idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,
     ) -> None:
         """
         Args:
-            agent_factory: Callable that returns a new LoopAgent instance.
+            agent_factory: Callable that returns a (possibly awaitable) LoopAgent.
             idle_timeout: Seconds of inactivity before a session is cleaned up.
         """
         self._agent_factory = agent_factory
@@ -42,7 +42,7 @@ class SessionRouter:
     def _session_key(self, channel: str, conversation_id: str) -> str:
         return f"{channel}:{conversation_id}"
 
-    def get_or_create_agent(self, channel: str, conversation_id: str) -> LoopAgent:
+    async def get_or_create_agent(self, channel: str, conversation_id: str) -> LoopAgent:
         """Get an existing agent or create a new one for the conversation.
 
         Args:
@@ -55,7 +55,10 @@ class SessionRouter:
         key = self._session_key(channel, conversation_id)
         if key not in self._sessions:
             logger.info("Creating new session for %s", key)
-            self._sessions[key] = self._agent_factory()
+            result = self._agent_factory()
+            if asyncio.isfuture(result) or asyncio.iscoroutine(result):
+                result = await result
+            self._sessions[key] = result
             self._locks[key] = asyncio.Lock()
         self._last_active[key] = time.time()
         return self._sessions[key]

--- a/test/test_bot_server.py
+++ b/test/test_bot_server.py
@@ -117,7 +117,7 @@ async def test_process_message_sends_ack_and_result(bot_server, fake_channel, mo
 
 async def test_process_message_error_sends_error_message(bot_server, fake_channel, mock_router):
     """When agent.run() fails, an error message is sent to the user."""
-    agent = mock_router.get_or_create_agent("test", "conv_err")
+    agent = await mock_router.get_or_create_agent("test", "conv_err")
     agent.run = AsyncMock(side_effect=RuntimeError("LLM timeout"))
 
     msg = IncomingMessage(
@@ -232,7 +232,7 @@ def _make_msg(text: str, conv: str = "conv_cmd") -> IncomingMessage:
 async def test_command_new_resets_session(bot_server, fake_channel, mock_router):
     """'/new' destroys the current session and replies with confirmation."""
     # Create a session first
-    mock_router.get_or_create_agent("test", "conv_cmd")
+    await mock_router.get_or_create_agent("test", "conv_cmd")
     assert mock_router.active_session_count == 1
 
     await bot_server._process_message(fake_channel, _make_msg("/new"))
@@ -244,7 +244,7 @@ async def test_command_new_resets_session(bot_server, fake_channel, mock_router)
 
 async def test_command_reset_alias(bot_server, fake_channel, mock_router):
     """'/reset' works the same as '/new'."""
-    mock_router.get_or_create_agent("test", "conv_cmd")
+    await mock_router.get_or_create_agent("test", "conv_cmd")
 
     await bot_server._process_message(fake_channel, _make_msg("/reset"))
 
@@ -259,7 +259,7 @@ async def test_command_compact(bot_server, fake_channel, mock_router):
     mock_result.token_savings = 1500
     mock_result.savings_percentage = 45.0
 
-    agent = mock_router.get_or_create_agent("test", "conv_cmd")
+    agent = await mock_router.get_or_create_agent("test", "conv_cmd")
     agent.memory.compress = AsyncMock(return_value=mock_result)
 
     await bot_server._process_message(fake_channel, _make_msg("/compact"))
@@ -274,7 +274,7 @@ async def test_command_compact(bot_server, fake_channel, mock_router):
 
 async def test_command_compact_nothing_to_compress(bot_server, fake_channel, mock_router):
     """'/compact' with nothing to compress returns appropriate message."""
-    agent = mock_router.get_or_create_agent("test", "conv_cmd")
+    agent = await mock_router.get_or_create_agent("test", "conv_cmd")
     agent.memory.compress = AsyncMock(return_value=None)
 
     await bot_server._process_message(fake_channel, _make_msg("/compact"))
@@ -284,7 +284,7 @@ async def test_command_compact_nothing_to_compress(bot_server, fake_channel, moc
 
 async def test_command_status(bot_server, fake_channel, mock_router):
     """'/status' returns session statistics."""
-    agent = mock_router.get_or_create_agent("test", "conv_cmd")
+    agent = await mock_router.get_or_create_agent("test", "conv_cmd")
     agent.memory.get_stats.return_value = {
         "current_tokens": 5000,
         "total_input_tokens": 12000,
@@ -343,7 +343,7 @@ async def test_unknown_command_passes_through(bot_server, fake_channel, mock_rou
 
 async def test_command_with_extra_args(bot_server, fake_channel, mock_router):
     """'/new some_arg' still parses as /new command."""
-    mock_router.get_or_create_agent("test", "conv_cmd")
+    await mock_router.get_or_create_agent("test", "conv_cmd")
 
     await bot_server._process_message(fake_channel, _make_msg("/new some extra text"))
 
@@ -352,7 +352,7 @@ async def test_command_with_extra_args(bot_server, fake_channel, mock_router):
 
 async def test_command_case_insensitive(bot_server, fake_channel, mock_router):
     """'/NEW' is treated as /new."""
-    mock_router.get_or_create_agent("test", "conv_cmd")
+    await mock_router.get_or_create_agent("test", "conv_cmd")
 
     await bot_server._process_message(fake_channel, _make_msg("/NEW"))
 

--- a/test/test_bot_session_router.py
+++ b/test/test_bot_session_router.py
@@ -11,64 +11,64 @@ def _mock_agent_factory():
     return MagicMock()
 
 
-def test_get_or_create_agent_creates_new_session():
+async def test_get_or_create_agent_creates_new_session():
     router = SessionRouter(agent_factory=_mock_agent_factory)
     assert router.active_session_count == 0
 
-    agent = router.get_or_create_agent("feishu", "chat_123")
+    agent = await router.get_or_create_agent("feishu", "chat_123")
     assert agent is not None
     assert router.active_session_count == 1
 
 
-def test_get_or_create_agent_reuses_existing():
+async def test_get_or_create_agent_reuses_existing():
     router = SessionRouter(agent_factory=_mock_agent_factory)
 
-    agent1 = router.get_or_create_agent("feishu", "chat_123")
-    agent2 = router.get_or_create_agent("feishu", "chat_123")
+    agent1 = await router.get_or_create_agent("feishu", "chat_123")
+    agent2 = await router.get_or_create_agent("feishu", "chat_123")
     assert agent1 is agent2
     assert router.active_session_count == 1
 
 
-def test_different_conversations_get_different_agents():
+async def test_different_conversations_get_different_agents():
     router = SessionRouter(agent_factory=_mock_agent_factory)
 
-    agent1 = router.get_or_create_agent("feishu", "chat_a")
-    agent2 = router.get_or_create_agent("feishu", "chat_b")
+    agent1 = await router.get_or_create_agent("feishu", "chat_a")
+    agent2 = await router.get_or_create_agent("feishu", "chat_b")
     assert agent1 is not agent2
     assert router.active_session_count == 2
 
 
-def test_different_channels_get_different_agents():
+async def test_different_channels_get_different_agents():
     router = SessionRouter(agent_factory=_mock_agent_factory)
 
-    agent1 = router.get_or_create_agent("feishu", "chat_123")
-    agent2 = router.get_or_create_agent("slack", "chat_123")
+    agent1 = await router.get_or_create_agent("feishu", "chat_123")
+    agent2 = await router.get_or_create_agent("slack", "chat_123")
     assert agent1 is not agent2
     assert router.active_session_count == 2
 
 
-def test_get_lock_returns_asyncio_lock():
+async def test_get_lock_returns_asyncio_lock():
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
 
     lock = router.get_lock("feishu", "chat_123")
     assert isinstance(lock, asyncio.Lock)
 
 
-def test_same_conversation_gets_same_lock():
+async def test_same_conversation_gets_same_lock():
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
 
     lock1 = router.get_lock("feishu", "chat_123")
     lock2 = router.get_lock("feishu", "chat_123")
     assert lock1 is lock2
 
 
-def test_cleanup_idle_sessions():
+async def test_cleanup_idle_sessions():
     router = SessionRouter(agent_factory=_mock_agent_factory, idle_timeout=0.0)
 
-    router.get_or_create_agent("feishu", "chat_123")
-    router.get_or_create_agent("feishu", "chat_456")
+    await router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_456")
     assert router.active_session_count == 2
 
     # With idle_timeout=0.0, all sessions are immediately idle
@@ -77,10 +77,10 @@ def test_cleanup_idle_sessions():
     assert router.active_session_count == 0
 
 
-def test_cleanup_preserves_active_sessions():
+async def test_cleanup_preserves_active_sessions():
     router = SessionRouter(agent_factory=_mock_agent_factory, idle_timeout=3600.0)
 
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
     assert router.active_session_count == 1
 
     # With a 1-hour timeout, nothing should be cleaned up
@@ -92,7 +92,7 @@ def test_cleanup_preserves_active_sessions():
 async def test_lock_serializes_access():
     """Verify that the per-conversation lock serializes concurrent access."""
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
     lock = router.get_lock("feishu", "chat_123")
 
     order: list[int] = []
@@ -112,9 +112,9 @@ async def test_lock_serializes_access():
 # ---------------------------------------------------------------------------
 
 
-def test_reset_session_destroys_agent():
+async def test_reset_session_destroys_agent():
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
     assert router.active_session_count == 1
 
     existed = router.reset_session("feishu", "chat_123")
@@ -132,12 +132,12 @@ def test_reset_session_nonexistent():
     assert existed is False
 
 
-def test_reset_session_new_agent_after_reset():
+async def test_reset_session_new_agent_after_reset():
     """After reset, get_or_create_agent returns a fresh agent."""
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    agent_before = router.get_or_create_agent("feishu", "chat_123")
+    agent_before = await router.get_or_create_agent("feishu", "chat_123")
     router.reset_session("feishu", "chat_123")
-    agent_after = router.get_or_create_agent("feishu", "chat_123")
+    agent_after = await router.get_or_create_agent("feishu", "chat_123")
     assert agent_before is not agent_after
 
 
@@ -151,9 +151,9 @@ def test_get_session_age_no_session():
     assert router.get_session_age("feishu", "chat_123") is None
 
 
-def test_get_session_age_returns_positive():
+async def test_get_session_age_returns_positive():
     router = SessionRouter(agent_factory=_mock_agent_factory)
-    router.get_or_create_agent("feishu", "chat_123")
+    await router.get_or_create_agent("feishu", "chat_123")
     age = router.get_session_age("feishu", "chat_123")
     assert age is not None
     assert age >= 0


### PR DESCRIPTION
## Summary

Bot mode new sessions now see newly installed skills. Previously, `SkillsRegistry` was loaded once at startup and the rendered `skills_section` was captured in the `agent_factory` closure — new sessions created after `/new` still used the stale cached skills. Now `agent_factory` is async and reloads skills from `~/.ouro/skills/` each time a new agent is created.

## Scope

- Goals: every new bot session picks up the latest installed skills from disk
- Non-goals: no changes to skill installation, no changes to interactive mode

## Invariants (Must Not Regress)

- [x] Existing sessions continue to work (skills only reload on *new* session creation)
- [x] Bot startup still bootstraps bundled skills to `~/.ouro/skills/`
- [x] `/new`, `/compact`, `/status`, `/help` commands work as before
- [x] Sync agent factories (used in tests) still work via `asyncio.iscoroutine` check

## Acceptance Criteria

- [x] `agent_factory` in `run_bot()` is async and reloads `SkillsRegistry` each call
- [x] `SessionRouter.get_or_create_agent` is async and handles both sync/async factories
- [x] All call sites updated to `await`

## Test Plan

- [x] `./scripts/dev.sh check` — 482 passed, 1 skipped
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — clean

## Smoke Run (Real CLI)

Not applicable — bot mode requires IM channel credentials. Verified via unit tests.

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?** Sync factory callers — mitigated by `asyncio.iscoroutine` check in `get_or_create_agent`.
- **Worst-case input/output size?** Skills reload reads a small directory; bounded by number of installed skills.
- **Any secrets/logging risks?** No.
- **Any async/blocking I/O added on hot paths?** `SkillsRegistry.load()` reads from disk, but only on new session creation (not per-message).
- **What error message does the user see on failure?** Skills load failure is logged as warning; agent still created without skills section.

## Docs / Compatibility

- [x] No docs changes needed
- [x] No secrets committed; no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)