### PR TITLE
feat(bot): add proactive heartbeat and cron mechanisms

### DIFF
--- a/bot/proactive.py
+++ b/bot/proactive.py
@@ -1,0 +1,443 @@
+"""Proactive mechanisms: heartbeat checks and cron-scheduled tasks.
+
+All proactive tasks run in *isolated sessions* (one-shot agents without
+conversation history) to keep token costs low. Results are broadcast to
+all active IM sessions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from croniter import croniter
+
+from config import Config
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from agent.agent import LoopAgent
+    from bot.channel.base import Channel
+    from bot.session_router import SessionRouter
+
+logger = logging.getLogger(__name__)
+
+# Paths under ~/.ouro/bot/
+_BOT_DIR = os.path.join(os.path.expanduser("~"), ".ouro", "bot")
+_HEARTBEAT_FILE = os.path.join(_BOT_DIR, "heartbeat.md")
+_CRON_JOBS_FILE = os.path.join(_BOT_DIR, "cron_jobs.json")
+
+# Execution timeout for isolated agent runs (seconds)
+_ISOLATED_TIMEOUT = 120
+
+_DEFAULT_HEARTBEAT = """\
+# Heartbeat Checklist
+
+This file is read every heartbeat cycle. Edit it to define periodic checks.
+
+- [ ] Check if any pending tasks need follow-up
+- [ ] Review recent memory for unresolved items
+"""
+
+_HEARTBEAT_PROMPT = """\
+You are running a periodic heartbeat check. This is an isolated session \
+with no conversation history.
+
+Read the following heartbeat checklist and follow it strictly. \
+Do not infer tasks from prior conversations.
+
+If nothing needs attention, respond with exactly: HEARTBEAT_OK
+If something needs attention, write a concise message.
+
+---
+{checklist}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def load_heartbeat() -> str:
+    """Load heartbeat.md, creating a default if it doesn't exist."""
+    if not os.path.isfile(_HEARTBEAT_FILE):
+        os.makedirs(_BOT_DIR, exist_ok=True)
+        with open(_HEARTBEAT_FILE, "w", encoding="utf-8") as f:
+            f.write(_DEFAULT_HEARTBEAT)
+        logger.info("Created default heartbeat file: %s", _HEARTBEAT_FILE)
+    try:
+        with open(_HEARTBEAT_FILE, encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        logger.warning("Could not read heartbeat file: %s", _HEARTBEAT_FILE, exc_info=True)
+        return ""
+
+
+def is_active_hours(
+    now: datetime | None = None,
+    *,
+    start: int | None = None,
+    end: int | None = None,
+    tz_name: str | None = None,
+) -> bool:
+    """Return True if the current hour falls within the active window.
+
+    Parameters default to Config values when not explicitly provided.
+    """
+    start = start if start is not None else Config.BOT_ACTIVE_HOURS_START
+    end = end if end is not None else Config.BOT_ACTIVE_HOURS_END
+    tz_name = tz_name if tz_name is not None else Config.BOT_ACTIVE_HOURS_TZ
+
+    if now is None:
+        if tz_name:
+            try:
+                import zoneinfo
+
+                tz = zoneinfo.ZoneInfo(tz_name)
+            except Exception:
+                tz = None
+        else:
+            tz = None
+        now = datetime.now(tz=tz)
+
+    hour = now.hour
+    if start <= end:
+        # e.g. 8–22
+        return start <= hour < end
+    # Wraps midnight, e.g. 22–6
+    return hour >= start or hour < end
+
+
+# ---------------------------------------------------------------------------
+# ProactiveExecutor — isolated execution + broadcast
+# ---------------------------------------------------------------------------
+
+
+class ProactiveExecutor:
+    """Run prompts in one-shot agent sessions and broadcast results."""
+
+    def __init__(
+        self,
+        agent_factory: Callable[[], LoopAgent] | Callable[[], Awaitable[LoopAgent]],
+        channels: list[Channel],
+        router: SessionRouter,
+    ) -> None:
+        self._agent_factory = agent_factory
+        self._channels = channels
+        self._router = router
+
+    async def run_isolated(self, prompt: str) -> str:
+        """Create a throwaway agent, execute *prompt*, return result.
+
+        The agent gets tools + soul + skills + LTM but no conversation history.
+        Hard timeout: ``_ISOLATED_TIMEOUT`` seconds.
+        """
+        result = self._agent_factory()
+        if asyncio.isfuture(result) or asyncio.iscoroutine(result):
+            agent: LoopAgent = await result
+        else:
+            agent = result  # type: ignore[assignment]
+
+        try:
+            return await asyncio.wait_for(agent.run(prompt), timeout=_ISOLATED_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning("Isolated agent timed out after %ds", _ISOLATED_TIMEOUT)
+            return "[Proactive task timed out]"
+
+    async def broadcast(self, text: str) -> int:
+        """Push *text* to all active sessions, skipping busy ones.
+
+        Returns the number of sessions successfully reached.
+        """
+        from bot.channel.base import OutgoingMessage
+
+        sessions = self._router.iter_active_sessions()
+        if not sessions:
+            logger.debug("broadcast: no active sessions")
+            return 0
+
+        # Build a name→channel lookup for fast dispatch
+        channel_map: dict[str, Channel] = {ch.name: ch for ch in self._channels}
+        sent = 0
+
+        for channel_name, conversation_id in sessions:
+            if self._router.is_session_busy(channel_name, conversation_id):
+                logger.debug(
+                    "broadcast: skipping busy session %s:%s", channel_name, conversation_id
+                )
+                continue
+            ch = channel_map.get(channel_name)
+            if ch is None:
+                continue
+            try:
+                await ch.send_message(OutgoingMessage(conversation_id=conversation_id, text=text))
+                sent += 1
+            except Exception:
+                logger.warning(
+                    "broadcast: failed to send to %s:%s",
+                    channel_name,
+                    conversation_id,
+                    exc_info=True,
+                )
+        return sent
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatRunner
+# ---------------------------------------------------------------------------
+
+
+class HeartbeatRunner:
+    """Periodically execute a heartbeat check and broadcast if needed."""
+
+    def __init__(self, executor: ProactiveExecutor, interval: int | None = None) -> None:
+        self._executor = executor
+        self._interval = interval if interval is not None else Config.BOT_HEARTBEAT_INTERVAL
+        self._last_run: datetime | None = None
+        self._next_run: datetime | None = None
+        self._running = False
+
+    # Expose for /heartbeat command
+    @property
+    def interval(self) -> int:
+        return self._interval
+
+    @property
+    def last_run(self) -> datetime | None:
+        return self._last_run
+
+    @property
+    def next_run(self) -> datetime | None:
+        return self._next_run
+
+    @property
+    def enabled(self) -> bool:
+        return self._interval > 0
+
+    async def loop(self) -> None:
+        """Main heartbeat loop — runs until cancelled."""
+        if not self.enabled:
+            logger.info("Heartbeat disabled (interval=0)")
+            return
+        self._running = True
+        logger.info("Heartbeat started (interval=%ds)", self._interval)
+        try:
+            while True:
+                self._next_run = datetime.now(tz=timezone.utc) + _td(self._interval)
+                await asyncio.sleep(self._interval)
+                await self._tick()
+        except asyncio.CancelledError:
+            logger.info("Heartbeat loop cancelled")
+        finally:
+            self._running = False
+
+    async def _tick(self) -> None:
+        """Single heartbeat tick."""
+        try:
+            if not is_active_hours():
+                logger.debug("Heartbeat skipped: outside active hours")
+                return
+
+            # Skip if all sessions are busy
+            sessions = self._executor._router.iter_active_sessions()
+            if sessions and all(
+                self._executor._router.is_session_busy(ch, cid) for ch, cid in sessions
+            ):
+                logger.debug("Heartbeat skipped: all sessions busy")
+                return
+
+            self._last_run = datetime.now(tz=timezone.utc)
+            checklist = load_heartbeat()
+            prompt = _HEARTBEAT_PROMPT.format(checklist=checklist)
+            result = await self._executor.run_isolated(prompt)
+
+            if result.strip().startswith("HEARTBEAT_OK"):
+                logger.info("Heartbeat: OK (nothing to report)")
+                return
+
+            count = await self._executor.broadcast(f"[Heartbeat] {result}")
+            logger.info("Heartbeat: broadcast to %d sessions", count)
+        except Exception:
+            logger.exception("Heartbeat tick failed")
+
+
+# ---------------------------------------------------------------------------
+# CronScheduler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CronJob:
+    """A single scheduled job."""
+
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    name: str = ""
+    schedule_type: str = "cron"  # "cron" | "every"
+    schedule_value: str = ""  # cron expression | seconds
+    prompt: str = ""
+    enabled: bool = True
+    last_run_at: str | None = None
+    next_run_at: str | None = None
+
+
+class CronScheduler:
+    """Run cron-scheduled prompts via ProactiveExecutor."""
+
+    def __init__(self, executor: ProactiveExecutor) -> None:
+        self._executor = executor
+        self._jobs: list[CronJob] = []
+        self._running = False
+        self._load_jobs()
+
+    # ---- Public API for slash commands -------------------------------------
+
+    @property
+    def jobs(self) -> list[CronJob]:
+        return list(self._jobs)
+
+    def add_job(
+        self,
+        schedule_expr: str,
+        prompt: str,
+        name: str = "",
+    ) -> CronJob:
+        """Add a new job. *schedule_expr* is a cron expression or an integer (seconds)."""
+        try:
+            seconds = int(schedule_expr)
+            stype, sval = "every", str(seconds)
+        except ValueError:
+            # Validate cron expression
+            croniter(schedule_expr)  # raises ValueError on bad expr
+            stype, sval = "cron", schedule_expr
+
+        job = CronJob(
+            name=name or prompt[:40],
+            schedule_type=stype,
+            schedule_value=sval,
+            prompt=prompt,
+        )
+        self._compute_next_run(job)
+        self._jobs.append(job)
+        self._save_jobs()
+        return job
+
+    def remove_job(self, job_id: str) -> bool:
+        """Remove a job by ID. Returns True if found."""
+        before = len(self._jobs)
+        self._jobs = [j for j in self._jobs if j.id != job_id]
+        removed = len(self._jobs) < before
+        if removed:
+            self._save_jobs()
+        return removed
+
+    # ---- Loop --------------------------------------------------------------
+
+    async def loop(self) -> None:
+        """Main scheduler loop — checks every 60s."""
+        self._running = True
+        logger.info("Cron scheduler started (%d jobs loaded)", len(self._jobs))
+        try:
+            while True:
+                await asyncio.sleep(60)
+                await self._tick()
+        except asyncio.CancelledError:
+            logger.info("Cron scheduler cancelled")
+        finally:
+            self._running = False
+
+    async def _tick(self) -> None:
+        """Check all jobs, execute those that are due."""
+        now = datetime.now(tz=timezone.utc)
+        for job in self._jobs:
+            if not job.enabled or not job.next_run_at:
+                continue
+            try:
+                next_dt = datetime.fromisoformat(job.next_run_at)
+            except (ValueError, TypeError):
+                continue
+            if now < next_dt:
+                continue
+
+            if not is_active_hours():
+                logger.debug("Cron job %s skipped: outside active hours", job.id)
+                self._compute_next_run(job)
+                continue
+
+            await self._execute_job(job)
+
+    async def _execute_job(self, job: CronJob) -> None:
+        """Execute a single job and broadcast the result."""
+        try:
+            logger.info("Cron executing job %s (%s)", job.id, job.name)
+            result = await self._executor.run_isolated(job.prompt)
+            label = job.name or job.id
+            await self._executor.broadcast(f"[Cron: {label}] {result}")
+        except Exception:
+            logger.exception("Cron job %s failed", job.id)
+        finally:
+            job.last_run_at = datetime.now(tz=timezone.utc).isoformat()
+            self._compute_next_run(job)
+            self._save_jobs()
+
+    # ---- Persistence -------------------------------------------------------
+
+    def _compute_next_run(self, job: CronJob) -> None:
+        """Set job.next_run_at based on schedule type."""
+        now = datetime.now(tz=timezone.utc)
+        try:
+            if job.schedule_type == "every":
+                seconds = int(job.schedule_value)
+                nxt = now + _td(seconds)
+            else:
+                cron = croniter(job.schedule_value, now)
+                nxt = cron.get_next(datetime)
+            job.next_run_at = nxt.isoformat()
+        except Exception:
+            logger.warning("Cannot compute next_run for job %s", job.id, exc_info=True)
+            job.next_run_at = None
+
+    def _save_jobs(self) -> None:
+        """Persist jobs to ~/.ouro/bot/cron_jobs.json."""
+        os.makedirs(_BOT_DIR, exist_ok=True)
+        data = [asdict(j) for j in self._jobs]
+        try:
+            with open(_CRON_JOBS_FILE, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except OSError:
+            logger.warning("Failed to save cron jobs", exc_info=True)
+
+    def _load_jobs(self) -> None:
+        """Load jobs from disk."""
+        if not os.path.isfile(_CRON_JOBS_FILE):
+            return
+        try:
+            with open(_CRON_JOBS_FILE, encoding="utf-8") as f:
+                data: list[dict[str, Any]] = json.load(f)
+            for item in data:
+                job = CronJob(
+                    **{k: v for k, v in item.items() if k in CronJob.__dataclass_fields__}
+                )
+                self._jobs.append(job)
+            logger.info("Loaded %d cron jobs from disk", len(self._jobs))
+        except Exception:
+            logger.warning("Failed to load cron jobs", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _td(seconds: int):
+    """Shorthand for timedelta."""
+    from datetime import timedelta
+
+    return timedelta(seconds=seconds)

--- a/bot/server.py
+++ b/bot/server.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from aiohttp import web
 
 from bot.channel.base import Channel, IncomingMessage, OutgoingMessage
+from bot.proactive import CronScheduler, HeartbeatRunner, ProactiveExecutor
 from bot.session_router import SessionRouter
 from config import Config
 
@@ -41,12 +42,19 @@ class BotServer:
         self,
         session_router: SessionRouter,
         channels: list[Channel],
+        *,
+        heartbeat: HeartbeatRunner | None = None,
+        cron_scheduler: CronScheduler | None = None,
     ) -> None:
         self._router = session_router
         self._channels = channels
+        self._heartbeat = heartbeat
+        self._cron_scheduler = cron_scheduler
         self._app = web.Application()
         self._app.router.add_get("/health", self._handle_health)
         self._cleanup_task: asyncio.Task | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+        self._cron_task: asyncio.Task | None = None
 
     async def _handle_health(self, request: web.Request) -> web.Response:
         return web.json_response(
@@ -60,11 +68,13 @@ class BotServer:
 
     _HELP_TEXT = (
         "Available commands:\n"
-        "  /new     — Start a fresh conversation (reset session)\n"
-        "  /reset   — Alias for /new\n"
-        "  /compact — Compress conversation memory to save tokens\n"
-        "  /status  — Show session statistics\n"
-        "  /help    — Show this message"
+        "  /new       — Start a fresh conversation (reset session)\n"
+        "  /reset     — Alias for /new\n"
+        "  /compact   — Compress conversation memory to save tokens\n"
+        "  /status    — Show session statistics\n"
+        "  /heartbeat — Show heartbeat status\n"
+        "  /cron      — Manage cron jobs (list | add | remove)\n"
+        "  /help      — Show this message"
     )
 
     async def _handle_command(
@@ -149,6 +159,14 @@ class BotServer:
             )
             return True
 
+        if cmd == "/heartbeat":
+            await self._handle_heartbeat_command(channel, msg)
+            return True
+
+        if cmd == "/cron":
+            await self._handle_cron_command(channel, msg)
+            return True
+
         if cmd == "/help":
             await channel.send_message(
                 OutgoingMessage(
@@ -160,6 +178,143 @@ class BotServer:
 
         # Unknown /command — pass through to agent as a normal message
         return False
+
+    async def _handle_heartbeat_command(self, channel: Channel, msg: IncomingMessage) -> None:
+        """Show heartbeat status."""
+        if not self._heartbeat:
+            text = "Heartbeat: not configured"
+        elif not self._heartbeat.enabled:
+            text = "Heartbeat: disabled (interval=0)"
+        else:
+            lines = [
+                "Heartbeat: enabled",
+                f"  Interval: {self._heartbeat.interval}s",
+                f"  Last run: {self._heartbeat.last_run or 'never'}",
+                f"  Next run: {self._heartbeat.next_run or 'pending'}",
+            ]
+            text = "\n".join(lines)
+        await channel.send_message(OutgoingMessage(conversation_id=msg.conversation_id, text=text))
+
+    async def _handle_cron_command(self, channel: Channel, msg: IncomingMessage) -> None:
+        """Handle /cron subcommands: list, add, remove."""
+        parts = msg.text.strip().split(maxsplit=2)
+        sub = parts[1].lower() if len(parts) > 1 else "list"
+
+        if sub == "list":
+            await self._cron_list(channel, msg)
+        elif sub == "add":
+            await self._cron_add(channel, msg, parts)
+        elif sub == "remove":
+            await self._cron_remove(channel, msg, parts)
+        else:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text="Usage: /cron list | /cron add <schedule> <prompt> | /cron remove <id>",
+                )
+            )
+
+    async def _cron_list(self, channel: Channel, msg: IncomingMessage) -> None:
+        if not self._cron_scheduler:
+            await channel.send_message(
+                OutgoingMessage(conversation_id=msg.conversation_id, text="Cron: not configured")
+            )
+            return
+        jobs = self._cron_scheduler.jobs
+        if not jobs:
+            await channel.send_message(
+                OutgoingMessage(conversation_id=msg.conversation_id, text="No cron jobs.")
+            )
+            return
+        lines = []
+        for j in jobs:
+            status = "on" if j.enabled else "off"
+            sched = f"{j.schedule_type}={j.schedule_value}"
+            lines.append(f"  [{status}] {j.id}  {sched}  {j.name}")
+        await channel.send_message(
+            OutgoingMessage(
+                conversation_id=msg.conversation_id,
+                text="Cron jobs:\n" + "\n".join(lines),
+            )
+        )
+
+    async def _cron_add(self, channel: Channel, msg: IncomingMessage, parts: list[str]) -> None:
+        if not self._cron_scheduler:
+            await channel.send_message(
+                OutgoingMessage(conversation_id=msg.conversation_id, text="Cron: not configured")
+            )
+            return
+        # /cron add <schedule> <prompt>
+        # Re-split the rest after "add" to get schedule + prompt
+        rest = msg.text.strip().split(maxsplit=2)
+        if len(rest) < 3:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text="Usage: /cron add <schedule> <prompt>\n"
+                    "  schedule: cron expression (e.g. '0 9 * * *') or interval in seconds",
+                )
+            )
+            return
+        add_rest = rest[2]  # everything after "/cron add"
+        # First token is schedule, rest is prompt
+        add_parts = add_rest.split(maxsplit=1)
+        if len(add_parts) < 2:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text="Usage: /cron add <schedule> <prompt>",
+                )
+            )
+            return
+        schedule_expr, prompt = add_parts
+        try:
+            job = self._cron_scheduler.add_job(schedule_expr, prompt)
+        except (ValueError, KeyError) as exc:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text=f"Invalid schedule: {exc}",
+                )
+            )
+            return
+        await channel.send_message(
+            OutgoingMessage(
+                conversation_id=msg.conversation_id,
+                text=f"Added cron job {job.id}: next run at {job.next_run_at}",
+            )
+        )
+
+    async def _cron_remove(self, channel: Channel, msg: IncomingMessage, parts: list[str]) -> None:
+        if not self._cron_scheduler:
+            await channel.send_message(
+                OutgoingMessage(conversation_id=msg.conversation_id, text="Cron: not configured")
+            )
+            return
+        rest = msg.text.strip().split()
+        if len(rest) < 3:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text="Usage: /cron remove <id>",
+                )
+            )
+            return
+        job_id = rest[2]
+        if self._cron_scheduler.remove_job(job_id):
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text=f"Removed cron job {job_id}.",
+                )
+            )
+        else:
+            await channel.send_message(
+                OutgoingMessage(
+                    conversation_id=msg.conversation_id,
+                    text=f"No cron job with id {job_id}.",
+                )
+            )
 
     # ---- Message processing ---------------------------------------------------
 
@@ -237,6 +392,12 @@ class BotServer:
         """Start channels + health server, block until cancelled."""
         self._cleanup_task = asyncio.create_task(self._periodic_cleanup())
 
+        # Start proactive background tasks
+        if self._heartbeat and self._heartbeat.enabled:
+            self._heartbeat_task = asyncio.create_task(self._heartbeat.loop())
+        if self._cron_scheduler:
+            self._cron_task = asyncio.create_task(self._cron_scheduler.loop())
+
         # Start each channel, giving it a callback bound to itself.
         for ch in self._channels:
             callback = self._make_callback(ch)
@@ -257,6 +418,10 @@ class BotServer:
         finally:
             if self._cleanup_task:
                 self._cleanup_task.cancel()
+            if self._heartbeat_task:
+                self._heartbeat_task.cancel()
+            if self._cron_task:
+                self._cron_task.cancel()
             for ch in self._channels:
                 await ch.stop()
             await runner.cleanup()
@@ -355,7 +520,18 @@ async def run_bot(model_id: str | None = None) -> None:
         return agent
 
     router = SessionRouter(agent_factory=agent_factory)
-    server = BotServer(session_router=router, channels=channels)
+
+    # Proactive mechanisms (heartbeat + cron)
+    executor = ProactiveExecutor(agent_factory, channels, router)
+    heartbeat = HeartbeatRunner(executor)
+    cron = CronScheduler(executor)
+
+    server = BotServer(
+        session_router=router,
+        channels=channels,
+        heartbeat=heartbeat,
+        cron_scheduler=cron,
+    )
 
     host = Config.BOT_HOST
     port = Config.BOT_PORT

--- a/bot/session_router.py
+++ b/bot/session_router.py
@@ -120,6 +120,22 @@ class SessionRouter:
             return None
         return time.time() - ts
 
+    def iter_active_sessions(self) -> list[tuple[str, str]]:
+        """Return (channel_name, conversation_id) pairs for all live sessions."""
+        result: list[tuple[str, str]] = []
+        for key in self._sessions:
+            channel, conversation_id = key.split(":", 1)
+            result.append((channel, conversation_id))
+        return result
+
+    def is_session_busy(self, channel: str, conversation_id: str) -> bool:
+        """Check whether the session lock is currently held (agent processing)."""
+        key = self._session_key(channel, conversation_id)
+        lock = self._locks.get(key)
+        if lock is None:
+            return False
+        return lock.locked()
+
     @property
     def active_session_count(self) -> int:
         """Number of active sessions."""

--- a/config.py
+++ b/config.py
@@ -129,6 +129,14 @@ class Config:
     SLACK_BOT_TOKEN = _cfg.get("SLACK_BOT_TOKEN", "")
     SLACK_APP_TOKEN = _cfg.get("SLACK_APP_TOKEN", "")
 
+    # Proactive: Heartbeat & Active Hours
+    BOT_HEARTBEAT_INTERVAL = int(
+        _cfg.get("BOT_HEARTBEAT_INTERVAL", "1800")
+    )  # seconds; 0 = disabled
+    BOT_ACTIVE_HOURS_START = int(_cfg.get("BOT_ACTIVE_HOURS_START", "8"))  # 24h format
+    BOT_ACTIVE_HOURS_END = int(_cfg.get("BOT_ACTIVE_HOURS_END", "22"))  # 24h format
+    BOT_ACTIVE_HOURS_TZ = _cfg.get("BOT_ACTIVE_HOURS_TZ", "")  # empty = local timezone
+
     @classmethod
     def get_retry_delay(cls, attempt: int) -> float:
         """Calculate delay for a given retry attempt using exponential backoff.

--- a/test/test_bot_proactive.py
+++ b/test/test_bot_proactive.py
@@ -1,0 +1,490 @@
+"""Tests for bot proactive mechanisms (heartbeat + cron)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bot.channel.base import OutgoingMessage
+from bot.proactive import (
+    CronScheduler,
+    HeartbeatRunner,
+    ProactiveExecutor,
+    is_active_hours,
+    load_heartbeat,
+)
+from bot.session_router import SessionRouter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeChannel:
+    """Minimal channel for testing broadcasts."""
+
+    def __init__(self, name: str = "test"):
+        self.name = name
+        self.sent: list[OutgoingMessage] = []
+
+    async def start(self, cb) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+    async def send_message(self, msg: OutgoingMessage) -> None:
+        self.sent.append(msg)
+
+
+def _make_executor(
+    agent_result: str = "some result",
+    *,
+    channels: list | None = None,
+    router: SessionRouter | None = None,
+    sessions: list[tuple[str, str]] | None = None,
+    busy_sessions: set[tuple[str, str]] | None = None,
+) -> ProactiveExecutor:
+    """Build a ProactiveExecutor with mock agent and optional test sessions."""
+    mock_agent = MagicMock()
+    mock_agent.run = AsyncMock(return_value=agent_result)
+    factory = lambda: mock_agent  # noqa: E731
+
+    if channels is None:
+        channels = [FakeChannel("test")]
+
+    if router is None:
+        router = SessionRouter(agent_factory=factory)
+        # Pre-populate sessions if requested
+        if sessions:
+            for ch, cid in sessions:
+                key = router._session_key(ch, cid)
+                router._sessions[key] = MagicMock()
+                router._locks[key] = asyncio.Lock()
+                router._last_active[key] = 0.0
+
+    if busy_sessions:
+        orig_busy = router.is_session_busy
+
+        def _busy(ch, cid):
+            if (ch, cid) in busy_sessions:
+                return True
+            return orig_busy(ch, cid)
+
+        router.is_session_busy = _busy  # type: ignore[assignment]
+
+    return ProactiveExecutor(factory, channels, router)
+
+
+# ---------------------------------------------------------------------------
+# is_active_hours
+# ---------------------------------------------------------------------------
+
+
+class TestIsActiveHours:
+    def test_within_window(self):
+        dt = datetime(2025, 6, 15, 10, 0)
+        assert is_active_hours(dt, start=8, end=22) is True
+
+    def test_outside_window(self):
+        dt = datetime(2025, 6, 15, 23, 0)
+        assert is_active_hours(dt, start=8, end=22) is False
+
+    def test_boundary_start(self):
+        dt = datetime(2025, 6, 15, 8, 0)
+        assert is_active_hours(dt, start=8, end=22) is True
+
+    def test_boundary_end_excluded(self):
+        dt = datetime(2025, 6, 15, 22, 0)
+        assert is_active_hours(dt, start=8, end=22) is False
+
+    def test_wrap_midnight_inside(self):
+        dt = datetime(2025, 6, 15, 23, 0)
+        assert is_active_hours(dt, start=22, end=6) is True
+
+    def test_wrap_midnight_outside(self):
+        dt = datetime(2025, 6, 15, 10, 0)
+        assert is_active_hours(dt, start=22, end=6) is False
+
+
+# ---------------------------------------------------------------------------
+# load_heartbeat
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHeartbeat:
+    def test_creates_default_file(self, tmp_path, monkeypatch):
+        hb_file = tmp_path / "heartbeat.md"
+        monkeypatch.setattr("bot.proactive._HEARTBEAT_FILE", str(hb_file))
+        monkeypatch.setattr("bot.proactive._BOT_DIR", str(tmp_path))
+        content = load_heartbeat()
+        assert hb_file.exists()
+        assert "Heartbeat Checklist" in content
+
+    def test_reads_existing_file(self, tmp_path, monkeypatch):
+        hb_file = tmp_path / "heartbeat.md"
+        hb_file.write_text("- Check servers")
+        monkeypatch.setattr("bot.proactive._HEARTBEAT_FILE", str(hb_file))
+        content = load_heartbeat()
+        assert content == "- Check servers"
+
+
+# ---------------------------------------------------------------------------
+# ProactiveExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveExecutor:
+    async def test_run_isolated_returns_agent_result(self):
+        executor = _make_executor("hello world")
+        result = await executor.run_isolated("test prompt")
+        assert result == "hello world"
+
+    async def test_run_isolated_timeout(self):
+        """Agent exceeding timeout returns a timeout message."""
+        mock_agent = MagicMock()
+
+        async def slow_run(prompt):
+            await asyncio.sleep(10)
+            return "late"
+
+        mock_agent.run = slow_run
+        executor = ProactiveExecutor(lambda: mock_agent, [], SessionRouter(lambda: MagicMock()))
+
+        with patch("bot.proactive._ISOLATED_TIMEOUT", 0.1):
+            result = await executor.run_isolated("test")
+        assert "timed out" in result
+
+    async def test_broadcast_sends_to_active_sessions(self):
+        ch = FakeChannel("test")
+        executor = _make_executor(channels=[ch], sessions=[("test", "c1"), ("test", "c2")])
+        count = await executor.broadcast("hello")
+        assert count == 2
+        assert len(ch.sent) == 2
+        assert ch.sent[0].text == "hello"
+
+    async def test_broadcast_skips_busy_sessions(self):
+        ch = FakeChannel("test")
+        executor = _make_executor(
+            channels=[ch],
+            sessions=[("test", "c1"), ("test", "c2")],
+            busy_sessions={("test", "c1")},
+        )
+        count = await executor.broadcast("hello")
+        assert count == 1
+        assert ch.sent[0].conversation_id == "c2"
+
+    async def test_broadcast_no_sessions(self):
+        executor = _make_executor()
+        count = await executor.broadcast("hello")
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# HeartbeatRunner
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatRunner:
+    async def test_heartbeat_ok_silently_dropped(self):
+        executor = _make_executor("HEARTBEAT_OK")
+        executor.broadcast = AsyncMock(return_value=0)
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await runner._tick()
+
+        executor.broadcast.assert_not_awaited()
+
+    async def test_heartbeat_broadcasts_non_ok(self):
+        executor = _make_executor("Server disk is 95% full")
+        executor.broadcast = AsyncMock(return_value=2)
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await runner._tick()
+
+        executor.broadcast.assert_awaited_once()
+        call_text = executor.broadcast.call_args[0][0]
+        assert "[Heartbeat]" in call_text
+        assert "disk" in call_text
+
+    async def test_heartbeat_skips_outside_active_hours(self):
+        executor = _make_executor("should not run")
+        executor.run_isolated = AsyncMock()
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=False):
+            await runner._tick()
+
+        executor.run_isolated.assert_not_awaited()
+
+    async def test_heartbeat_skips_all_busy(self):
+        ch = FakeChannel("test")
+        executor = _make_executor(
+            channels=[ch],
+            sessions=[("test", "c1")],
+            busy_sessions={("test", "c1")},
+        )
+        executor.run_isolated = AsyncMock()
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await runner._tick()
+
+        executor.run_isolated.assert_not_awaited()
+
+    async def test_heartbeat_exception_does_not_crash(self):
+        executor = _make_executor()
+        executor.run_isolated = AsyncMock(side_effect=RuntimeError("boom"))
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            # Should not raise
+            await runner._tick()
+
+    def test_disabled_when_interval_zero(self):
+        executor = _make_executor()
+        runner = HeartbeatRunner(executor, interval=0)
+        assert runner.enabled is False
+
+    def test_enabled_when_interval_positive(self):
+        executor = _make_executor()
+        runner = HeartbeatRunner(executor, interval=60)
+        assert runner.enabled is True
+
+    async def test_heartbeat_injects_checklist(self, tmp_path, monkeypatch):
+        hb_file = tmp_path / "heartbeat.md"
+        hb_file.write_text("- [ ] Check disk space")
+        monkeypatch.setattr("bot.proactive._HEARTBEAT_FILE", str(hb_file))
+
+        captured_prompt = None
+
+        async def capture_run(prompt):
+            nonlocal captured_prompt
+            captured_prompt = prompt
+            return "HEARTBEAT_OK"
+
+        executor = _make_executor()
+        executor.run_isolated = capture_run  # type: ignore[assignment]
+        runner = HeartbeatRunner(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await runner._tick()
+
+        assert captured_prompt is not None
+        assert "Check disk space" in captured_prompt
+
+
+# ---------------------------------------------------------------------------
+# CronScheduler
+# ---------------------------------------------------------------------------
+
+
+class TestCronScheduler:
+    @pytest.fixture(autouse=True)
+    def _isolate_cron_files(self, tmp_path, monkeypatch):
+        """Ensure each test uses an isolated cron jobs file."""
+        monkeypatch.setattr("bot.proactive._CRON_JOBS_FILE", str(tmp_path / "cron_jobs.json"))
+        monkeypatch.setattr("bot.proactive._BOT_DIR", str(tmp_path))
+
+    def test_add_job_every(self):
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        job = sched.add_job("300", "Say hello")
+        assert job.schedule_type == "every"
+        assert job.schedule_value == "300"
+        assert job.next_run_at is not None
+
+    def test_add_job_cron(self):
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        job = sched.add_job("0 9 * * *", "Morning report")
+        assert job.schedule_type == "cron"
+        assert job.schedule_value == "0 9 * * *"
+
+    def test_add_job_invalid_cron(self):
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        with pytest.raises((ValueError, KeyError)):
+            sched.add_job("bad cron expr", "test")
+
+    def test_remove_job(self):
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        job = sched.add_job("300", "test")
+        assert sched.remove_job(job.id) is True
+        assert len(sched.jobs) == 0
+
+    def test_remove_nonexistent_job(self):
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        assert sched.remove_job("nonexistent") is False
+
+    async def test_tick_executes_due_job(self):
+        executor = _make_executor("Job done")
+        executor.broadcast = AsyncMock(return_value=1)
+        sched = CronScheduler(executor)
+        job = sched.add_job("300", "Do stuff", name="test-job")
+
+        # Force the job to be due now
+        past = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+        job.next_run_at = past
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await sched._tick()
+
+        executor.broadcast.assert_awaited_once()
+        call_text = executor.broadcast.call_args[0][0]
+        assert "[Cron: test-job]" in call_text
+        # next_run_at should have been recomputed
+        assert job.next_run_at != past
+
+    async def test_tick_skips_outside_active_hours(self):
+        executor = _make_executor()
+        executor.run_isolated = AsyncMock()
+        sched = CronScheduler(executor)
+        job = sched.add_job("300", "test")
+        job.next_run_at = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+
+        with patch("bot.proactive.is_active_hours", return_value=False):
+            await sched._tick()
+
+        executor.run_isolated.assert_not_awaited()
+
+    async def test_tick_not_due_yet(self):
+        executor = _make_executor()
+        executor.run_isolated = AsyncMock()
+        sched = CronScheduler(executor)
+        sched.add_job("300", "test")
+        # next_run_at is already in the future from add_job
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            await sched._tick()
+
+        executor.run_isolated.assert_not_awaited()
+
+    def test_persistence_roundtrip(self, tmp_path):
+        jobs_file = tmp_path / "cron_jobs.json"
+        # Already patched by _isolate_cron_files, but the roundtrip test
+        # needs to know the exact file to verify on disk.
+
+        executor = _make_executor()
+        sched = CronScheduler(executor)
+        sched.add_job("600", "Persist me", name="persist-test")
+
+        assert jobs_file.exists()
+        data = json.loads(jobs_file.read_text())
+        assert len(data) == 1
+        assert data[0]["name"] == "persist-test"
+
+        # Reload
+        sched2 = CronScheduler(executor)
+        assert len(sched2.jobs) == 1
+        assert sched2.jobs[0].name == "persist-test"
+
+    async def test_job_failure_does_not_crash_loop(self):
+        executor = _make_executor()
+        executor.run_isolated = AsyncMock(side_effect=RuntimeError("LLM down"))
+        executor.broadcast = AsyncMock()
+        sched = CronScheduler(executor)
+        job = sched.add_job("300", "test")
+        job.next_run_at = datetime(2020, 1, 1, tzinfo=timezone.utc).isoformat()
+
+        with patch("bot.proactive.is_active_hours", return_value=True):
+            # Should not raise
+            await sched._tick()
+
+        # last_run_at should still be set
+        assert job.last_run_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Slash commands in BotServer
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveSlashCommands:
+    """Test /heartbeat and /cron commands via BotServer."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_cron_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("bot.proactive._CRON_JOBS_FILE", str(tmp_path / "cron_jobs.json"))
+        monkeypatch.setattr("bot.proactive._BOT_DIR", str(tmp_path))
+
+    @pytest.fixture
+    def setup(self):
+        from bot.server import BotServer
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value="ok")
+        router = SessionRouter(agent_factory=lambda: mock_agent)
+
+        ch = FakeChannel("test")
+        executor = _make_executor(channels=[ch], router=router)
+        hb = HeartbeatRunner(executor, interval=1800)
+        cron = CronScheduler(executor)
+
+        server = BotServer(
+            session_router=router,
+            channels=[ch],
+            heartbeat=hb,
+            cron_scheduler=cron,
+        )
+        return server, ch, cron
+
+    def _msg(self, text: str):
+        from bot.channel.base import IncomingMessage
+
+        return IncomingMessage(
+            channel="test",
+            conversation_id="c1",
+            user_id="u1",
+            text=text,
+            message_id="m1",
+        )
+
+    async def test_heartbeat_command(self, setup):
+        server, ch, _ = setup
+        await server._process_message(ch, self._msg("/heartbeat"))
+        assert len(ch.sent) == 1
+        assert "Heartbeat: enabled" in ch.sent[0].text
+        assert "1800s" in ch.sent[0].text
+
+    async def test_cron_list_empty(self, setup):
+        server, ch, _ = setup
+        await server._process_message(ch, self._msg("/cron list"))
+        assert "No cron jobs" in ch.sent[0].text
+
+    async def test_cron_add_and_list(self, setup):
+        server, ch, cron = setup
+        await server._process_message(ch, self._msg("/cron add 120 Say hello"))
+        assert "Added cron job" in ch.sent[0].text
+
+        ch.sent.clear()
+        await server._process_message(ch, self._msg("/cron list"))
+        assert "every=120" in ch.sent[0].text
+
+    async def test_cron_remove(self, setup):
+        server, ch, cron = setup
+        job = cron.add_job("300", "test")
+
+        await server._process_message(ch, self._msg(f"/cron remove {job.id}"))
+        assert "Removed" in ch.sent[0].text
+        assert len(cron.jobs) == 0
+
+    async def test_cron_remove_nonexistent(self, setup):
+        server, ch, _ = setup
+        await server._process_message(ch, self._msg("/cron remove fake123"))
+        assert "No cron job" in ch.sent[0].text
+
+    async def test_help_includes_proactive_commands(self, setup):
+        server, ch, _ = setup
+        await server._process_message(ch, self._msg("/help"))
+        text = ch.sent[0].text
+        assert "/heartbeat" in text
+        assert "/cron" in text


### PR DESCRIPTION
## Summary

Introduce **Heartbeat** and **Cron** proactive mechanisms so the bot can periodically self-check a user-editable checklist and execute scheduled tasks, broadcasting results to all active IM sessions. Inspired by OpenClaw's design — all proactive work runs in **isolated one-shot agent sessions** (no conversation history) to keep token costs low (~5-15k vs 170k+ per session).

## Scope

- **Goals**: Heartbeat loop, cron scheduler, isolated execution, full-session broadcast, slash commands (`/heartbeat`, `/cron`), active-hours gating, busy-session skipping
- **Non-goals**: `at` one-time tasks, per-channel targeting, webhook delivery, heartbeat model override, agent self-editing heartbeat.md, web UI

## Invariants (Must Not Regress)

- [x] Existing bot message processing unchanged (reactive path untouched)
- [x] Existing slash commands (`/new`, `/reset`, `/compact`, `/status`, `/help`) work as before
- [x] Session routing and cleanup unaffected
- [x] Channel start/stop lifecycle unchanged
- [x] No new dependencies (croniter already in project)

## Acceptance Criteria

- [x] Heartbeat runs at configurable interval, skips outside active hours
- [x] `HEARTBEAT_OK` responses silently dropped, actionable results broadcast
- [x] Cron jobs support cron expressions and "every N seconds" intervals
- [x] Cron jobs persist to `~/.ouro/bot/cron_jobs.json`
- [x] `/heartbeat` shows status; `/cron list|add|remove` manages jobs
- [x] Busy sessions skipped during broadcast
- [x] Execution timeout (120s) prevents runaway agents
- [x] Single failure doesn't crash the loop

## Test Plan

- [x] `./scripts/dev.sh test -q test/test_bot_proactive.py` — 37 tests
- [x] `./scripts/dev.sh test -q test/test_bot_server.py test/test_bot_session_router.py` — 32 tests (regression)
- [x] `./scripts/dev.sh check` — 482 passed, 0 failed

## Smoke Run (Real CLI)

Bot mode requires IM credentials; manual smoke test deferred to deployment. Unit tests cover all code paths including slash commands and broadcast logic.

## Adversarial Review

- **What could break?** Only additive changes to existing files; `BotServer.__init__` gains optional kwargs with `None` defaults, fully backward-compatible.
- **Worst-case I/O?** Isolated agent capped at 120s timeout. Cron jobs file is tiny JSON.
- **Secrets/logging?** No secrets logged. Heartbeat file content passed to agent prompt, not logged.
- **Async/blocking?** All new I/O is async. File reads in `load_heartbeat()` and `_load_jobs()` are small and infrequent.
- **Error messages?** Invalid cron expressions: `"Invalid schedule: <error>"`. Timeout: `"[Proactive task timed out]"`.

## Docs / Compatibility

- [x] No secrets committed
- [x] No generated artifacts

## File Changes

| File | Change |
|------|--------|
| `config.py` | +4 config options (heartbeat interval, active hours start/end/tz) |
| `bot/session_router.py` | +`iter_active_sessions()`, `is_session_busy()` |
| `bot/proactive.py` | **New** — ProactiveExecutor, HeartbeatRunner, CronScheduler |
| `bot/server.py` | Wire proactive components, `/heartbeat` + `/cron` commands |
| `test/test_bot_proactive.py` | **New** — 37 unit tests |