### PR TITLE
fix(bot): remove redundant default heartbeat checklist

### DIFF
--- a/bot/proactive.py
+++ b/bot/proactive.py
@@ -41,9 +41,7 @@ _DEFAULT_HEARTBEAT = """\
 # Heartbeat Checklist
 
 This file is read every heartbeat cycle. Edit it to define periodic checks.
-
-- [ ] Check if any pending tasks need follow-up
-- [ ] Review recent memory for unresolved items
+Use the manage_heartbeat tool to add or remove items.
 """
 
 _HEARTBEAT_PROMPT = """\


### PR DESCRIPTION
## Summary

Remove the two default heartbeat checklist items that were ineffective in an isolated session:
- "Check if any pending tasks need follow-up" — isolated session has no task context
- "Review recent memory for unresolved items" — LTM is already injected into the system prompt

Replace with an empty checklist and a hint to use `manage_heartbeat` tool.

## Scope

- Goals: clean default heartbeat template
- Non-goals: no behavior change for users who already customized their `heartbeat.md`

## Invariants (Must Not Regress)

- [x] Heartbeat scheduling/execution flow unchanged
- [x] Existing user-customized `heartbeat.md` files unaffected (default only written on first creation)
- [x] `manage_heartbeat` tool still works as before

## Acceptance Criteria

- [x] Default `heartbeat.md` has no checklist items
- [x] Default includes hint about `manage_heartbeat` tool

## Test Plan

- [x] `./scripts/dev.sh test -q` (no heartbeat tests reference the removed default items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)