### PR TITLE
fix(bot): skip heartbeat when checklist is empty + fix HEARTBEAT_OK detection

### DIFF
--- a/bot/proactive.py
+++ b/bot/proactive.py
@@ -79,6 +79,11 @@ def load_heartbeat() -> str:
         return ""
 
 
+def _has_checklist_items(text: str) -> bool:
+    """Return True if *text* contains at least one ``- [ ] …`` item."""
+    return any(line.strip().startswith("- [ ] ") for line in text.splitlines())
+
+
 def is_active_hours(
     now: datetime | None = None,
     *,
@@ -254,10 +259,15 @@ class HeartbeatScheduler:
 
             self._last_run = datetime.now(tz=timezone.utc)
             checklist = load_heartbeat()
+
+            if not _has_checklist_items(checklist):
+                logger.debug("Heartbeat skipped: checklist has no items")
+                return
+
             prompt = _HEARTBEAT_PROMPT.format(checklist=checklist)
             result = await self._executor.run_isolated(prompt)
 
-            if result.strip().startswith("HEARTBEAT_OK"):
+            if "HEARTBEAT_OK" in result:
                 logger.info("Heartbeat: OK (nothing to report)")
                 return
 

--- a/config.py
+++ b/config.py
@@ -131,7 +131,7 @@ class Config:
 
     # Proactive: Heartbeat & Active Hours
     BOT_HEARTBEAT_INTERVAL = int(
-        _cfg.get("BOT_HEARTBEAT_INTERVAL", "1800")
+        _cfg.get("BOT_HEARTBEAT_INTERVAL", "3600")
     )  # seconds; 0 = disabled
     BOT_ACTIVE_HOURS_START = int(_cfg.get("BOT_ACTIVE_HOURS_START", "8"))  # 24h format
     BOT_ACTIVE_HOURS_END = int(_cfg.get("BOT_ACTIVE_HOURS_END", "22"))  # 24h format

--- a/test/test_bot_proactive.py
+++ b/test/test_bot_proactive.py
@@ -14,6 +14,7 @@ from bot.proactive import (
     CronScheduler,
     HeartbeatScheduler,
     IsolatedAgentRunner,
+    _has_checklist_items,
     is_active_hours,
     load_heartbeat,
 )
@@ -116,6 +117,23 @@ class TestIsActiveHours:
 # ---------------------------------------------------------------------------
 
 
+class TestHasChecklistItems:
+    def test_empty_string(self):
+        assert _has_checklist_items("") is False
+
+    def test_default_template(self):
+        text = "# Heartbeat Checklist\n\nUse the manage_heartbeat tool.\n"
+        assert _has_checklist_items(text) is False
+
+    def test_with_items(self):
+        text = "# Heartbeat Checklist\n\n- [ ] Check disk space\n- [ ] Check logs\n"
+        assert _has_checklist_items(text) is True
+
+    def test_checked_items_not_counted(self):
+        text = "- [x] Already done\n"
+        assert _has_checklist_items(text) is False
+
+
 class TestLoadHeartbeat:
     def test_creates_default_file(self, tmp_path, monkeypatch):
         hb_file = tmp_path / "heartbeat.md"
@@ -195,9 +213,43 @@ class TestHeartbeatScheduler:
         executor.broadcast = AsyncMock(return_value=0)
         runner = HeartbeatScheduler(executor, interval=10)
 
+        with patch("bot.proactive.is_active_hours", return_value=True), patch(
+            "bot.proactive.load_heartbeat", return_value="- [ ] Check servers"
+        ):
+            await runner._tick()
+
+        executor.broadcast.assert_not_awaited()
+
+    async def test_heartbeat_ok_detected_with_surrounding_text(self):
+        """LLM may wrap HEARTBEAT_OK in extra text — must still be detected."""
+        executor = _make_executor(
+            "The heartbeat checklist is empty. Nothing needs attention.\n\nHEARTBEAT_OK"
+        )
+        executor.broadcast = AsyncMock(return_value=0)
+        runner = HeartbeatScheduler(executor, interval=10)
+
+        with patch("bot.proactive.is_active_hours", return_value=True), patch(
+            "bot.proactive.load_heartbeat", return_value="- [ ] Check servers"
+        ):
+            await runner._tick()
+
+        executor.broadcast.assert_not_awaited()
+
+    async def test_heartbeat_skips_empty_checklist(self, tmp_path, monkeypatch):
+        """No LLM call when the checklist has no items."""
+        hb_file = tmp_path / "heartbeat.md"
+        hb_file.write_text("# Heartbeat Checklist\n\nNo items here.\n")
+        monkeypatch.setattr("bot.proactive._HEARTBEAT_FILE", str(hb_file))
+
+        executor = _make_executor()
+        executor.run_isolated = AsyncMock()
+        executor.broadcast = AsyncMock()
+        runner = HeartbeatScheduler(executor, interval=10)
+
         with patch("bot.proactive.is_active_hours", return_value=True):
             await runner._tick()
 
+        executor.run_isolated.assert_not_awaited()
         executor.broadcast.assert_not_awaited()
 
     async def test_heartbeat_broadcasts_non_ok(self):
@@ -205,7 +257,9 @@ class TestHeartbeatScheduler:
         executor.broadcast = AsyncMock(return_value=2)
         runner = HeartbeatScheduler(executor, interval=10)
 
-        with patch("bot.proactive.is_active_hours", return_value=True):
+        with patch("bot.proactive.is_active_hours", return_value=True), patch(
+            "bot.proactive.load_heartbeat", return_value="- [ ] Check disk space"
+        ):
             await runner._tick()
 
         executor.broadcast.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fix heartbeat broadcasting "nothing to do" messages when the checklist is empty. Also change default interval from 30min to 1h.

## Scope

- Goals: eliminate wasted LLM calls on empty checklists; fix HEARTBEAT_OK detection when LLM wraps it in extra text; default interval → 1h
- Non-goals: no changes to cron, heartbeat tool, or broadcast logic

## Invariants (Must Not Regress)

- [x] Heartbeat with actual checklist items still triggers LLM call and broadcasts results
- [x] HEARTBEAT_OK response still suppresses broadcast
- [x] Outside active hours still skips heartbeat
- [x] All-busy sessions still skips heartbeat
- [x] Heartbeat exceptions do not crash the loop

## Acceptance Criteria

- [x] Empty checklist → no LLM call, no broadcast
- [x] LLM response containing HEARTBEAT_OK anywhere (not just at start) → no broadcast
- [x] Default interval is 3600s (1 hour)

## Test Plan

- [x] `./scripts/dev.sh test -q test/test_bot_proactive.py` — 47 passed
- [x] `./scripts/dev.sh check` — 547 passed, 1 skipped

## Smoke Run (Real CLI)

Not applicable — heartbeat runs in bot mode on a timer; verified via unit tests.

## Adversarial Review

- What existing behavior could this break? None — only adds an early-return path and relaxes string matching
- Worst-case input/output size? Unchanged
- Any secrets/logging risks? No
- Any async/blocking I/O added on hot paths? No — the early return *removes* an async call
- What error message does the user see on failure? N/A — internal mechanism

## Docs / Compatibility

- [x] No secrets committed; no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)