### PR TITLE
fix(bot): skill installer writes to bot skills dir in bot mode

### DIFF
--- a/agent/skills/system/skill-installer/scripts/_common.py
+++ b/agent/skills/system/skill-installer/scripts/_common.py
@@ -15,6 +15,9 @@ def ouro_home() -> Path:
 
 def skills_dir() -> Path:
     """Get skills installation directory."""
+    override = os.environ.get("OURO_SKILLS_DIR")
+    if override:
+        return Path(override)
     return ouro_home() / "skills"
 
 

--- a/bot/server.py
+++ b/bot/server.py
@@ -618,6 +618,11 @@ async def run_bot(model_id: str | None = None) -> None:
     bot_memory_dir = get_bot_memory_dir()
     bot_skills_dir = Path(get_bot_skills_dir())
 
+    # Tell skill-installer scripts to write into the bot skills directory
+    import os
+
+    os.environ["OURO_SKILLS_DIR"] = str(bot_skills_dir)
+
     channels = _build_channels()
     if not channels:
         print(


### PR DESCRIPTION
## Summary

Bot mode skill installation wrote to `~/.ouro/skills/` instead of `~/.ouro/bot/skills/`, making newly installed skills invisible to the bot.

## Scope

- Goals: skill-installer scripts respect bot mode's skills directory
- Non-goals: no changes to CLI mode behavior

## Invariants (Must Not Regress)

- [ ] CLI mode still installs skills to `~/.ouro/skills/`
- [ ] Bot mode still loads skills from `~/.ouro/bot/skills/`
- [ ] `skills_dir()` returns a `Path` in all cases
- [ ] No env var leakage — `OURO_SKILLS_DIR` is only set inside `run_bot()`

## Acceptance Criteria

- [ ] In bot mode, skill-installer scripts write to `~/.ouro/bot/skills/`
- [ ] In CLI mode (no `OURO_SKILLS_DIR` set), default path `~/.ouro/skills` is used

## Test Plan

- [ ] `./scripts/dev.sh test -q` — 561 passed, 1 skipped
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — clean

## Smoke Run (Real CLI)

- Manual: bot mode install → skill lands in `~/.ouro/bot/skills/`
- Manual: CLI mode install → skill lands in `~/.ouro/skills/`

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?** Only if something relies on bot-mode skill installs going to `~/.ouro/skills/` (a bug, not a feature).
- **Worst-case input/output size?** N/A — single env var read.
- **Any secrets/logging risks?** No — the env var contains a filesystem path only.
- **Any async/blocking I/O added on hot paths?** No — `os.environ` access is synchronous and trivial.
- **What error message does the user see on failure?** No new error paths.

## Docs / Compatibility

- [x] No docs update needed (internal fix)
- [x] No secrets committed; no generated artifacts