### PR TITLE
fix(bot): enable file logging in bot mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,6 +243,9 @@ def main():
     # Bot mode: start webhook server (before login/logout/task checks)
     if args.bot:
         terminal_ui.console = Console(quiet=True)
+        # Bot is a long-running daemon — always enable file logging.
+        ensure_runtime_dirs(create_logs=True)
+        setup_logger()
 
         try:
             Config.validate()


### PR DESCRIPTION
## Summary

Bot mode is a long-running daemon but `setup_logger()` was only called when `--verbose` was passed, causing all log output to be silently discarded. This fix always initializes file logging for the bot code path.

## Scope

- Goals: Bot mode logs are always written to `~/.ouro/logs/`
- Non-goals: No changes to interactive mode logging behavior

## Invariants (Must Not Regress)

- [x] Interactive mode logging unchanged (still requires `--verbose`)
- [x] `setup_logger()` idempotent guard (`_logging_initialized`) prevents double init when `--bot --verbose`
- [x] Bot mode startup sequence unchanged (Console quiet, Config.validate, run_bot)

## Acceptance Criteria

- [x] `python main.py --bot` writes logs to `~/.ouro/logs/ouro_*.log`
- [x] `python main.py --bot --verbose` still works (no double init)

## Test Plan

- [x] `./scripts/dev.sh test -q` — 561 passed, 1 skipped
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues

## Adversarial Review

- **What existing behavior could this break?** None — bot mode previously had no file logging at all.
- **Worst-case input/output size?** Log files grow over time as expected for a daemon; no new truncation concerns.
- **Any secrets/logging risks?** No — uses existing `setup_logger()` which already excludes secrets.
- **Any async/blocking I/O added on hot paths?** No — `setup_logger()` runs once at startup before the event loop.
- **What error message does the user see on failure?** N/A — logging init is transparent.

## Docs / Compatibility

- [x] No secrets committed; no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)