### PR TITLE
feat(bot): add @mention filtering and image message support

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,7 +1,10 @@
 """Loop agent implementation."""
 
+from __future__ import annotations
+
+import base64
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from config import Config
 from llm import LLMMessage
@@ -11,6 +14,9 @@ from utils.tui.progress import AsyncSpinner
 from .base import BaseAgent
 from .context import format_context_prompt
 
+if TYPE_CHECKING:
+    from bot.channel.base import ImageData
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,10 +24,10 @@ class LoopAgent(BaseAgent):
     """Primary agent implementation — one unified loop for all tasks."""
 
     # Optional sections injected into system prompt (set by caller)
-    _skills_section: Optional[str] = None
-    _soul_section: Optional[str] = None
+    _skills_section: str | None = None
+    _soul_section: str | None = None
 
-    def set_skills_section(self, skills_section: Optional[str]) -> None:
+    def set_skills_section(self, skills_section: str | None) -> None:
         """Set the skills section to inject into system prompt.
 
         Args:
@@ -30,7 +36,7 @@ class LoopAgent(BaseAgent):
         """
         self._skills_section = skills_section
 
-    def set_soul_section(self, soul_section: Optional[str]) -> None:
+    def set_soul_section(self, soul_section: str | None) -> None:
         """Set the soul/personality section to prepend to the system prompt.
 
         Args:
@@ -75,13 +81,19 @@ AGENTS.md is optional. If not found, proceed normally.
 
 """
 
-    async def run(self, task: str, verify: bool = False) -> str:
+    async def run(
+        self,
+        task: str,
+        verify: bool = False,
+        images: list[ImageData] | None = None,
+    ) -> str:
         """Execute ReAct loop until task is complete.
 
         Args:
             task: The task to complete
             verify: If True, use ralph loop (outer verification). If False, use
                     plain react loop (suitable for interactive multi-turn sessions).
+            images: Optional list of image attachments to include with the task.
 
         Returns:
             Final answer as a string
@@ -129,8 +141,23 @@ AGENTS.md is optional. If not found, proceed normally.
             # Add system message only on first turn
             await self.memory.add_message(LLMMessage(role="system", content=system_content))
 
-        # Add user task/message
-        await self.memory.add_message(LLMMessage(role="user", content=task))
+        # Add user task/message (with optional images as multimodal content blocks)
+        if images:
+            content_blocks: list[dict] = []
+            if task:
+                content_blocks.append({"type": "text", "text": task})
+            for img in images:
+                b64 = base64.b64encode(img.data).decode()
+                content_blocks.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{img.mime_type};base64,{b64}"},
+                    }
+                )
+            user_msg = LLMMessage(role="user", content=content_blocks)
+        else:
+            user_msg = LLMMessage(role="user", content=task)
+        await self.memory.add_message(user_msg)
 
         tools = self.tool_executor.get_tool_schemas()
         self.memory.set_tool_schemas(tools)
@@ -154,6 +181,18 @@ AGENTS.md is optional. If not found, proceed normally.
                 save_to_memory=True,
                 task=task,
             )
+
+        # Replace image content blocks with text placeholders to prevent
+        # session/memory bloat (base64 images can be 1-10MB each).
+        if images and isinstance(user_msg.content, list):
+            user_msg.content = [
+                (
+                    block
+                    if block.get("type") != "image_url"
+                    else {"type": "text", "text": "[Image was provided and analyzed]"}
+                )
+                for block in user_msg.content
+            ]
 
         self._print_memory_stats()
 

--- a/bot/channel/base.py
+++ b/bot/channel/base.py
@@ -8,6 +8,14 @@ from typing import Protocol, runtime_checkable
 
 
 @dataclass
+class ImageData:
+    """An image attachment from an IM message."""
+
+    data: bytes  # Raw image bytes
+    mime_type: str  # e.g. "image/png", "image/jpeg"
+
+
+@dataclass
 class IncomingMessage:
     """A message received from an IM channel."""
 
@@ -17,6 +25,7 @@ class IncomingMessage:
     text: str
     message_id: str  # for deduplication
     raw: dict = field(default_factory=dict)
+    images: list[ImageData] = field(default_factory=list)
 
 
 @dataclass

--- a/bot/channel/lark.py
+++ b/bot/channel/lark.py
@@ -18,10 +18,11 @@ import lark_oapi as lark
 from lark_oapi.api.im.v1 import (
     CreateMessageRequest,
     CreateMessageRequestBody,
+    GetMessageResourceRequest,
     P2ImMessageReceiveV1,
 )
 
-from bot.channel.base import IncomingMessage, OutgoingMessage
+from bot.channel.base import ImageData, IncomingMessage, OutgoingMessage
 
 if TYPE_CHECKING:
     from bot.channel.base import MessageCallback
@@ -44,6 +45,7 @@ class LarkChannel:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._ws_client: lark.ws.Client | None = None
         self._thread: threading.Thread | None = None
+        self._bot_open_id: str = ""
 
         # Sync lark client for sending messages.
         self._api_client = (
@@ -58,6 +60,9 @@ class LarkChannel:
         """Open the WebSocket connection and begin dispatching messages."""
         self._callback = message_callback
         self._loop = asyncio.get_running_loop()
+
+        # Fetch bot's own open_id so we can filter group @mentions.
+        await asyncio.to_thread(self._fetch_bot_info)
 
         # Build the event handler for im.message.receive_v1
         event_handler = (
@@ -81,7 +86,7 @@ class LarkChannel:
             name="lark-ws",
         )
         self._thread.start()
-        logger.info("Lark WebSocket channel started")
+        logger.info("Lark WebSocket channel started (bot_open_id=%s)", self._bot_open_id)
 
     async def stop(self) -> None:
         """Shut down the WebSocket connection."""
@@ -99,6 +104,27 @@ class LarkChannel:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _fetch_bot_info(self) -> None:
+        """Fetch the bot's own open_id via the Lark bot info API."""
+        try:
+            from lark_oapi.api.bot.v3 import GetBotInfoRequest
+
+            request = GetBotInfoRequest.builder().build()
+            response = self._api_client.bot.v3.bot_info.get(request)
+            if response.success() and response.data and response.data.bot:
+                self._bot_open_id = response.data.bot.open_id or ""
+                logger.info("Fetched bot open_id: %s", self._bot_open_id)
+            else:
+                logger.warning(
+                    "Failed to fetch bot info: code=%s msg=%s",
+                    getattr(response, "code", "?"),
+                    getattr(response, "msg", "?"),
+                )
+        except Exception:
+            logger.warning(
+                "Could not fetch bot info — mention filtering may not work", exc_info=True
+            )
 
     def _run_ws(self) -> None:
         """Thread target: create a fresh event loop for the SDK.
@@ -135,19 +161,59 @@ class LarkChannel:
         if msg_obj is None or sender is None:
             return
 
-        # Only handle text messages for MVP.
-        if msg_obj.message_type != "text":
+        # --- @ mention filtering for group chats ---
+        chat_type = getattr(msg_obj, "chat_type", "p2p")
+        if chat_type == "group" and self._bot_open_id:
+            mentions = getattr(msg_obj, "mentions", None) or []
+            bot_mentioned = any(
+                getattr(m, "id", None) and getattr(m.id, "open_id", None) == self._bot_open_id
+                for m in mentions
+            )
+            if not bot_mentioned:
+                logger.debug("Ignoring group message without bot mention")
+                return
+
+        # --- Parse by message type ---
+        text = ""
+        images: list[ImageData] = []
+
+        if msg_obj.message_type == "text":
+            # Parse text content (Lark wraps it in JSON: {"text": "hello"}).
+            try:
+                content = json.loads(msg_obj.content or "{}")
+                text = content.get("text", "")
+            except json.JSONDecodeError:
+                text = msg_obj.content or ""
+        elif msg_obj.message_type == "image":
+            try:
+                content = json.loads(msg_obj.content or "{}")
+                image_key = content.get("image_key", "")
+            except json.JSONDecodeError:
+                image_key = ""
+            if image_key:
+                image_bytes = self._download_image(msg_obj.message_id or "", image_key)
+                if image_bytes:
+                    images.append(ImageData(data=image_bytes, mime_type="image/png"))
+                else:
+                    logger.warning("Failed to download image, dropping message")
+                    return
+            else:
+                return
+        else:
             logger.debug("Ignoring message type: %s", msg_obj.message_type)
             return
 
-        # Parse text content (Lark wraps it in JSON: {"text": "hello"}).
-        try:
-            content = json.loads(msg_obj.content or "{}")
-            text = content.get("text", "")
-        except json.JSONDecodeError:
-            text = msg_obj.content or ""
+        # Strip bot mention placeholder from text in group chats.
+        if chat_type == "group" and self._bot_open_id:
+            mentions = getattr(msg_obj, "mentions", None) or []
+            for m in mentions:
+                m_id = getattr(m, "id", None)
+                if m_id and getattr(m_id, "open_id", None) == self._bot_open_id:
+                    key = getattr(m, "key", None)
+                    if key:
+                        text = text.replace(key, "").strip()
 
-        if not text.strip():
+        if not text.strip() and not images:
             return
 
         incoming = IncomingMessage(
@@ -156,11 +222,33 @@ class LarkChannel:
             user_id=(sender.sender_id.open_id if sender.sender_id else "") or "",
             text=text.strip(),
             message_id=msg_obj.message_id or "",
+            images=images,
         )
 
         # Bridge into the asyncio event loop.
         coro = self._callback(incoming)
         asyncio.run_coroutine_threadsafe(coro, self._loop)  # type: ignore[arg-type]
+
+    def _download_image(self, message_id: str, file_key: str) -> bytes:
+        """Download image from Lark using message resource API."""
+        try:
+            request = (
+                GetMessageResourceRequest.builder()
+                .message_id(message_id)
+                .file_key(file_key)
+                .type("image")
+                .build()
+            )
+            response = self._api_client.im.v1.message_resource.get(request)
+            if not response.success():
+                logger.error(
+                    "Failed to download image: code=%s msg=%s", response.code, response.msg
+                )
+                return b""
+            return response.file.read()
+        except Exception:
+            logger.exception("Error downloading image from Lark")
+            return b""
 
     def _send_sync(self, message: OutgoingMessage) -> None:
         """Blocking send via the sync lark client."""

--- a/bot/channel/slack.py
+++ b/bot/channel/slack.py
@@ -15,7 +15,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
-from bot.channel.base import IncomingMessage, OutgoingMessage
+from bot.channel.base import ImageData, IncomingMessage, OutgoingMessage
 
 if TYPE_CHECKING:
     from bot.channel.base import MessageCallback
@@ -40,6 +40,7 @@ class SlackChannel:
         self._callback: MessageCallback | None = None
         self._web_client = AsyncWebClient(token=self._bot_token)
         self._socket_client: AsyncSocketModeClient | None = None
+        self._bot_user_id: str = ""
 
         # Bounded dedup set: OrderedDict used as an ordered set.
         self._seen: OrderedDict[str, None] = OrderedDict()
@@ -51,6 +52,16 @@ class SlackChannel:
     async def start(self, message_callback: MessageCallback) -> None:
         """Open the Socket Mode connection and begin dispatching messages."""
         self._callback = message_callback
+
+        # Fetch the bot's own user ID for mention filtering.
+        try:
+            auth_resp = await self._web_client.auth_test()
+            self._bot_user_id = auth_resp.get("user_id", "") or ""
+            logger.info("Fetched bot user_id: %s", self._bot_user_id)
+        except Exception:
+            logger.warning(
+                "Could not fetch bot user ID — mention filtering may not work", exc_info=True
+            )
 
         self._socket_client = AsyncSocketModeClient(
             app_token=self._app_token,
@@ -94,12 +105,34 @@ class SlackChannel:
         if event.get("type") != "message":
             return
 
-        # Skip bot messages, message edits/deletes, and subtypes.
-        if event.get("bot_id") or event.get("subtype"):
+        # Skip bot messages, message edits/deletes, and subtypes
+        # (but allow "file_share" subtype so image-only messages come through).
+        subtype = event.get("subtype")
+        if event.get("bot_id") or (subtype and subtype != "file_share"):
             return
 
         text = (event.get("text") or "").strip()
-        if not text:
+
+        # --- Download image attachments ---
+        images: list[ImageData] = []
+        for f in event.get("files", []):
+            mime = f.get("mimetype", "")
+            if mime.startswith("image/"):
+                url = f.get("url_private_download") or f.get("url_private", "")
+                if url:
+                    img_data = await self._download_file(url)
+                    if img_data:
+                        images.append(ImageData(data=img_data, mime_type=mime))
+
+        # --- @ mention filtering for group/channel messages ---
+        channel_type = event.get("channel_type", "")
+        if channel_type != "im" and self._bot_user_id:
+            mention_tag = f"<@{self._bot_user_id}>"
+            if mention_tag not in text:
+                return
+            text = text.replace(mention_tag, "").strip()
+
+        if not text and not images:
             return
 
         # Dedup by client_msg_id (set by Slack clients).
@@ -118,10 +151,28 @@ class SlackChannel:
             text=text,
             message_id=msg_id,
             raw=req.payload or {},
+            images=images,
         )
 
         if self._callback is not None:
             await self._callback(incoming)
+
+    async def _download_file(self, url: str) -> bytes | None:
+        """Download a file from Slack using bot token for auth."""
+        import aiohttp
+
+        headers = {"Authorization": f"Bearer {self._bot_token}"}
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=30)) as resp,
+            ):
+                if resp.status == 200:
+                    return await resp.read()
+                logger.error("Failed to download Slack file: status=%d", resp.status)
+        except Exception:
+            logger.exception("Error downloading Slack file")
+        return None
 
     def _is_duplicate(self, msg_id: str) -> bool:
         """Check and record a message ID for deduplication."""

--- a/bot/server.py
+++ b/bot/server.py
@@ -460,7 +460,7 @@ class BotServer:
                     msg.conversation_id,
                     msg.text[:80],
                 )
-                result = await agent.run(msg.text)
+                result = await agent.run(msg.text, images=msg.images if msg.images else None)
 
                 # Persist session mapping so conversation survives restarts
                 await self._router.update_session_mapping(msg.channel, msg.conversation_id)

--- a/llm/litellm_adapter.py
+++ b/llm/litellm_adapter.py
@@ -193,13 +193,12 @@ class LiteLLMAdapter:
 
             # Handle tool messages (new OpenAI format)
             elif msg.role == "tool":
-                litellm_messages.append(
-                    {
-                        "role": "tool",
-                        "content": msg.content or "",
-                        "tool_call_id": msg.tool_call_id or "",
-                    }
-                )
+                tool_msg: Dict[str, Any] = {
+                    "role": "tool",
+                    "content": msg.content or "",
+                    "tool_call_id": msg.tool_call_id or "",
+                }
+                litellm_messages.append(tool_msg)
 
             # Handle user messages
             elif msg.role == "user":
@@ -212,9 +211,13 @@ class LiteLLMAdapter:
                     if tool_messages:
                         litellm_messages.extend(tool_messages)
                     else:
-                        # Not tool results, extract text
-                        content = extract_text(msg.content)
-                        litellm_messages.append({"role": "user", "content": content})
+                        # Pass through as multimodal content blocks (text + image_url).
+                        # LiteLLM supports OpenAI vision format natively.
+                        multimodal_msg: Dict[str, Any] = {
+                            "role": "user",
+                            "content": msg.content,
+                        }
+                        litellm_messages.append(multimodal_msg)
                 else:
                     content = extract_text(msg.content)
                     litellm_messages.append({"role": "user", "content": content})

--- a/llm/message_types.py
+++ b/llm/message_types.py
@@ -5,7 +5,7 @@ All types follow the OpenAI/LiteLLM format for consistency and serialization.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from typing_extensions import TypedDict
 
@@ -72,7 +72,7 @@ class LLMMessage:
 
     Follows OpenAI/LiteLLM format:
     - role: "system", "user", "assistant", or "tool"
-    - content: Text content (str or None for assistant with tool_calls)
+    - content: Text content (str), multimodal content blocks (list), or None
     - tool_calls: For assistant role, list of tool calls
     - tool_call_id: For tool role, ID of the tool call this responds to
     - name: For tool role, name of the tool
@@ -81,7 +81,7 @@ class LLMMessage:
     """
 
     role: Literal["system", "user", "assistant", "tool"]
-    content: Optional[str] = None
+    content: Optional[Union[str, List[Dict[str, Any]]]] = None
     tool_calls: Optional[List[ToolCallBlock]] = None
     tool_call_id: Optional[str] = None  # For tool role
     name: Optional[str] = None  # Tool name (for tool role)

--- a/test/test_lark_channel.py
+++ b/test/test_lark_channel.py
@@ -15,12 +15,24 @@ from bot.channel.base import IncomingMessage, OutgoingMessage
 # ---------------------------------------------------------------------------
 
 
+def _make_mention(open_id: str, key: str = "@_user_1") -> MagicMock:
+    """Build a mock mention entry."""
+    m = MagicMock()
+    m.id = MagicMock()
+    m.id.open_id = open_id
+    m.key = key
+    return m
+
+
 def _make_sdk_event(
     text: str = "hello",
     chat_id: str = "oc_abc123",
     message_id: str = "msg_001",
     user_id: str = "ou_user1",
     message_type: str = "text",
+    chat_type: str = "p2p",
+    mentions: list | None = None,
+    content: str | None = None,
 ) -> MagicMock:
     """Build a mock P2ImMessageReceiveV1 object matching lark SDK structure."""
     sender_id = MagicMock()
@@ -33,7 +45,16 @@ def _make_sdk_event(
     msg.chat_id = chat_id
     msg.message_id = message_id
     msg.message_type = message_type
-    msg.content = json.dumps({"text": text})
+    msg.chat_type = chat_type
+    msg.mentions = mentions
+    if content is not None:
+        msg.content = content
+    elif message_type == "text":
+        msg.content = json.dumps({"text": text})
+    elif message_type == "image":
+        msg.content = json.dumps({"image_key": "img_key_123"})
+    else:
+        msg.content = "{}"
 
     event = MagicMock()
     event.message = msg
@@ -73,7 +94,14 @@ def _mock_lark():
     mock_lark.LogLevel.WARNING = 3
 
     with (
-        patch.dict("sys.modules", {"lark_oapi": mock_lark, "lark_oapi.api.im.v1": MagicMock()}),
+        patch.dict(
+            "sys.modules",
+            {
+                "lark_oapi": mock_lark,
+                "lark_oapi.api.im.v1": MagicMock(),
+                "lark_oapi.api.bot.v3": MagicMock(),
+            },
+        ),
         patch("config.Config") as mock_config,
     ):
         mock_config.LARK_APP_ID = "test_app_id"
@@ -92,7 +120,9 @@ def _mock_lark():
 @pytest.fixture
 def channel(_mock_lark):
     lark_mod, _ = _mock_lark
-    return lark_mod.LarkChannel()
+    ch = lark_mod.LarkChannel()
+    ch._bot_open_id = "bot_open_id_123"
+    return ch
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +154,8 @@ async def test_on_message_dispatches_text(channel):
     assert received[0].message_id == "m1"
 
 
-async def test_on_message_ignores_non_text(channel):
+async def test_on_message_ignores_unsupported_type(channel):
+    """Non-text, non-image message types should be ignored."""
     received: list[IncomingMessage] = []
 
     async def cb(msg: IncomingMessage) -> None:
@@ -133,7 +164,7 @@ async def test_on_message_ignores_non_text(channel):
     channel._callback = cb
     channel._loop = asyncio.get_running_loop()
 
-    data = _make_sdk_event(message_type="image")
+    data = _make_sdk_event(message_type="audio")
     channel._on_message(data)
     await asyncio.sleep(0.05)
 
@@ -174,6 +205,156 @@ async def test_on_message_none_event(channel):
 
 
 # ---------------------------------------------------------------------------
+# @ Mention filtering tests
+# ---------------------------------------------------------------------------
+
+
+async def test_on_message_group_mention_dispatches(channel):
+    """Group chat with bot mention should dispatch."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    mention = _make_mention(open_id="bot_open_id_123", key="@_user_1")
+    data = _make_sdk_event(
+        text="@_user_1 what is this?",
+        chat_type="group",
+        mentions=[mention],
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+
+
+async def test_on_message_group_no_mention_ignored(channel):
+    """Group chat without bot mention should be ignored."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    data = _make_sdk_event(
+        text="hey everyone",
+        chat_type="group",
+        mentions=[],
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 0
+
+
+async def test_on_message_dm_always_dispatches(channel):
+    """DM (p2p) messages should always dispatch, even without mention."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    data = _make_sdk_event(
+        text="hello",
+        chat_type="p2p",
+        mentions=[],
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+
+
+async def test_on_message_mention_stripped_from_text(channel):
+    """Bot's mention tag should be stripped from the text."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    mention = _make_mention(open_id="bot_open_id_123", key="@_user_1")
+    data = _make_sdk_event(
+        text="@_user_1 summarize this",
+        chat_type="group",
+        mentions=[mention],
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+    assert received[0].text == "summarize this"
+
+
+# ---------------------------------------------------------------------------
+# Image message tests
+# ---------------------------------------------------------------------------
+
+
+async def test_on_message_image_dispatches(channel):
+    """Image message should dispatch with images populated."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    # Mock image download
+    mock_file = MagicMock()
+    mock_file.read.return_value = b"\x89PNG\r\n\x1a\nfakeimage"
+    mock_response = MagicMock()
+    mock_response.success.return_value = True
+    mock_response.file = mock_file
+    channel._api_client.im.v1.message_resource.get.return_value = mock_response
+
+    data = _make_sdk_event(message_type="image")
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+    assert len(received[0].images) == 1
+    assert received[0].images[0].mime_type == "image/png"
+    assert received[0].images[0].data == b"\x89PNG\r\n\x1a\nfakeimage"
+    assert received[0].text == ""
+
+
+async def test_on_message_image_download_failure(channel):
+    """Image download failure should drop the message."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    # Mock failed download
+    mock_response = MagicMock()
+    mock_response.success.return_value = False
+    mock_response.code = 99999
+    mock_response.msg = "not found"
+    channel._api_client.im.v1.message_resource.get.return_value = mock_response
+
+    data = _make_sdk_event(message_type="image")
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 0
+
+
+# ---------------------------------------------------------------------------
 # send_message tests
 # ---------------------------------------------------------------------------
 
@@ -198,7 +379,10 @@ async def test_start_spawns_thread(channel, _mock_lark):
     _, mock_lark = _mock_lark
 
     cb = AsyncMock()
-    with patch("bot.channel.lark.threading.Thread") as MockThread:
+    with (
+        patch("bot.channel.lark.threading.Thread") as MockThread,
+        patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock),
+    ):
         mock_thread_instance = MagicMock()
         MockThread.return_value = mock_thread_instance
 

--- a/test/test_slack_channel.py
+++ b/test/test_slack_channel.py
@@ -23,6 +23,8 @@ def _make_socket_request(
     req_type: str = "events_api",
     bot_id: str | None = None,
     subtype: str | None = None,
+    channel_type: str = "im",
+    files: list | None = None,
 ) -> MagicMock:
     """Build a mock SocketModeRequest."""
     event: dict = {
@@ -31,6 +33,7 @@ def _make_socket_request(
         "channel": channel_id,
         "user": user_id,
         "ts": ts,
+        "channel_type": channel_type,
     }
     if client_msg_id:
         event["client_msg_id"] = client_msg_id
@@ -38,6 +41,8 @@ def _make_socket_request(
         event["bot_id"] = bot_id
     if subtype:
         event["subtype"] = subtype
+    if files:
+        event["files"] = files
 
     req = MagicMock()
     req.type = req_type
@@ -99,7 +104,9 @@ def _mock_slack():
 @pytest.fixture
 def channel(_mock_slack):
     slack_mod, _, _, _ = _mock_slack
-    return slack_mod.SlackChannel()
+    ch = slack_mod.SlackChannel()
+    ch._bot_user_id = "UBOTID"
+    return ch
 
 
 @pytest.fixture
@@ -241,6 +248,151 @@ async def test_on_request_always_acks(channel):
     await channel._on_request(client, req)
 
     client.send_socket_mode_response.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# @ Mention filtering tests
+# ---------------------------------------------------------------------------
+
+
+async def test_on_request_channel_mention_dispatches(channel):
+    """Channel message with @bot mention should dispatch."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    req = _make_socket_request(
+        text="<@UBOTID> what is this?",
+        channel_type="channel",
+    )
+    await channel._on_request(client, req)
+
+    assert len(received) == 1
+
+
+async def test_on_request_channel_no_mention_ignored(channel):
+    """Channel message without @bot mention should be ignored."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    req = _make_socket_request(
+        text="hey everyone",
+        channel_type="channel",
+    )
+    await channel._on_request(client, req)
+
+    assert len(received) == 0
+
+
+async def test_on_request_dm_always_dispatches(channel):
+    """DM messages should always dispatch, even without mention."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    req = _make_socket_request(
+        text="hello",
+        channel_type="im",
+    )
+    await channel._on_request(client, req)
+
+    assert len(received) == 1
+
+
+async def test_on_request_mention_stripped(channel):
+    """Bot's mention tag should be stripped from the text."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    req = _make_socket_request(
+        text="<@UBOTID> summarize this",
+        channel_type="channel",
+    )
+    await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert received[0].text == "summarize this"
+
+
+async def test_on_request_image_attachment(channel):
+    """Message with image file attachment should populate images."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    files = [
+        {
+            "mimetype": "image/png",
+            "url_private_download": "https://files.slack.com/img.png",
+        }
+    ]
+    req = _make_socket_request(
+        text="look at this image",
+        files=files,
+    )
+
+    with patch.object(channel, "_download_file", new_callable=AsyncMock) as mock_dl:
+        mock_dl.return_value = b"\x89PNGfakedata"
+        await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert len(received[0].images) == 1
+    assert received[0].images[0].mime_type == "image/png"
+    assert received[0].images[0].data == b"\x89PNGfakedata"
+
+
+async def test_on_request_image_only_no_text(channel):
+    """Image-only message (no text) should still dispatch."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    files = [
+        {
+            "mimetype": "image/jpeg",
+            "url_private_download": "https://files.slack.com/photo.jpg",
+        }
+    ]
+    req = _make_socket_request(
+        text="",
+        files=files,
+        subtype="file_share",
+    )
+
+    with patch.object(channel, "_download_file", new_callable=AsyncMock) as mock_dl:
+        mock_dl.return_value = b"\xff\xd8\xff\xe0fakejpeg"
+        await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert received[0].text == ""
+    assert len(received[0].images) == 1
+    assert received[0].images[0].mime_type == "image/jpeg"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In group chats, the bot now only responds when @mentioned (DMs always respond). Image messages from Lark and Slack are downloaded and passed to the LLM as multimodal content blocks (OpenAI vision format).

## Scope

- Goals: @mention filtering for group chats, image message support for Lark and Slack
- Non-goals: Voice/audio message support (deferred), video support

## Invariants (Must Not Regress)

- [x] DM messages continue to work without @mention
- [x] Text-only messages in all chat types work as before
- [x] Bot slash commands (/new, /help, etc.) still function
- [x] Session persistence and memory compression unaffected
- [x] Existing Lark and Slack channel lifecycle (start/stop/send) unchanged

## Acceptance Criteria

- [x] Group messages without bot @mention are silently ignored
- [x] Group messages with bot @mention are processed, mention tag stripped
- [x] DM messages always processed regardless of mention
- [x] Image messages from Lark (message_type=image) are downloaded and sent to LLM
- [x] Image files from Slack (files with image/* mimetype) are downloaded and sent to LLM
- [x] Image data replaced with placeholder after LLM turn to prevent memory bloat
- [x] LLMMessage.content supports multimodal content blocks (list[dict])

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_lark_channel.py test/test_slack_channel.py` (32 passed)
- [x] `./scripts/dev.sh test -q` (573 passed)
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` (0 errors)
- [x] `./scripts/dev.sh check` (all green)

### New tests (12 total)

**Lark (6):** group mention dispatch, group no mention ignored, DM always dispatches, mention stripped, image dispatches, image download failure  
**Slack (6):** channel mention dispatch, channel no mention ignored, DM always dispatches, mention stripped, image attachment, image-only no text

## Smoke Run (Real CLI)

Bot mode requires live IM credentials — tested via unit tests only.

## Adversarial Review

- **What existing behavior could this break?** Mention filtering could miss messages if bot info API fails (graceful fallback: logs warning, no filtering applied). Slack `file_share` subtype is now allowed through.
- **Worst-case input/output size?** Image downloads capped at 30s timeout. Base64 images cleaned from memory after LLM turn.
- **Any secrets/logging risks?** Slack bot token used in Authorization header for file download — not logged. Lark API client uses existing credential pattern.
- **Any async/blocking I/O added on hot paths?** Lark image download is sync (runs in SDK thread, not event loop). Slack file download is async with 30s timeout. Bot info fetch runs once at startup.
- **What error message does the user see on failure?** Image download failure → message silently dropped (logged as warning). Bot info fetch failure → logged warning, mention filtering disabled.

## Docs / Compatibility

- [x] No secrets committed; no generated artifacts
- [ ] Docs update deferred — bot guide update in follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)