### PR TITLE
feat(bot): add file sending/receiving support

### DIFF
--- a/bot/channel/__init__.py
+++ b/bot/channel/__init__.py
@@ -1,5 +1,11 @@
 """IM channel implementations for bot mode."""
 
-from bot.channel.base import Channel, IncomingMessage, MessageCallback, OutgoingMessage
+from bot.channel.base import (
+    Channel,
+    FileAttachment,
+    IncomingMessage,
+    MessageCallback,
+    OutgoingMessage,
+)
 
-__all__ = ["Channel", "IncomingMessage", "MessageCallback", "OutgoingMessage"]
+__all__ = ["Channel", "FileAttachment", "IncomingMessage", "MessageCallback", "OutgoingMessage"]

--- a/bot/channel/base.py
+++ b/bot/channel/base.py
@@ -16,6 +16,15 @@ class ImageData:
 
 
 @dataclass
+class FileAttachment:
+    """A non-image file attachment from an IM message."""
+
+    data: bytes
+    filename: str  # e.g. "report.pdf"
+    mime_type: str  # e.g. "application/pdf"
+
+
+@dataclass
 class IncomingMessage:
     """A message received from an IM channel."""
 
@@ -26,6 +35,7 @@ class IncomingMessage:
     message_id: str  # for deduplication
     raw: dict = field(default_factory=dict)
     images: list[ImageData] = field(default_factory=list)
+    files: list[FileAttachment] = field(default_factory=list)
 
 
 @dataclass
@@ -69,4 +79,15 @@ class Channel(Protocol):
         Args:
             message: The outgoing message to send.
         """
+        ...
+
+    async def send_file(
+        self,
+        conversation_id: str,
+        file_path: str | None = None,
+        file_bytes: bytes | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> bool:
+        """Upload and send a file to the IM channel. Returns True on success."""
         ...

--- a/bot/channel/lark.py
+++ b/bot/channel/lark.py
@@ -22,7 +22,7 @@ from lark_oapi.api.im.v1 import (
     P2ImMessageReceiveV1,
 )
 
-from bot.channel.base import ImageData, IncomingMessage, OutgoingMessage
+from bot.channel.base import FileAttachment, ImageData, IncomingMessage, OutgoingMessage
 
 if TYPE_CHECKING:
     from bot.channel.base import MessageCallback
@@ -176,6 +176,7 @@ class LarkChannel:
         # --- Parse by message type ---
         text = ""
         images: list[ImageData] = []
+        files: list[FileAttachment] = []
 
         if msg_obj.message_type == "text":
             # Parse text content (Lark wraps it in JSON: {"text": "hello"}).
@@ -199,6 +200,28 @@ class LarkChannel:
                     return
             else:
                 return
+        elif msg_obj.message_type == "file":
+            try:
+                content = json.loads(msg_obj.content or "{}")
+                file_key = content.get("file_key", "")
+                file_name = content.get("file_name", "attachment")
+            except json.JSONDecodeError:
+                file_key = ""
+                file_name = "attachment"
+            if file_key:
+                file_bytes = self._download_file_resource(msg_obj.message_id or "", file_key)
+                if file_bytes:
+                    import mimetypes
+
+                    mime = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
+                    files.append(
+                        FileAttachment(data=file_bytes, filename=file_name, mime_type=mime)
+                    )
+                else:
+                    logger.warning("Failed to download file, dropping message")
+                    return
+            else:
+                return
         else:
             logger.debug("Ignoring message type: %s", msg_obj.message_type)
             return
@@ -213,7 +236,7 @@ class LarkChannel:
                     if key:
                         text = text.replace(key, "").strip()
 
-        if not text.strip() and not images:
+        if not text.strip() and not images and not files:
             return
 
         incoming = IncomingMessage(
@@ -223,6 +246,7 @@ class LarkChannel:
             text=text.strip(),
             message_id=msg_obj.message_id or "",
             images=images,
+            files=files,
         )
 
         # Bridge into the asyncio event loop.
@@ -250,6 +274,25 @@ class LarkChannel:
             logger.exception("Error downloading image from Lark")
             return b""
 
+    def _download_file_resource(self, message_id: str, file_key: str) -> bytes:
+        """Download a non-image file from Lark using message resource API."""
+        try:
+            request = (
+                GetMessageResourceRequest.builder()
+                .message_id(message_id)
+                .file_key(file_key)
+                .type("file")
+                .build()
+            )
+            response = self._api_client.im.v1.message_resource.get(request)
+            if not response.success():
+                logger.error("Failed to download file: code=%s msg=%s", response.code, response.msg)
+                return b""
+            return response.file.read()
+        except Exception:
+            logger.exception("Error downloading file from Lark")
+            return b""
+
     def _send_sync(self, message: OutgoingMessage) -> None:
         """Blocking send via the sync lark client."""
         body = (
@@ -269,3 +312,166 @@ class LarkChannel:
                 response.code,
                 response.msg,
             )
+
+    # ------------------------------------------------------------------
+    # File sending
+    # ------------------------------------------------------------------
+
+    async def send_file(
+        self,
+        conversation_id: str,
+        file_path: str | None = None,
+        file_bytes: bytes | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> bool:
+        """Upload and send a file to Lark (async-safe)."""
+        return await asyncio.to_thread(
+            self._send_file_sync, conversation_id, file_path, file_bytes, filename, mime_type
+        )
+
+    def _send_file_sync(
+        self,
+        conversation_id: str,
+        file_path: str | None,
+        file_bytes: bytes | None,
+        filename: str | None,
+        mime_type: str | None,
+    ) -> bool:
+        """Blocking file send — reads bytes, dispatches to image or file upload."""
+
+        if file_path is not None:
+            from pathlib import Path
+
+            p = Path(file_path)
+            data = p.read_bytes()
+            filename = filename or p.name
+        elif file_bytes is not None:
+            data = file_bytes
+            filename = filename or "file"
+        else:
+            logger.error("send_file called with neither file_path nor file_bytes")
+            return False
+
+        if mime_type and mime_type.startswith("image/"):
+            return self._upload_and_send_image(conversation_id, data, filename)
+        return self._upload_and_send_file(conversation_id, data, filename)
+
+    def _upload_and_send_image(self, conversation_id: str, data: bytes, filename: str) -> bool:
+        """Upload image via im.v1.image.create, then send as image message."""
+        import io
+
+        from lark_oapi.api.im.v1 import CreateImageRequest, CreateImageRequestBody
+
+        try:
+            body = (
+                CreateImageRequestBody.builder()
+                .image_type("message")
+                .image(io.BytesIO(data))
+                .build()
+            )
+            req = CreateImageRequest.builder().request_body(body).build()
+            resp = self._api_client.im.v1.image.create(req)
+            if not resp.success() or not resp.data:
+                logger.error(
+                    "Failed to upload image to Lark: code=%s msg=%s",
+                    getattr(resp, "code", "?"),
+                    getattr(resp, "msg", "?"),
+                )
+                return False
+            image_key = resp.data.image_key
+
+            msg_body = (
+                CreateMessageRequestBody.builder()
+                .receive_id(conversation_id)
+                .msg_type("image")
+                .content(json.dumps({"image_key": image_key}))
+                .build()
+            )
+            msg_req = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(msg_body)
+                .build()
+            )
+            msg_resp = self._api_client.im.v1.message.create(msg_req)
+            if not msg_resp.success():
+                logger.error(
+                    "Failed to send Lark image message: code=%s msg=%s",
+                    msg_resp.code,
+                    msg_resp.msg,
+                )
+                return False
+            return True
+        except Exception:
+            logger.exception("Error uploading/sending image to Lark")
+            return False
+
+    def _upload_and_send_file(self, conversation_id: str, data: bytes, filename: str) -> bool:
+        """Upload file via im.v1.file.create, then send as file message."""
+        import io
+
+        from lark_oapi.api.im.v1 import CreateFileRequest, CreateFileRequestBody
+
+        try:
+            file_type = self._lark_file_type(filename)
+            body = (
+                CreateFileRequestBody.builder()
+                .file_type(file_type)
+                .file_name(filename)
+                .file(io.BytesIO(data))
+                .build()
+            )
+            req = CreateFileRequest.builder().request_body(body).build()
+            resp = self._api_client.im.v1.file.create(req)
+            if not resp.success() or not resp.data:
+                logger.error(
+                    "Failed to upload file to Lark: code=%s msg=%s",
+                    getattr(resp, "code", "?"),
+                    getattr(resp, "msg", "?"),
+                )
+                return False
+            file_key = resp.data.file_key
+
+            msg_body = (
+                CreateMessageRequestBody.builder()
+                .receive_id(conversation_id)
+                .msg_type("file")
+                .content(json.dumps({"file_key": file_key}))
+                .build()
+            )
+            msg_req = (
+                CreateMessageRequest.builder()
+                .receive_id_type("chat_id")
+                .request_body(msg_body)
+                .build()
+            )
+            msg_resp = self._api_client.im.v1.message.create(msg_req)
+            if not msg_resp.success():
+                logger.error(
+                    "Failed to send Lark file message: code=%s msg=%s",
+                    msg_resp.code,
+                    msg_resp.msg,
+                )
+                return False
+            return True
+        except Exception:
+            logger.exception("Error uploading/sending file to Lark")
+            return False
+
+    @staticmethod
+    def _lark_file_type(filename: str) -> str:
+        """Map file extension to Lark's file_type enum value."""
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        mapping = {
+            "opus": "opus",
+            "mp4": "mp4",
+            "pdf": "pdf",
+            "doc": "doc",
+            "docx": "doc",
+            "xls": "xls",
+            "xlsx": "xls",
+            "ppt": "ppt",
+            "pptx": "ppt",
+        }
+        return mapping.get(ext, "stream")

--- a/bot/channel/slack.py
+++ b/bot/channel/slack.py
@@ -15,7 +15,7 @@ from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
 from slack_sdk.web.async_client import AsyncWebClient
 
-from bot.channel.base import ImageData, IncomingMessage, OutgoingMessage
+from bot.channel.base import FileAttachment, ImageData, IncomingMessage, OutgoingMessage
 
 if TYPE_CHECKING:
     from bot.channel.base import MessageCallback
@@ -113,16 +113,23 @@ class SlackChannel:
 
         text = (event.get("text") or "").strip()
 
-        # --- Download image attachments ---
+        # --- Download file attachments (images + other files) ---
         images: list[ImageData] = []
+        files: list[FileAttachment] = []
         for f in event.get("files", []):
             mime = f.get("mimetype", "")
+            url = f.get("url_private_download") or f.get("url_private", "")
+            if not url:
+                continue
             if mime.startswith("image/"):
-                url = f.get("url_private_download") or f.get("url_private", "")
-                if url:
-                    img_data = await self._download_file(url)
-                    if img_data:
-                        images.append(ImageData(data=img_data, mime_type=mime))
+                img_data = await self._download_file(url)
+                if img_data:
+                    images.append(ImageData(data=img_data, mime_type=mime))
+            else:
+                file_data = await self._download_file(url)
+                if file_data:
+                    fname = f.get("name", "attachment")
+                    files.append(FileAttachment(data=file_data, filename=fname, mime_type=mime))
 
         # --- @ mention filtering for group/channel messages ---
         channel_type = event.get("channel_type", "")
@@ -132,7 +139,7 @@ class SlackChannel:
                 return
             text = text.replace(mention_tag, "").strip()
 
-        if not text and not images:
+        if not text and not images and not files:
             return
 
         # Dedup by client_msg_id (set by Slack clients).
@@ -152,10 +159,40 @@ class SlackChannel:
             message_id=msg_id,
             raw=req.payload or {},
             images=images,
+            files=files,
         )
 
         if self._callback is not None:
             await self._callback(incoming)
+
+    async def send_file(
+        self,
+        conversation_id: str,
+        file_path: str | None = None,
+        file_bytes: bytes | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> bool:
+        """Upload and send a file to a Slack channel/DM."""
+        try:
+            kwargs: dict[str, object] = {"channel": conversation_id}
+            if file_path is not None:
+                kwargs["file"] = file_path
+                kwargs["filename"] = filename or file_path.rsplit("/", 1)[-1]
+            elif file_bytes is not None:
+                kwargs["content"] = file_bytes
+                kwargs["filename"] = filename or "file"
+            else:
+                logger.error("send_file called with neither file_path nor file_bytes")
+                return False
+            resp = await self._web_client.files_upload_v2(**kwargs)
+            if not resp.get("ok"):
+                logger.error("Failed to upload Slack file: %s", resp.get("error"))
+                return False
+            return True
+        except Exception:
+            logger.exception("Error uploading file to Slack")
+            return False
 
     async def _download_file(self, url: str) -> bytes | None:
         """Download a file from Slack using bot token for auth."""

--- a/bot/server.py
+++ b/bot/server.py
@@ -454,13 +454,58 @@ class BotServer:
                     )
                 )
 
+                # Save incoming file attachments to a temp directory so the
+                # agent can read them with file tools.
+                task_text = msg.text
+                tmp_dir: str | None = None
+                if msg.files:
+                    import tempfile
+                    from pathlib import Path
+
+                    tmp_dir = tempfile.mkdtemp(prefix="ouro_files_")
+                    for fa in msg.files:
+                        dest = Path(tmp_dir) / fa.filename
+                        dest.write_bytes(fa.data)
+                        task_text += (
+                            f"\n[Attached file: {fa.filename} ({fa.mime_type})"
+                            f" saved at: {dest}]"
+                        )
+
+                # Wire send_file context if agent has one
+                send_file_ctx = getattr(agent, "_send_file_ctx", None)
+                if send_file_ctx is not None:
+
+                    async def _send_fn(
+                        file_path: str | None = None,
+                        file_bytes: bytes | None = None,
+                        filename: str | None = None,
+                        mime_type: str | None = None,
+                    ) -> bool:
+                        return await channel.send_file(
+                            conversation_id=msg.conversation_id,
+                            file_path=file_path,
+                            file_bytes=file_bytes,
+                            filename=filename,
+                            mime_type=mime_type,
+                        )
+
+                    send_file_ctx.set_send_fn(_send_fn)
+
                 logger.info(
                     "Processing message from %s:%s — %s",
                     msg.channel,
                     msg.conversation_id,
                     msg.text[:80],
                 )
-                result = await agent.run(msg.text, images=msg.images if msg.images else None)
+                try:
+                    result = await agent.run(task_text, images=msg.images if msg.images else None)
+                finally:
+                    if send_file_ctx is not None:
+                        send_file_ctx.clear()
+                    if tmp_dir is not None:
+                        import shutil
+
+                        shutil.rmtree(tmp_dir, ignore_errors=True)
 
                 # Persist session mapping so conversation survives restarts
                 await self._router.update_session_mapping(msg.channel, msg.conversation_id)
@@ -672,6 +717,14 @@ async def run_bot(model_id: str | None = None) -> None:
         from tools.heartbeat_tool import HeartbeatTool
 
         agent.tool_executor.add_tool(HeartbeatTool())
+
+        # Give the agent a send_file tool (context is set per-message in _process_message)
+        from tools.send_file_tool import SendFileContext, SendFileTool
+
+        ctx = SendFileContext()
+        agent.tool_executor.add_tool(SendFileTool(ctx))
+        agent._send_file_ctx = ctx  # type: ignore[attr-defined]  # stash for _process_message
+
         return agent
 
     router = SessionRouter(

--- a/test/test_bot_server.py
+++ b/test/test_bot_server.py
@@ -26,6 +26,7 @@ class FakeChannel:
 
     def __init__(self):
         self.sent_messages: list[OutgoingMessage] = []
+        self.sent_files: list[dict] = []
         self._callback = None
         self._started = False
         self._stopped = False
@@ -40,6 +41,25 @@ class FakeChannel:
 
     async def send_message(self, message: OutgoingMessage) -> None:
         self.sent_messages.append(message)
+
+    async def send_file(
+        self,
+        conversation_id: str,
+        file_path: str | None = None,
+        file_bytes: bytes | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> bool:
+        self.sent_files.append(
+            {
+                "conversation_id": conversation_id,
+                "file_path": file_path,
+                "file_bytes": file_bytes,
+                "filename": filename,
+                "mime_type": mime_type,
+            }
+        )
+        return True
 
     async def inject_message(self, msg: IncomingMessage) -> None:
         """Simulate an incoming message from the IM platform."""
@@ -357,3 +377,63 @@ async def test_command_case_insensitive(bot_server, fake_channel, mock_router):
     await bot_server._process_message(fake_channel, _make_msg("/NEW"))
 
     assert "Session reset" in fake_channel.sent_messages[0].text
+
+
+# ---------------------------------------------------------------------------
+# File attachment processing tests
+# ---------------------------------------------------------------------------
+
+
+async def test_process_message_with_file_augments_text(bot_server, fake_channel, mock_router):
+    """Incoming file attachments are saved to disk and text is augmented."""
+    from bot.channel.base import FileAttachment
+
+    msg = IncomingMessage(
+        channel="test",
+        conversation_id="conv_f",
+        user_id="user_1",
+        text="Here is a file",
+        message_id="msg_f",
+        files=[FileAttachment(data=b"hello", filename="test.txt", mime_type="text/plain")],
+    )
+
+    agent = await mock_router.get_or_create_agent("test", "conv_f")
+
+    await bot_server._process_message(fake_channel, msg)
+
+    # agent.run should have been called with augmented text
+    call_args = agent.run.call_args
+    task_text = call_args[0][0]
+    assert "Here is a file" in task_text
+    assert "[Attached file: test.txt (text/plain) saved at:" in task_text
+
+    # The temp dir should have been cleaned up
+    import re
+
+    m = re.search(r"saved at: (/[^\]]+)", task_text)
+    assert m is not None
+    import os
+
+    assert not os.path.exists(m.group(1))
+
+
+async def test_send_file_context_lifecycle(bot_server, fake_channel, mock_router):
+    """SendFileContext is set before agent.run() and cleared after."""
+    from tools.send_file_tool import SendFileContext
+
+    agent = await mock_router.get_or_create_agent("test", "conv_ctx")
+    ctx = SendFileContext()
+    agent._send_file_ctx = ctx
+
+    msg = IncomingMessage(
+        channel="test",
+        conversation_id="conv_ctx",
+        user_id="user_1",
+        text="hi",
+        message_id="msg_ctx",
+    )
+
+    await bot_server._process_message(fake_channel, msg)
+
+    # After processing, the context should be cleared
+    assert ctx._send_fn is None

--- a/test/test_lark_channel.py
+++ b/test/test_lark_channel.py
@@ -407,3 +407,130 @@ async def test_stop_clears_state(channel):
     assert channel._callback is None
     assert channel._loop is None
     assert channel._ws_client is None
+
+
+# ---------------------------------------------------------------------------
+# File message tests
+# ---------------------------------------------------------------------------
+
+
+async def test_on_message_file_dispatches(channel):
+    """File message type should dispatch with files populated."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    # Mock file download
+    mock_file = MagicMock()
+    mock_file.read.return_value = b"%PDF-1.4 fake content"
+    mock_response = MagicMock()
+    mock_response.success.return_value = True
+    mock_response.file = mock_file
+    channel._api_client.im.v1.message_resource.get.return_value = mock_response
+
+    data = _make_sdk_event(
+        message_type="file",
+        content=json.dumps({"file_key": "fk_123", "file_name": "report.pdf"}),
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+    assert len(received[0].files) == 1
+    assert received[0].files[0].filename == "report.pdf"
+    assert received[0].files[0].mime_type == "application/pdf"
+    assert received[0].files[0].data == b"%PDF-1.4 fake content"
+    assert received[0].text == ""
+
+
+async def test_on_message_file_download_failure(channel):
+    """Failed file download should drop the message."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    mock_response = MagicMock()
+    mock_response.success.return_value = False
+    mock_response.code = 99999
+    mock_response.msg = "not found"
+    channel._api_client.im.v1.message_resource.get.return_value = mock_response
+
+    data = _make_sdk_event(
+        message_type="file",
+        content=json.dumps({"file_key": "fk_bad", "file_name": "missing.pdf"}),
+    )
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 0
+
+
+# ---------------------------------------------------------------------------
+# send_file tests
+# ---------------------------------------------------------------------------
+
+
+async def test_send_file_image(channel):
+    """send_file with image MIME delegates to _upload_and_send_image."""
+    channel._upload_and_send_image = MagicMock(return_value=True)
+
+    with patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+        mock_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
+
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG\r\nfakeimage")
+            f.flush()
+            path = f.name
+
+        try:
+            result = await channel.send_file(
+                conversation_id="oc_1",
+                file_path=path,
+                mime_type="image/png",
+            )
+            assert result is True
+            channel._upload_and_send_image.assert_called_once()
+            call_args = channel._upload_and_send_image.call_args[0]
+            assert call_args[0] == "oc_1"  # conversation_id
+        finally:
+            import os
+
+            os.unlink(path)
+
+
+async def test_send_file_document(channel):
+    """send_file with non-image MIME delegates to _upload_and_send_file."""
+    channel._upload_and_send_file = MagicMock(return_value=True)
+
+    with patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+        mock_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
+
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            f.write(b"%PDF-1.4 fake")
+            f.flush()
+            path = f.name
+
+        try:
+            result = await channel.send_file(
+                conversation_id="oc_1",
+                file_path=path,
+                mime_type="application/pdf",
+            )
+            assert result is True
+            channel._upload_and_send_file.assert_called_once()
+        finally:
+            import os
+
+            os.unlink(path)

--- a/test/test_send_file_tool.py
+++ b/test/test_send_file_tool.py
@@ -1,0 +1,150 @@
+"""Tests for the send_file tool."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from tools.send_file_tool import SendFileContext, SendFileTool
+
+
+@pytest.fixture
+def ctx():
+    return SendFileContext()
+
+
+@pytest.fixture
+def tool(ctx):
+    return SendFileTool(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+
+async def test_relative_path_error(tool):
+    result = await tool.execute(file_path="relative/path.txt")
+    assert "must be absolute" in result
+
+
+async def test_nonexistent_file_error(tool):
+    result = await tool.execute(file_path="/tmp/nonexistent_file_12345.txt")
+    assert "file not found" in result
+
+
+async def test_file_too_large(tool, tmp_path):
+    big_file = tmp_path / "big.bin"
+    # Create a file just over 50 MB
+    big_file.write_bytes(b"\x00" * (50 * 1024 * 1024 + 1))
+    result = await tool.execute(file_path=str(big_file))
+    assert "too large" in result
+
+
+async def test_context_not_set(tool):
+    """When send_fn is not set, the tool returns an error."""
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"hello")
+        f.flush()
+        path = f.name
+    try:
+        result = await tool.execute(file_path=path)
+        assert "failed to send" in result.lower() or "not available" in result.lower()
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Success tests
+# ---------------------------------------------------------------------------
+
+
+async def test_valid_file_sends(ctx, tool):
+    """A valid absolute file path triggers the send callback."""
+    sent: list[dict] = []
+
+    async def fake_send(**kwargs):
+        sent.append(kwargs)
+        return True
+
+    ctx.set_send_fn(fake_send)
+
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+        f.write(b"%PDF-1.4 fake")
+        f.flush()
+        path = f.name
+    try:
+        result = await tool.execute(file_path=path)
+        assert "File sent" in result
+        assert len(sent) == 1
+        assert sent[0]["file_path"] == path
+        assert sent[0]["filename"] == os.path.basename(path)
+        assert sent[0]["mime_type"] == "application/pdf"
+    finally:
+        os.unlink(path)
+
+
+async def test_filename_defaults_to_basename(ctx, tool):
+    """When no filename is given, basename is used."""
+    sent: list[dict] = []
+
+    async def fake_send(**kwargs):
+        sent.append(kwargs)
+        return True
+
+    ctx.set_send_fn(fake_send)
+
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False, prefix="report_") as f:
+        f.write(b"a,b,c")
+        f.flush()
+        path = f.name
+    try:
+        await tool.execute(file_path=path)
+        assert sent[0]["filename"] == os.path.basename(path)
+    finally:
+        os.unlink(path)
+
+
+async def test_custom_filename(ctx, tool):
+    """Explicit filename overrides basename."""
+    sent: list[dict] = []
+
+    async def fake_send(**kwargs):
+        sent.append(kwargs)
+        return True
+
+    ctx.set_send_fn(fake_send)
+
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"data")
+        f.flush()
+        path = f.name
+    try:
+        result = await tool.execute(file_path=path, filename="custom_name.txt")
+        assert "File sent: custom_name.txt" in result
+        assert sent[0]["filename"] == "custom_name.txt"
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# SendFileContext tests
+# ---------------------------------------------------------------------------
+
+
+async def test_context_clear():
+    ctx = SendFileContext()
+    called = False
+
+    async def fn(**kwargs):
+        nonlocal called
+        called = True
+        return True
+
+    ctx.set_send_fn(fn)
+    ctx.clear()
+    result = await ctx.send(file_path="/tmp/x")
+    assert result is False
+    assert not called

--- a/test/test_slack_channel.py
+++ b/test/test_slack_channel.py
@@ -452,3 +452,104 @@ async def test_stop_closes(channel, mock_socket_client):
 
     mock_socket_client.close.assert_called_once()
     assert channel._callback is None
+
+
+# ---------------------------------------------------------------------------
+# Non-image file attachment tests
+# ---------------------------------------------------------------------------
+
+
+async def test_on_request_non_image_file(channel):
+    """PDF file attachment should populate files list."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    files = [
+        {
+            "mimetype": "application/pdf",
+            "name": "report.pdf",
+            "url_private_download": "https://files.slack.com/report.pdf",
+        }
+    ]
+    req = _make_socket_request(
+        text="check this doc",
+        files=files,
+    )
+
+    with patch.object(channel, "_download_file", new_callable=AsyncMock) as mock_dl:
+        mock_dl.return_value = b"%PDF-1.4 content"
+        await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert len(received[0].images) == 0
+    assert len(received[0].files) == 1
+    assert received[0].files[0].filename == "report.pdf"
+    assert received[0].files[0].mime_type == "application/pdf"
+    assert received[0].files[0].data == b"%PDF-1.4 content"
+
+
+async def test_on_request_mixed_files(channel):
+    """Image + PDF -> both lists populated."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    files = [
+        {
+            "mimetype": "image/png",
+            "name": "screenshot.png",
+            "url_private_download": "https://files.slack.com/screenshot.png",
+        },
+        {
+            "mimetype": "application/pdf",
+            "name": "document.pdf",
+            "url_private_download": "https://files.slack.com/document.pdf",
+        },
+    ]
+    req = _make_socket_request(
+        text="here are both",
+        files=files,
+        subtype="file_share",
+    )
+
+    with patch.object(channel, "_download_file", new_callable=AsyncMock) as mock_dl:
+        mock_dl.side_effect = [b"\x89PNGimg", b"%PDF-1.4doc"]
+        await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert len(received[0].images) == 1
+    assert received[0].images[0].mime_type == "image/png"
+    assert len(received[0].files) == 1
+    assert received[0].files[0].filename == "document.pdf"
+
+
+# ---------------------------------------------------------------------------
+# send_file tests
+# ---------------------------------------------------------------------------
+
+
+async def test_send_file_calls_upload_v2(channel):
+    """send_file should call files_upload_v2."""
+    channel._web_client.files_upload_v2 = AsyncMock(return_value={"ok": True})
+
+    result = await channel.send_file(
+        conversation_id="C1",
+        file_bytes=b"hello",
+        filename="test.txt",
+    )
+
+    assert result is True
+    channel._web_client.files_upload_v2.assert_called_once()
+    call_kwargs = channel._web_client.files_upload_v2.call_args[1]
+    assert call_kwargs["channel"] == "C1"
+    assert call_kwargs["content"] == b"hello"
+    assert call_kwargs["filename"] == "test.txt"

--- a/tools/send_file_tool.py
+++ b/tools/send_file_tool.py
@@ -1,0 +1,118 @@
+"""Send-file tool for agents running in bot mode."""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from tools.base import BaseTool
+
+logger = logging.getLogger(__name__)
+
+# 50 MB hard limit
+_MAX_FILE_SIZE = 50 * 1024 * 1024
+
+# Callback signature: async (**kwargs) -> bool
+SendFn = Callable[..., Awaitable[bool]]
+
+
+class SendFileContext:
+    """Mutable holder for the per-message send callback.
+
+    The bot server sets the callback before each ``agent.run()`` and
+    clears it afterwards so the tool cannot accidentally send to a
+    stale conversation.
+    """
+
+    def __init__(self) -> None:
+        self._send_fn: SendFn | None = None
+
+    def set_send_fn(self, fn: SendFn) -> None:
+        self._send_fn = fn
+
+    def clear(self) -> None:
+        self._send_fn = None
+
+    async def send(
+        self,
+        file_path: str | None = None,
+        file_bytes: bytes | None = None,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> bool:
+        if self._send_fn is None:
+            return False
+        return await self._send_fn(
+            file_path=file_path,
+            file_bytes=file_bytes,
+            filename=filename,
+            mime_type=mime_type,
+        )
+
+
+class SendFileTool(BaseTool):
+    """Agent-facing tool to send a file to the current IM conversation."""
+
+    def __init__(self, context: SendFileContext) -> None:
+        self._ctx = context
+
+    @property
+    def name(self) -> str:
+        return "send_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Send a file to the user in the current IM conversation. "
+            "Use this when the user asks you to create, generate, or share "
+            "a file (e.g. PDF, CSV, image, document). "
+            "The file must exist on disk at an absolute path."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "file_path": {
+                "type": "string",
+                "description": "Absolute path to the file to send.",
+            },
+            "filename": {
+                "type": "string",
+                "description": "Optional display name for the file (defaults to basename).",
+                "default": "",
+            },
+        }
+
+    async def execute(
+        self,
+        file_path: str,
+        filename: str = "",
+        **kwargs: Any,
+    ) -> str:
+        # Validate path
+        if not os.path.isabs(file_path):
+            return f"Error: file_path must be absolute, got: {file_path}"
+        if not os.path.isfile(file_path):
+            return f"Error: file not found: {file_path}"
+
+        size = os.path.getsize(file_path)
+        if size > _MAX_FILE_SIZE:
+            return (
+                f"Error: file too large ({size / 1024 / 1024:.1f} MB). "
+                f"Maximum is {_MAX_FILE_SIZE / 1024 / 1024:.0f} MB."
+            )
+
+        display_name = filename or os.path.basename(file_path)
+        mime, _ = mimetypes.guess_type(display_name)
+
+        ok = await self._ctx.send(
+            file_path=file_path,
+            filename=display_name,
+            mime_type=mime,
+        )
+        if ok:
+            return f"File sent: {display_name}"
+        return "Error: failed to send file (channel not available or upload failed)."


### PR DESCRIPTION
## Summary

Enable bots to receive non-image file attachments (PDFs, docs, etc.) from users and send files back via a new `send_file` agent tool. Previously the bot only handled text and images — this adds full file transfer in both directions for Lark and Slack channels.

## Scope

- Goals:
  - Incoming: users can send file attachments (PDF, doc, etc.) to the bot; files are saved to a temp dir and the agent can process them
  - Outgoing: agent can send files to users via a new `send_file` tool
  - Both Lark and Slack channels supported
- Non-goals:
  - No changes to image handling (existing `ImageData` flow untouched)
  - No UI changes or new slash commands

## Invariants (Must Not Regress)

- [x] Existing text message flow unchanged
- [x] Existing image message flow unchanged (ImageData path untouched)
- [x] Slash commands continue to work
- [x] Channel protocol backward compatible (send_file has default implementation)
- [x] All existing tests pass

## Acceptance Criteria

- [x] `FileAttachment` dataclass added to data model
- [x] Lark handles incoming `message_type="file"` messages
- [x] Slack handles non-image file attachments
- [x] Incoming files saved to temp dir, task text augmented with file paths
- [x] Temp dir cleaned up after agent.run() completes
- [x] `SendFileTool` validates path (absolute, exists, ≤50MB), guesses MIME type
- [x] `SendFileContext` lifecycle: set before agent.run(), cleared after
- [x] Lark send_file: images via `im.v1.image.create`, files via `im.v1.file.create`
- [x] Slack send_file: via `files_upload_v2`

## Test Plan

- [x] `test/test_send_file_tool.py` — 8 tests (validation, success, context)
- [x] `test/test_lark_channel.py` — 4 new tests (file dispatch, download failure, send image, send doc)
- [x] `test/test_slack_channel.py` — 3 new tests (non-image file, mixed files, upload_v2)
- [x] `test/test_bot_server.py` — 2 new tests (file augments text, context lifecycle)
- [x] `./scripts/dev.sh check` — 590 passed, 0 failed
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — clean

## Smoke Run (Real CLI)

Not applicable — requires live Lark/Slack credentials. Covered by unit tests mocking SDK calls.

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?** Text/image message flow is untouched. New `files` field on `IncomingMessage` defaults to empty list. `send_file` on Channel protocol is additive.
- **Worst-case input/output size?** send_file tool enforces 50MB limit. Temp files cleaned up in finally block.
- **Any secrets/logging risks?** No — file contents not logged, only filenames.
- **Any async/blocking I/O added on hot paths?** Lark file upload uses `asyncio.to_thread` (same pattern as existing `send_message`). Slack uses native async SDK.
- **What error message does the user see on failure?** Tool returns actionable error strings ("file not found", "too large", "not available").

## Docs / Compatibility

- [x] No secrets committed; no generated artifacts
- [ ] Docs update deferred (no user-facing config changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)