### PR TITLE
feat(bot): make proactive task timeout configurable

### DIFF
--- a/bot/proactive.py
+++ b/bot/proactive.py
@@ -34,8 +34,9 @@ _BOT_DIR = os.path.join(os.path.expanduser("~"), ".ouro", "bot")
 _HEARTBEAT_FILE = os.path.join(_BOT_DIR, "heartbeat.md")
 _CRON_JOBS_FILE = os.path.join(_BOT_DIR, "cron_jobs.json")
 
-# Execution timeout for isolated agent runs (seconds)
-_ISOLATED_TIMEOUT = 120
+# Execution timeout for isolated agent runs (seconds).
+# Configured via BOT_PROACTIVE_TIMEOUT; defaults to 1200 (20 min).
+_ISOLATED_TIMEOUT = Config.BOT_PROACTIVE_TIMEOUT
 
 _DEFAULT_HEARTBEAT = """\
 # Heartbeat Checklist

--- a/config.py
+++ b/config.py
@@ -138,6 +138,9 @@ class Config:
     BOT_ACTIVE_HOURS_START = int(_cfg.get("BOT_ACTIVE_HOURS_START", "8"))  # 24h format
     BOT_ACTIVE_HOURS_END = int(_cfg.get("BOT_ACTIVE_HOURS_END", "22"))  # 24h format
     BOT_ACTIVE_HOURS_TZ = _cfg.get("BOT_ACTIVE_HOURS_TZ", "")  # empty = local timezone
+    BOT_PROACTIVE_TIMEOUT = int(
+        _cfg.get("BOT_PROACTIVE_TIMEOUT", "1200")
+    )  # seconds; timeout for isolated agent runs (heartbeat/cron)
 
     @classmethod
     def get_retry_delay(cls, attempt: int) -> float:


### PR DESCRIPTION
## Summary

Make the isolated agent execution timeout (used by heartbeat and cron tasks) configurable via `BOT_PROACTIVE_TIMEOUT`. Default changed from 120s to 1200s (20 min) to allow complex cron tasks to complete.

## Scope

- Goals: configurable proactive task timeout
- Non-goals: no behavioral changes to scheduling logic

## Invariants (Must Not Regress)

- [ ] Heartbeat still runs on schedule and times out correctly
- [ ] Cron jobs still execute and broadcast results
- [ ] Existing config values (`BOT_HEARTBEAT_INTERVAL`, etc.) unaffected
- [ ] Timeout still enforced via `asyncio.wait_for`

## Acceptance Criteria

- [ ] `BOT_PROACTIVE_TIMEOUT` configurable via `~/.ouro/config` or env var
- [ ] Default is 1200 seconds (20 min)
- [ ] Follows existing `Config` class pattern

## Test Plan

- [ ] `./scripts/dev.sh check` — all 573 tests pass
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)