### PR TITLE
fix(bot): add missing permissions docs and save images to disk

### DIFF
--- a/bot/LARK.md
+++ b/bot/LARK.md
@@ -44,8 +44,13 @@ Go to **Events & Callbacks** -> **Event Configuration** -> Add event:
 
 Go to **Permissions & Scopes** -> search and enable:
 
-- `im:message` -- Read messages in chats
-- `im:message:send_as_bot` -- Send messages as the bot
+| Scope | Description | Required for |
+|-------|-------------|--------------|
+| `im:message` | Read messages in chats | Receiving messages |
+| `im:message:send_as_bot` | Send messages as the bot | Sending text/image/file messages |
+| `im:resource` | Upload & download message resources | Sending and receiving images/files |
+
+**Note**: Without `im:resource`, the bot can send/receive text but image and file operations will fail with "upload failed".
 
 ## 7. Publish the App
 
@@ -92,6 +97,10 @@ pip install "python-socks[asyncio]"
 ### "This event loop is already running"
 
 This should not happen with the current implementation (we create a dedicated event loop for the SDK thread). If you see this, please file an issue.
+
+### "channel not available or upload failed" when sending images/files
+
+The bot app is missing the `im:resource` permission. Go to **Permissions & Scopes** in the Lark developer console, enable `im:resource`, and re-publish the app version. Check bot logs for the specific Lark error code (e.g. `Failed to upload image to Lark: code=... msg=...`).
 
 ### Event subscription fails with "app has not established long connection"
 

--- a/bot/SLACK.md
+++ b/bot/SLACK.md
@@ -34,11 +34,15 @@ Under **Subscribe to bot events**, add:
 
 Go to **OAuth & Permissions** -> **Scopes** -> **Bot Token Scopes**, add:
 
-| Scope | Description |
-|-------|-------------|
-| `chat:write` | Send messages |
-| `im:history` | Read DM history |
-| `channels:history` | Read channel history (if using `message.channels`) |
+| Scope | Description | Required for |
+|-------|-------------|--------------|
+| `chat:write` | Send messages | Sending text messages |
+| `im:history` | Read DM history | Receiving direct messages |
+| `files:read` | Read files shared in channels | Receiving image/file attachments |
+| `files:write` | Upload and share files | Sending images/files to users |
+| `channels:history` | Read channel history | Receiving messages in public channels (optional) |
+
+**Note**: Without `files:read` and `files:write`, the bot can send/receive text but image and file operations will fail.
 
 ## 5. Install the App
 
@@ -95,6 +99,11 @@ Bot server listening on 0.0.0.0:8080
 - Check that Socket Mode is enabled in the Slack app settings
 - Verify the bot has been invited to the channel (for non-DM channels)
 - Check that the `xapp-` token has the `connections:write` scope
+
+### "upload failed" or images/files not working
+
+- Ensure `files:read` and `files:write` scopes are added in **OAuth & Permissions**
+- After adding new scopes, **re-install the app** to your workspace (OAuth & Permissions -> Install to Workspace)
 
 ### "invalid_auth" errors
 

--- a/bot/server.py
+++ b/bot/server.py
@@ -454,11 +454,11 @@ class BotServer:
                     )
                 )
 
-                # Save incoming file attachments to a temp directory so the
-                # agent can read them with file tools.
+                # Save incoming file/image attachments to a temp directory so
+                # the agent can read them with file tools.
                 task_text = msg.text
                 tmp_dir: str | None = None
-                if msg.files:
+                if msg.files or msg.images:
                     import tempfile
                     from pathlib import Path
 
@@ -469,6 +469,14 @@ class BotServer:
                         task_text += (
                             f"\n[Attached file: {fa.filename} ({fa.mime_type})"
                             f" saved at: {dest}]"
+                        )
+                    for idx, img in enumerate(msg.images):
+                        ext = img.mime_type.split("/")[-1] if img.mime_type else "png"
+                        img_name = f"image_{idx}.{ext}"
+                        dest = Path(tmp_dir) / img_name
+                        dest.write_bytes(img.data)
+                        task_text += (
+                            f"\n[Attached image: {img_name} ({img.mime_type})" f" saved at: {dest}]"
                         )
 
                 # Wire send_file context if agent has one


### PR DESCRIPTION
## Summary

- Add missing permission scopes to Lark and Slack setup docs that are required for image/file operations
- Fix incoming images not being saved to disk, so the agent can reference them by file path

## Scope

- Goals: Complete permissions documentation for both platforms; make received images accessible via file tools
- Non-goals: No changes to image/file upload logic itself

## Invariants (Must Not Regress)

- [x] Text-only message sending/receiving unchanged
- [x] File attachment sending/receiving unchanged
- [x] Images still passed as multimodal vision input to agent
- [x] Temp directory cleanup still happens in `finally` block
- [x] Existing bot slash commands unaffected

## Acceptance Criteria

- [x] `bot/LARK.md` documents `im:resource` scope
- [x] `bot/SLACK.md` documents `files:read` and `files:write` scopes
- [x] Both docs have troubleshooting entries for file upload failures
- [x] Incoming images saved to temp dir with path in task text

## Test Plan

- [x] `./scripts/dev.sh test -q` — 590 passed
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)