### PR TITLE
fix(skills): only bootstrap system skills in bot mode

### DIFF
--- a/agent/skills/registry.py
+++ b/agent/skills/registry.py
@@ -23,12 +23,14 @@ BUNDLED_SKILLS_DIR = Path(__file__).parent / "system"
 class SkillsRegistry:
     """Index and resolve skills for ouro."""
 
-    def __init__(self, skills_dir: Path | None = None) -> None:
+    def __init__(self, skills_dir: Path | None = None, *, bootstrap: bool = False) -> None:
         self.skills: dict[str, SkillInfo] = {}
         self._skills_dir = skills_dir or (Path.home() / ".ouro" / "skills")
+        self._bootstrap = bootstrap
 
     async def load(self) -> None:
-        await self._bootstrap_bundled_skills()
+        if self._bootstrap:
+            await self._bootstrap_bundled_skills()
         self.skills = await self._load_skills(self._skills_dir)
 
     async def _bootstrap_bundled_skills(self) -> None:

--- a/bot/server.py
+++ b/bot/server.py
@@ -690,7 +690,7 @@ async def run_bot(model_id: str | None = None) -> None:
 
     # Bootstrap bundled skills into bot's own skills directory
     try:
-        bootstrap_registry = SkillsRegistry(skills_dir=bot_skills_dir)
+        bootstrap_registry = SkillsRegistry(skills_dir=bot_skills_dir, bootstrap=True)
         await bootstrap_registry.load()
     except Exception as e:
         logger.warning("Failed to bootstrap skills registry: %s", e)

--- a/test/test_skills_registry.py
+++ b/test/test_skills_registry.py
@@ -14,7 +14,7 @@ async def test_bundled_skills_bootstrapped(tmp_path, monkeypatch) -> None:
     # Create empty user skills directory
     (tmp_path / ".ouro" / "skills").mkdir(parents=True)
 
-    registry = SkillsRegistry()
+    registry = SkillsRegistry(bootstrap=True)
     await registry.load()
 
     # Bundled skills should be bootstrapped and loaded
@@ -51,7 +51,7 @@ async def test_user_skill_overrides_system_skill(tmp_path, monkeypatch) -> None:
         ).strip()
     )
 
-    registry = SkillsRegistry()
+    registry = SkillsRegistry(bootstrap=True)
     await registry.load()
 
     # User skill should take precedence


### PR DESCRIPTION
## Summary

System skills were being copied to `~/.ouro/skills/` on every startup regardless of mode. Now the bootstrap (copy) step only runs in bot mode, keeping the user's skills directory clean in interactive and single-task modes.

## Scope

- Goals: Only copy bundled system skills to `~/.ouro/bot/skills/` when running in bot mode.
- Non-goals: No change to how skills are loaded/resolved; only the copy-on-startup behavior changes.

## Invariants (Must Not Regress)

- [x] Bot mode still seeds bundled skills into `~/.ouro/bot/skills/`
- [x] Interactive/single-task modes still load user skills from `~/.ouro/skills/`
- [x] User-customized skills are never overwritten by bootstrap
- [x] Skills registry `call_skill()` works unchanged

## Acceptance Criteria

- [x] `SkillsRegistry()` (default) does not copy bundled skills
- [x] `SkillsRegistry(bootstrap=True)` copies bundled skills (bot mode only)

## Test Plan

- [x] `./scripts/dev.sh test -q test/test_skills_registry.py` — 4 passed
- [x] `./scripts/dev.sh check` — 590 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)