### PR TITLE
feat(bot): replace text ack with emoji reactions

### DIFF
--- a/bot/LARK.md
+++ b/bot/LARK.md
@@ -49,6 +49,7 @@ Go to **Permissions & Scopes** -> search and enable:
 | `im:message` | Read messages in chats | Receiving messages |
 | `im:message:send_as_bot` | Send messages as the bot | Sending text/image/file messages |
 | `im:resource` | Upload & download message resources | Sending and receiving images/files |
+| `im:message.reactions:write_as_bot` | Add/remove emoji reactions | Processing status indicators |
 
 **Note**: Without `im:resource`, the bot can send/receive text but image and file operations will fail with "upload failed".
 
@@ -82,7 +83,7 @@ Bot server listening on 0.0.0.0:8080
 
 ## 9. Test
 
-Find your bot in Lark and send a message. You should receive "Working on it..." followed by the agent's response.
+Find your bot in Lark and send a message. You should see an eyes emoji reaction on your message (indicating the bot is processing), followed by the agent's response and a checkmark reaction.
 
 ## Troubleshooting
 

--- a/bot/SLACK.md
+++ b/bot/SLACK.md
@@ -37,6 +37,7 @@ Go to **OAuth & Permissions** -> **Scopes** -> **Bot Token Scopes**, add:
 | Scope | Description | Required for |
 |-------|-------------|--------------|
 | `chat:write` | Send messages | Sending text messages |
+| `reactions:write` | Add/remove emoji reactions | Processing status indicators |
 | `im:history` | Read DM history | Receiving direct messages |
 | `files:read` | Read files shared in channels | Receiving image/file attachments |
 | `files:write` | Upload and share files | Sending images/files to users |
@@ -74,7 +75,7 @@ Bot server listening on 0.0.0.0:8080
 
 ## 7. Test
 
-Open a DM with your bot in Slack and send a message. You should receive "Working on it..." followed by the agent's response.
+Open a DM with your bot in Slack and send a message. You should see an :eyes: emoji reaction on your message (indicating the bot is processing), followed by the agent's response and a :white_check_mark: reaction.
 
 ## Running Both Lark and Slack
 

--- a/bot/channel/base.py
+++ b/bot/channel/base.py
@@ -36,6 +36,7 @@ class IncomingMessage:
     raw: dict = field(default_factory=dict)
     images: list[ImageData] = field(default_factory=list)
     files: list[FileAttachment] = field(default_factory=list)
+    platform_message_id: str = ""  # platform-native ID for reactions (Slack ts, Lark message_id)
 
 
 @dataclass
@@ -90,4 +91,18 @@ class Channel(Protocol):
         mime_type: str | None = None,
     ) -> bool:
         """Upload and send a file to the IM channel. Returns True on success."""
+        ...
+
+    async def add_reaction(self, conversation_id: str, message_id: str, emoji: str) -> str | None:
+        """Add an emoji reaction to a message. Returns a reaction ID if available."""
+        ...
+
+    async def remove_reaction(
+        self,
+        conversation_id: str,
+        message_id: str,
+        emoji: str,
+        reaction_id: str | None = None,
+    ) -> None:
+        """Remove an emoji reaction from a message."""
         ...

--- a/bot/channel/lark.py
+++ b/bot/channel/lark.py
@@ -101,9 +101,84 @@ class LarkChannel:
         """Send a text message to a Lark chat (async-safe)."""
         await asyncio.to_thread(self._send_sync, message)
 
+    async def add_reaction(self, conversation_id: str, message_id: str, emoji: str) -> str | None:
+        """Add an emoji reaction to a Lark message. Returns the reaction_id."""
+        return await asyncio.to_thread(self._add_reaction_sync, message_id, emoji)
+
+    async def remove_reaction(
+        self,
+        conversation_id: str,
+        message_id: str,
+        emoji: str,
+        reaction_id: str | None = None,
+    ) -> None:
+        """Remove an emoji reaction from a Lark message."""
+        if reaction_id:
+            await asyncio.to_thread(self._delete_reaction_sync, message_id, reaction_id)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    # Lark uses uppercase emoji type names; map common Slack-style names.
+    _EMOJI_MAP: dict[str, str] = {
+        "eyes": "EYES",
+        "white_check_mark": "OK",
+    }
+
+    def _add_reaction_sync(self, message_id: str, emoji: str) -> str | None:
+        """Blocking: add a reaction via the Lark API."""
+        try:
+            from lark_oapi.api.im.v1 import (
+                CreateMessageReactionRequest,
+                CreateMessageReactionRequestBody,
+                Emoji,
+            )
+
+            emoji_type = self._EMOJI_MAP.get(emoji, emoji.upper())
+            body = (
+                CreateMessageReactionRequestBody.builder()
+                .reaction_type(Emoji.builder().emoji_type(emoji_type).build())
+                .build()
+            )
+            request = (
+                CreateMessageReactionRequest.builder()
+                .message_id(message_id)
+                .request_body(body)
+                .build()
+            )
+            response = self._api_client.im.v1.message_reaction.create(request)
+            if response.success() and response.data:
+                return getattr(response.data, "reaction_id", None)
+            logger.warning(
+                "Failed to add Lark reaction: code=%s msg=%s",
+                getattr(response, "code", "?"),
+                getattr(response, "msg", "?"),
+            )
+        except Exception:
+            logger.warning("Error adding Lark reaction", exc_info=True)
+        return None
+
+    def _delete_reaction_sync(self, message_id: str, reaction_id: str) -> None:
+        """Blocking: delete a reaction via the Lark API."""
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageReactionRequest
+
+            request = (
+                DeleteMessageReactionRequest.builder()
+                .message_id(message_id)
+                .reaction_id(reaction_id)
+                .build()
+            )
+            response = self._api_client.im.v1.message_reaction.delete(request)
+            if not response.success():
+                logger.warning(
+                    "Failed to remove Lark reaction: code=%s msg=%s",
+                    getattr(response, "code", "?"),
+                    getattr(response, "msg", "?"),
+                )
+        except Exception:
+            logger.warning("Error removing Lark reaction", exc_info=True)
 
     def _fetch_bot_info(self) -> None:
         """Fetch the bot's own open_id via the Lark bot info API."""
@@ -247,6 +322,7 @@ class LarkChannel:
             message_id=msg_obj.message_id or "",
             images=images,
             files=files,
+            platform_message_id=msg_obj.message_id or "",
         )
 
         # Bridge into the asyncio event loop.

--- a/bot/channel/slack.py
+++ b/bot/channel/slack.py
@@ -151,6 +151,8 @@ class SlackChannel:
         channel_id = event.get("channel", "")
         user_id = event.get("user", "")
 
+        ts = event.get("ts", "")
+
         incoming = IncomingMessage(
             channel=self.name,
             conversation_id=channel_id,
@@ -160,10 +162,40 @@ class SlackChannel:
             raw=req.payload or {},
             images=images,
             files=files,
+            platform_message_id=ts,
         )
 
         if self._callback is not None:
             await self._callback(incoming)
+
+    async def add_reaction(self, conversation_id: str, message_id: str, emoji: str) -> str | None:
+        """Add an emoji reaction to a Slack message."""
+        try:
+            resp = await self._web_client.reactions_add(
+                channel=conversation_id, name=emoji, timestamp=message_id
+            )
+            if not resp.get("ok"):
+                logger.warning("Failed to add Slack reaction: %s", resp.get("error"))
+        except Exception:
+            logger.warning("Error adding Slack reaction", exc_info=True)
+        return None
+
+    async def remove_reaction(
+        self,
+        conversation_id: str,
+        message_id: str,
+        emoji: str,
+        reaction_id: str | None = None,
+    ) -> None:
+        """Remove an emoji reaction from a Slack message."""
+        try:
+            resp = await self._web_client.reactions_remove(
+                channel=conversation_id, name=emoji, timestamp=message_id
+            )
+            if not resp.get("ok"):
+                logger.warning("Failed to remove Slack reaction: %s", resp.get("error"))
+        except Exception:
+            logger.warning("Error removing Slack reaction", exc_info=True)
 
     async def send_file(
         self,

--- a/bot/server.py
+++ b/bot/server.py
@@ -434,8 +434,13 @@ class BotServer:
 
     # ---- Message processing ---------------------------------------------------
 
+    # Emoji constants for reaction-based acknowledgment.
+    _PROCESSING_EMOJI = "eyes"
+    _DONE_EMOJI = "white_check_mark"
+
     async def _process_message(self, channel: Channel, msg: IncomingMessage) -> None:
-        """Process a message: command check -> lock -> ack -> agent.run -> send result."""
+        """Process a message: command check -> reaction ack -> lock -> agent.run -> send result."""
+        reaction_id: str | None = None
         try:
             # Fast path: slash commands that don't need the agent lock
             # (/new, /help are stateless; /compact and /status acquire no external lock
@@ -443,17 +448,20 @@ class BotServer:
             if await self._handle_command(channel, msg):
                 return
 
+            # Instant feedback: add 👀 reaction *before* the lock so the user
+            # knows we received the message even while a previous one is processing.
+            if msg.platform_message_id:
+                try:
+                    reaction_id = await channel.add_reaction(
+                        msg.conversation_id, msg.platform_message_id, self._PROCESSING_EMOJI
+                    )
+                except Exception:
+                    logger.debug("Failed to add processing reaction", exc_info=True)
+
             agent = await self._router.get_or_create_agent(msg.channel, msg.conversation_id)
             lock = self._router.get_lock(msg.channel, msg.conversation_id)
 
             async with lock:
-                await channel.send_message(
-                    OutgoingMessage(
-                        conversation_id=msg.conversation_id,
-                        text="Working on it...",
-                    )
-                )
-
                 # Save incoming file/image attachments to a temp directory so
                 # the agent can read them with file tools.
                 task_text = msg.text
@@ -532,6 +540,24 @@ class BotServer:
                     len(result),
                 )
 
+            # Swap reactions: remove 👀, add ✅ (after lock released)
+            if msg.platform_message_id:
+                try:
+                    await channel.remove_reaction(
+                        msg.conversation_id,
+                        msg.platform_message_id,
+                        self._PROCESSING_EMOJI,
+                        reaction_id,
+                    )
+                except Exception:
+                    logger.debug("Failed to remove processing reaction", exc_info=True)
+                try:
+                    await channel.add_reaction(
+                        msg.conversation_id, msg.platform_message_id, self._DONE_EMOJI
+                    )
+                except Exception:
+                    logger.debug("Failed to add done reaction", exc_info=True)
+
         except Exception:
             logger.exception(
                 "Error processing message %s from %s:%s",
@@ -539,6 +565,17 @@ class BotServer:
                 msg.channel,
                 msg.conversation_id,
             )
+            # Clean up processing reaction on error
+            if msg.platform_message_id:
+                try:
+                    await channel.remove_reaction(
+                        msg.conversation_id,
+                        msg.platform_message_id,
+                        self._PROCESSING_EMOJI,
+                        reaction_id,
+                    )
+                except Exception:
+                    logger.debug("Failed to remove processing reaction on error", exc_info=True)
             try:
                 await channel.send_message(
                     OutgoingMessage(

--- a/test/test_bot_server.py
+++ b/test/test_bot_server.py
@@ -27,6 +27,8 @@ class FakeChannel:
     def __init__(self):
         self.sent_messages: list[OutgoingMessage] = []
         self.sent_files: list[dict] = []
+        self.reactions_added: list[tuple[str, str, str]] = []  # (conv_id, msg_id, emoji)
+        self.reactions_removed: list[tuple[str, str, str, str | None]] = []
         self._callback = None
         self._started = False
         self._stopped = False
@@ -60,6 +62,19 @@ class FakeChannel:
             }
         )
         return True
+
+    async def add_reaction(self, conversation_id: str, message_id: str, emoji: str) -> str | None:
+        self.reactions_added.append((conversation_id, message_id, emoji))
+        return f"reaction_{emoji}"
+
+    async def remove_reaction(
+        self,
+        conversation_id: str,
+        message_id: str,
+        emoji: str,
+        reaction_id: str | None = None,
+    ) -> None:
+        self.reactions_removed.append((conversation_id, message_id, emoji, reaction_id))
 
     async def inject_message(self, msg: IncomingMessage) -> None:
         """Simulate an incoming message from the IM platform."""
@@ -124,15 +139,20 @@ async def test_process_message_sends_ack_and_result(bot_server, fake_channel, mo
         user_id="user_1",
         text="What is 2+2?",
         message_id="msg_1",
+        platform_message_id="ts_1",
     )
 
     await bot_server._process_message(fake_channel, msg)
 
-    # Should have sent 2 messages: ack + result
-    assert len(fake_channel.sent_messages) == 2
-    assert fake_channel.sent_messages[0].text == "Working on it..."
-    assert fake_channel.sent_messages[1].text == "Agent response"
+    # Should have sent 1 message (agent result only, no "Working on it..." ack)
+    assert len(fake_channel.sent_messages) == 1
+    assert fake_channel.sent_messages[0].text == "Agent response"
     assert fake_channel.sent_messages[0].conversation_id == "conv_1"
+
+    # Reactions: processing emoji added then removed, done emoji added
+    assert ("conv_1", "ts_1", "eyes") in fake_channel.reactions_added
+    assert ("conv_1", "ts_1", "white_check_mark") in fake_channel.reactions_added
+    assert any(r[:3] == ("conv_1", "ts_1", "eyes") for r in fake_channel.reactions_removed)
 
 
 async def test_process_message_error_sends_error_message(bot_server, fake_channel, mock_router):
@@ -146,13 +166,17 @@ async def test_process_message_error_sends_error_message(bot_server, fake_channe
         user_id="user_1",
         text="Do something",
         message_id="msg_err",
+        platform_message_id="ts_err",
     )
 
     await bot_server._process_message(fake_channel, msg)
 
-    assert len(fake_channel.sent_messages) == 2
-    assert "Working on it..." in fake_channel.sent_messages[0].text
-    assert "went wrong" in fake_channel.sent_messages[1].text
+    # Only error message sent (no "Working on it..." text)
+    assert len(fake_channel.sent_messages) == 1
+    assert "went wrong" in fake_channel.sent_messages[0].text
+
+    # Processing reaction should have been cleaned up
+    assert any(r[:3] == ("conv_err", "ts_err", "eyes") for r in fake_channel.reactions_removed)
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +262,9 @@ def test_build_channels_empty():
 # ---------------------------------------------------------------------------
 
 
-def _make_msg(text: str, conv: str = "conv_cmd") -> IncomingMessage:
+def _make_msg(
+    text: str, conv: str = "conv_cmd", platform_message_id: str = "platform_msg_cmd"
+) -> IncomingMessage:
     """Helper: build an IncomingMessage with the given text."""
     return IncomingMessage(
         channel="test",
@@ -246,6 +272,7 @@ def _make_msg(text: str, conv: str = "conv_cmd") -> IncomingMessage:
         user_id="user_1",
         text=text,
         message_id="msg_cmd",
+        platform_message_id=platform_message_id,
     )
 
 
@@ -346,19 +373,18 @@ async def test_non_command_passes_through(bot_server, fake_channel, mock_router)
     """A regular message (no / prefix) goes to agent.run()."""
     await bot_server._process_message(fake_channel, _make_msg("hello world"))
 
-    # Should see ack + agent response = 2 messages
-    assert len(fake_channel.sent_messages) == 2
-    assert fake_channel.sent_messages[0].text == "Working on it..."
-    assert fake_channel.sent_messages[1].text == "Agent response"
+    # Should see only agent response (ack is via reaction, not text)
+    assert len(fake_channel.sent_messages) == 1
+    assert fake_channel.sent_messages[0].text == "Agent response"
 
 
 async def test_unknown_command_passes_through(bot_server, fake_channel, mock_router):
     """An unknown /command is forwarded to agent.run() as a regular message."""
     await bot_server._process_message(fake_channel, _make_msg("/unknown_cmd"))
 
-    # Should see ack + agent response (command not handled)
-    assert len(fake_channel.sent_messages) == 2
-    assert fake_channel.sent_messages[0].text == "Working on it..."
+    # Should see only agent response (ack is via reaction)
+    assert len(fake_channel.sent_messages) == 1
+    assert fake_channel.sent_messages[0].text == "Agent response"
 
 
 async def test_command_with_extra_args(bot_server, fake_channel, mock_router):
@@ -437,3 +463,38 @@ async def test_send_file_context_lifecycle(bot_server, fake_channel, mock_router
 
     # After processing, the context should be cleared
     assert ctx._send_fn is None
+
+
+# ---------------------------------------------------------------------------
+# Reaction acknowledgment tests
+# ---------------------------------------------------------------------------
+
+
+async def test_no_platform_id_skips_reactions(bot_server, fake_channel, mock_router):
+    """When platform_message_id is empty, no reactions are added."""
+    msg = _make_msg("hello world", platform_message_id="")
+
+    await bot_server._process_message(fake_channel, msg)
+
+    assert len(fake_channel.reactions_added) == 0
+    assert len(fake_channel.reactions_removed) == 0
+    # Agent response should still be sent
+    assert len(fake_channel.sent_messages) == 1
+    assert fake_channel.sent_messages[0].text == "Agent response"
+
+
+async def test_reaction_failure_does_not_block(bot_server, fake_channel, mock_router):
+    """add_reaction raising an exception should not block message processing."""
+
+    async def _failing_add(conv_id, msg_id, emoji):
+        raise RuntimeError("API down")
+
+    fake_channel.add_reaction = _failing_add  # type: ignore[assignment]
+
+    msg = _make_msg("hello world")
+
+    await bot_server._process_message(fake_channel, msg)
+
+    # Processing should complete normally — agent response sent
+    assert len(fake_channel.sent_messages) == 1
+    assert fake_channel.sent_messages[0].text == "Agent response"

--- a/test/test_lark_channel.py
+++ b/test/test_lark_channel.py
@@ -534,3 +534,63 @@ async def test_send_file_document(channel):
             import os
 
             os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Reaction tests
+# ---------------------------------------------------------------------------
+
+
+async def test_add_reaction_calls_api(channel):
+    """add_reaction calls message_reaction.create and returns reaction_id."""
+    mock_response = MagicMock()
+    mock_response.success.return_value = True
+    mock_response.data = MagicMock()
+    mock_response.data.reaction_id = "react_123"
+    channel._api_client.im.v1.message_reaction.create.return_value = mock_response
+
+    with patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+        mock_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
+        result = await channel.add_reaction("oc_1", "msg_001", "eyes")
+
+    assert result == "react_123"
+    channel._api_client.im.v1.message_reaction.create.assert_called_once()
+
+
+async def test_remove_reaction_calls_api(channel):
+    """remove_reaction calls message_reaction.delete with correct params."""
+    mock_response = MagicMock()
+    mock_response.success.return_value = True
+    channel._api_client.im.v1.message_reaction.delete.return_value = mock_response
+
+    with patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+        mock_thread.side_effect = lambda fn, *a, **kw: fn(*a, **kw)
+        await channel.remove_reaction("oc_1", "msg_001", "eyes", reaction_id="react_123")
+
+    channel._api_client.im.v1.message_reaction.delete.assert_called_once()
+
+
+async def test_remove_reaction_skips_without_reaction_id(channel):
+    """remove_reaction with no reaction_id should be a no-op."""
+    with patch("bot.channel.lark.asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+        await channel.remove_reaction("oc_1", "msg_001", "eyes", reaction_id=None)
+
+    mock_thread.assert_not_called()
+
+
+async def test_platform_message_id_populated(channel):
+    """platform_message_id should be set to message_id from the Lark event."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+    channel._loop = asyncio.get_running_loop()
+
+    data = _make_sdk_event(text="hello", message_id="lark_msg_001")
+    channel._on_message(data)
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+    assert received[0].platform_message_id == "lark_msg_001"

--- a/test/test_slack_channel.py
+++ b/test/test_slack_channel.py
@@ -553,3 +553,48 @@ async def test_send_file_calls_upload_v2(channel):
     assert call_kwargs["channel"] == "C1"
     assert call_kwargs["content"] == b"hello"
     assert call_kwargs["filename"] == "test.txt"
+
+
+# ---------------------------------------------------------------------------
+# Reaction tests
+# ---------------------------------------------------------------------------
+
+
+async def test_add_reaction(channel):
+    """add_reaction calls reactions_add with correct params."""
+    channel._web_client.reactions_add = AsyncMock(return_value={"ok": True})
+
+    result = await channel.add_reaction("C1", "1234567890.000100", "eyes")
+
+    channel._web_client.reactions_add.assert_called_once_with(
+        channel="C1", name="eyes", timestamp="1234567890.000100"
+    )
+    assert result is None  # Slack reactions_add doesn't return an ID
+
+
+async def test_remove_reaction(channel):
+    """remove_reaction calls reactions_remove with correct params."""
+    channel._web_client.reactions_remove = AsyncMock(return_value={"ok": True})
+
+    await channel.remove_reaction("C1", "1234567890.000100", "eyes")
+
+    channel._web_client.reactions_remove.assert_called_once_with(
+        channel="C1", name="eyes", timestamp="1234567890.000100"
+    )
+
+
+async def test_platform_message_id_populated(channel, mock_response_cls):
+    """platform_message_id should be set to ts from the event."""
+    received: list[IncomingMessage] = []
+
+    async def cb(msg: IncomingMessage) -> None:
+        received.append(msg)
+
+    channel._callback = cb
+
+    client = AsyncMock()
+    req = _make_socket_request(text="hello", ts="9999.1234")
+    await channel._on_request(client, req)
+
+    assert len(received) == 1
+    assert received[0].platform_message_id == "9999.1234"


### PR DESCRIPTION
## Summary

Replace the "Working on it..." text message with instant emoji reactions (👀 → ✅) for bot message processing feedback. The reaction is added **before** the per-conversation lock, so users get immediate visual feedback even when a previous message is still processing.

## Scope

- Goals: instant feedback via emoji reactions, no chat history pollution
- Non-goals: configurable emoji, reaction-based flow control

## Invariants (Must Not Regress)

- [x] Slash commands (/new, /help, /status, etc.) still work without reactions
- [x] Agent response is still sent as a text message
- [x] Error handling still sends error message to user
- [x] File/image attachments still processed correctly
- [x] Reaction failures never block message processing

## Acceptance Criteria

- [x] 👀 reaction appears instantly on user message (before lock)
- [x] 👀 removed and ✅ added after processing completes
- [x] 👀 cleaned up on error before error message sent
- [x] Empty `platform_message_id` → no reaction calls (graceful skip)
- [x] Exception in `add_reaction`/`remove_reaction` → processing continues

## Test Plan

- [x] `./scripts/dev.sh test -q` — 599 passed, 1 skipped
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues
- [x] `./scripts/dev.sh check` — all green

### New tests added:
- `test_no_platform_id_skips_reactions` — empty platform_message_id skips reactions
- `test_reaction_failure_does_not_block` — add_reaction exception doesn't block processing
- `test_add_reaction` / `test_remove_reaction` (Slack) — correct API calls
- `test_platform_message_id_populated` (Slack + Lark) — field set from event
- `test_add_reaction_calls_api` / `test_remove_reaction_calls_api` (Lark) — correct API calls
- `test_remove_reaction_skips_without_reaction_id` (Lark) — no-op without ID

## Smoke Run (Real CLI)

Manual smoke test with real Slack/Lark needed — requires `reactions:write` (Slack) / `im:message.reactions:write_as_bot` (Lark) permissions.

## Adversarial Review

- **What existing behavior could this break?** Channels missing `add_reaction`/`remove_reaction` — mitigated by Protocol extension + all implementations in-tree.
- **Worst-case input/output size?** Reactions are single API calls, no size concerns.
- **Any secrets/logging risks?** No — only emoji names logged at debug level.
- **Any async/blocking I/O added on hot paths?** Lark reactions use `asyncio.to_thread` (same pattern as existing `send_message`). Slack reactions are natively async.
- **What error message does the user see on failure?** None — reaction failures are silently logged, processing continues.

## Docs / Compatibility

- [x] Updated `bot/LARK.md` and `bot/SLACK.md` with new permission scopes and updated test instructions
- [x] No secrets committed

### Required Platform Permissions (User Action)

| Platform | New Scope | Where to Add |
|----------|-----------|-------------|
| Slack | `reactions:write` | App → OAuth & Permissions → Bot Token Scopes |
| Lark | `im:message.reactions:write_as_bot` | 飞书开放平台 → 应用权限 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)