### PR TITLE
feat(llm): add GitHub Copilot subscription as an OAuth provider

### DIFF
--- a/llm/chatgpt_auth.py
+++ b/llm/chatgpt_auth.py
@@ -20,7 +20,7 @@ import webbrowser
 from contextlib import suppress
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import aiofiles
 import aiofiles.os
@@ -28,10 +28,17 @@ import httpx
 
 from utils.runtime import get_runtime_dir
 
+if TYPE_CHECKING:
+    from .copilot_auth import CopilotAuthStatus
+
 _AUTH_PROVIDER_ALIASES = {
     "chatgpt": "chatgpt",
     "codex": "chatgpt",
     "openai-codex": "chatgpt",
+    "copilot": "copilot",
+    "github": "copilot",
+    "github-copilot": "copilot",
+    "github_copilot": "copilot",
 }
 
 CHATGPT_OAUTH_AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
@@ -74,10 +81,10 @@ def normalize_auth_provider(provider: str | None) -> str | None:
 
 
 def get_supported_auth_providers() -> tuple[str, ...]:
-    return ("chatgpt",)
+    return ("chatgpt", "copilot")
 
 
-def is_auth_status_logged_in(status: ChatGPTAuthStatus) -> bool:
+def is_auth_status_logged_in(status: ChatGPTAuthStatus | CopilotAuthStatus) -> bool:
     """Whether local auth state looks usable for requests."""
     return status.exists and status.has_access_token
 
@@ -794,7 +801,7 @@ async def get_chatgpt_auth_status() -> ChatGPTAuthStatus:
     )
 
 
-async def get_auth_provider_status(provider: str) -> ChatGPTAuthStatus:
+async def get_auth_provider_status(provider: str) -> ChatGPTAuthStatus | CopilotAuthStatus:
     """Get auth status for a supported provider."""
     normalized = normalize_auth_provider(provider)
     if not normalized:
@@ -802,19 +809,23 @@ async def get_auth_provider_status(provider: str) -> ChatGPTAuthStatus:
 
     if normalized == "chatgpt":
         return await get_chatgpt_auth_status()
+    if normalized == "copilot":
+        from .copilot_auth import get_copilot_auth_status
+
+        return await get_copilot_auth_status()
 
     raise ValueError(f"Unsupported provider: {provider}")
 
 
-async def get_all_auth_provider_statuses() -> dict[str, ChatGPTAuthStatus]:
+async def get_all_auth_provider_statuses() -> dict[str, ChatGPTAuthStatus | CopilotAuthStatus]:
     """Get auth statuses for all supported providers."""
-    statuses: dict[str, ChatGPTAuthStatus] = {}
+    statuses: dict[str, ChatGPTAuthStatus | CopilotAuthStatus] = {}
     for provider in get_supported_auth_providers():
         statuses[provider] = await get_auth_provider_status(provider)
     return statuses
 
 
-async def login_auth_provider(provider: str) -> ChatGPTAuthStatus:
+async def login_auth_provider(provider: str) -> ChatGPTAuthStatus | CopilotAuthStatus:
     """Login to a supported provider."""
     normalized = normalize_auth_provider(provider)
     if not normalized:
@@ -822,6 +833,10 @@ async def login_auth_provider(provider: str) -> ChatGPTAuthStatus:
 
     if normalized == "chatgpt":
         return await login_chatgpt()
+    if normalized == "copilot":
+        from .copilot_auth import login_copilot
+
+        return await login_copilot()
 
     raise ValueError(f"Unsupported provider: {provider}")
 
@@ -834,5 +849,9 @@ async def logout_auth_provider(provider: str) -> bool:
 
     if normalized == "chatgpt":
         return await logout_chatgpt()
+    if normalized == "copilot":
+        from .copilot_auth import logout_copilot
+
+        return await logout_copilot()
 
     raise ValueError(f"Unsupported provider: {provider}")

--- a/llm/copilot_auth.py
+++ b/llm/copilot_auth.py
@@ -1,0 +1,376 @@
+"""GitHub Copilot subscription auth helpers (LiteLLM-compatible token layout).
+
+This module keeps Copilot OAuth credentials under ``~/.ouro/auth/copilot`` and
+mirrors the on-disk format LiteLLM's `github_copilot` provider expects:
+
+- ``access-token``: plain-text GitHub OAuth access token (from device flow).
+- ``api-key.json``: short-lived Copilot API key + endpoints map.
+
+At request time LiteLLM's Authenticator auto-refreshes ``api-key.json`` from the
+access token, so we only need to establish (and persist) the GitHub access token
+here. Pointing ``GITHUB_COPILOT_TOKEN_DIR`` at our directory makes LiteLLM read
+and write those files in-place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any
+
+import aiofiles
+import aiofiles.os
+import httpx
+
+from utils.runtime import get_runtime_dir
+
+GITHUB_CLIENT_ID = "Iv1.b507a08c87ecfe98"
+GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code"
+GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_COPILOT_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token"
+GITHUB_OAUTH_SCOPE = "read:user"
+
+COPILOT_DEFAULT_POLL_INTERVAL_SECONDS = 5
+COPILOT_DEFAULT_POLL_ATTEMPTS = 60  # 5 min @ 5s
+COPILOT_HTTP_TIMEOUT_SECONDS = 30
+COPILOT_ERROR_BODY_LIMIT = 2000
+
+
+@dataclass
+class CopilotAuthStatus:
+    provider: str
+    auth_file: str
+    exists: bool
+    has_access_token: bool
+    account_id: str | None
+    expires_at: int | None
+    expired: bool | None
+
+
+class CopilotLoginRequiredError(RuntimeError):
+    """Raised when a non-interactive caller needs user login."""
+
+
+def _normalize_token_dir(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path.strip()))
+
+
+def configure_copilot_auth_env() -> str:
+    """Configure Copilot auth dir for LiteLLM and return it.
+
+    LiteLLM's ``github_copilot`` authenticator reads ``GITHUB_COPILOT_TOKEN_DIR``
+    to locate the access-token / api-key files on disk. Point it at ouro's own
+    runtime dir so local state stays under ``~/.ouro/auth/copilot``.
+    """
+    token_dir = os.environ.get("GITHUB_COPILOT_TOKEN_DIR")
+    if token_dir and token_dir.strip():
+        normalized = _normalize_token_dir(token_dir)
+        os.environ["GITHUB_COPILOT_TOKEN_DIR"] = normalized
+        return normalized
+
+    token_dir = _normalize_token_dir(os.path.join(get_runtime_dir(), "auth", "copilot"))
+    os.environ["GITHUB_COPILOT_TOKEN_DIR"] = token_dir
+    return token_dir
+
+
+def _get_access_token_path() -> str:
+    token_dir = configure_copilot_auth_env()
+    filename = os.environ.get("GITHUB_COPILOT_ACCESS_TOKEN_FILE", "access-token")
+    return os.path.join(token_dir, filename)
+
+
+def _get_api_key_path() -> str:
+    token_dir = configure_copilot_auth_env()
+    filename = os.environ.get("GITHUB_COPILOT_API_KEY_FILE", "api-key.json")
+    return os.path.join(token_dir, filename)
+
+
+async def _ensure_auth_dir() -> None:
+    token_dir = configure_copilot_auth_env()
+    await aiofiles.os.makedirs(token_dir, exist_ok=True)
+    with suppress(OSError):
+        await asyncio.to_thread(os.chmod, token_dir, 0o700)
+
+
+async def _path_exists(path: str) -> bool:
+    try:
+        await aiofiles.os.stat(path)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+async def _read_text(path: str) -> str | None:
+    if not await _path_exists(path):
+        return None
+    try:
+        async with aiofiles.open(path, encoding="utf-8") as f:
+            return (await f.read()).strip()
+    except OSError:
+        return None
+
+
+async def _write_text(path: str, content: str) -> None:
+    async with aiofiles.open(path, "w", encoding="utf-8") as f:
+        await f.write(content)
+    with suppress(OSError):
+        await asyncio.to_thread(os.chmod, path, 0o600)
+
+
+async def _read_json(path: str) -> dict[str, Any] | None:
+    text = await _read_text(path)
+    if text is None:
+        return None
+    try:
+        data = json.loads(text)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def _parse_expires_at(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str):
+        with suppress(ValueError):
+            return int(float(value))
+    return None
+
+
+def _copilot_user_agent() -> str:
+    return "ouro/1.0 (github-copilot)"
+
+
+def _github_headers(access_token: str | None = None) -> dict[str, str]:
+    headers = {
+        "accept": "application/json",
+        "editor-version": "vscode/1.95.0",
+        "editor-plugin-version": "copilot-chat/0.26.7",
+        "user-agent": _copilot_user_agent(),
+        "accept-encoding": "gzip,deflate,br",
+        "content-type": "application/json",
+    }
+    if access_token:
+        headers["authorization"] = f"token {access_token}"
+    return headers
+
+
+def _get_http_timeout_seconds() -> float:
+    raw = (os.environ.get("OURO_COPILOT_HTTP_TIMEOUT_SECONDS") or "").strip()
+    if not raw:
+        return float(COPILOT_HTTP_TIMEOUT_SECONDS)
+    with suppress(ValueError):
+        value = float(raw)
+        if value > 0:
+            return value
+    return float(COPILOT_HTTP_TIMEOUT_SECONDS)
+
+
+def _http_error_details(exc: httpx.HTTPStatusError) -> str:
+    response = exc.response
+    if response is None:
+        return str(exc)
+    status = response.status_code
+    body = ""
+    with suppress(Exception):
+        body = (response.text or "").strip()
+    if len(body) > COPILOT_ERROR_BODY_LIMIT:
+        body = body[:COPILOT_ERROR_BODY_LIMIT] + "…"
+    return f"HTTP {status}: {body}" if body else f"HTTP {status}"
+
+
+async def _request_device_code() -> dict[str, Any]:
+    timeout = httpx.Timeout(_get_http_timeout_seconds())
+    async with httpx.AsyncClient(timeout=timeout, headers=_github_headers()) as client:
+        try:
+            resp = await client.post(
+                GITHUB_DEVICE_CODE_URL,
+                json={"client_id": GITHUB_CLIENT_ID, "scope": GITHUB_OAUTH_SCOPE},
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(
+                f"Copilot device code request failed: {_http_error_details(exc)}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"Copilot device code request failed: {exc}") from exc
+
+        data = resp.json()
+
+    required = ("device_code", "user_code", "verification_uri")
+    missing = [f for f in required if not data.get(f)]
+    if missing:
+        raise RuntimeError(f"Device code response missing fields: {', '.join(missing)}")
+    return data
+
+
+async def _poll_for_github_access_token(
+    *, device_code: str, interval: int, max_attempts: int
+) -> str:
+    timeout = httpx.Timeout(_get_http_timeout_seconds())
+    async with httpx.AsyncClient(timeout=timeout, headers=_github_headers()) as client:
+        for _ in range(max_attempts):
+            try:
+                resp = await client.post(
+                    GITHUB_ACCESS_TOKEN_URL,
+                    json={
+                        "client_id": GITHUB_CLIENT_ID,
+                        "device_code": device_code,
+                        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    },
+                )
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise RuntimeError(
+                    f"Copilot token poll failed: {_http_error_details(exc)}"
+                ) from exc
+            except httpx.RequestError as exc:
+                raise RuntimeError(f"Copilot token poll failed: {exc}") from exc
+
+            body = resp.json()
+            access_token = body.get("access_token")
+            if isinstance(access_token, str) and access_token:
+                return access_token
+
+            error = body.get("error")
+            if error == "authorization_pending":
+                await asyncio.sleep(interval)
+                continue
+            if error == "slow_down":
+                interval = min(interval + 5, 60)
+                await asyncio.sleep(interval)
+                continue
+            if error in {"access_denied", "expired_token"}:
+                raise RuntimeError(f"Copilot login aborted: {error}")
+            if error:
+                raise RuntimeError(f"Copilot login error: {error}")
+
+            await asyncio.sleep(interval)
+
+    raise RuntimeError("Timed out waiting for the user to authorize the device.")
+
+
+async def _fetch_copilot_api_key(access_token: str) -> dict[str, Any]:
+    """Exchange a GitHub access token for a Copilot API key record.
+
+    Also persists the record at ``api-key.json`` so LiteLLM's authenticator can
+    reuse it on subsequent calls without a round-trip.
+    """
+    timeout = httpx.Timeout(_get_http_timeout_seconds())
+    async with httpx.AsyncClient(
+        timeout=timeout, headers=_github_headers(access_token)
+    ) as client:
+        try:
+            resp = await client.get(GITHUB_COPILOT_API_KEY_URL)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise RuntimeError(
+                f"Copilot API key request failed: {_http_error_details(exc)}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"Copilot API key request failed: {exc}") from exc
+
+        data = resp.json()
+
+    if not isinstance(data, dict) or not data.get("token"):
+        raise RuntimeError("Copilot API key response missing token.")
+
+    await _write_text(_get_api_key_path(), json.dumps(data))
+    return data
+
+
+async def _run_device_code_login(
+    *,
+    interval: int = COPILOT_DEFAULT_POLL_INTERVAL_SECONDS,
+    max_attempts: int = COPILOT_DEFAULT_POLL_ATTEMPTS,
+) -> str:
+    """Run the GitHub device code flow and persist the access token.
+
+    Returns the GitHub access token (also written to ``access-token``).
+    """
+    device = await _request_device_code()
+    user_code = device["user_code"]
+    verification_uri = device["verification_uri"]
+    interval = int(device.get("interval") or interval)
+
+    print(  # noqa: T201
+        "To authorize Copilot, visit "
+        f"{verification_uri} and enter code {user_code}.\n"
+        "Waiting for authorization (Ctrl+C to cancel)...",
+        flush=True,
+    )
+
+    access_token = await _poll_for_github_access_token(
+        device_code=device["device_code"], interval=interval, max_attempts=max_attempts
+    )
+    await _write_text(_get_access_token_path(), access_token)
+
+    # Warm the Copilot API key record so the first completion call doesn't stall
+    # waiting for LiteLLM to synchronously refresh.
+    with suppress(Exception):
+        await _fetch_copilot_api_key(access_token)
+
+    return access_token
+
+
+async def ensure_copilot_access_token(*, interactive: bool) -> str:
+    """Ensure a GitHub access token exists on disk for LiteLLM.
+
+    Unlike the ChatGPT flow, GitHub OAuth device tokens do not include a refresh
+    token: once the access token is revoked, the user must re-run login. This
+    helper only triggers the device-code flow when no token is present.
+    """
+    await _ensure_auth_dir()
+    access_token = await _read_text(_get_access_token_path())
+    if access_token:
+        return access_token
+
+    if not interactive:
+        raise CopilotLoginRequiredError("GitHub Copilot is not logged in.")
+
+    return await _run_device_code_login()
+
+
+async def login_copilot() -> CopilotAuthStatus:
+    """Run the GitHub device code flow for Copilot and return status."""
+    await _ensure_auth_dir()
+    await _run_device_code_login()
+    return await get_copilot_auth_status()
+
+
+async def logout_copilot() -> bool:
+    """Remove persisted Copilot credentials. Returns True if something was removed."""
+    removed_any = False
+    for path in (_get_access_token_path(), _get_api_key_path()):
+        if await _path_exists(path):
+            await aiofiles.os.remove(path)
+            removed_any = True
+    return removed_any
+
+
+async def get_copilot_auth_status() -> CopilotAuthStatus:
+    """Inspect local Copilot auth state."""
+    await _ensure_auth_dir()
+    access_token = await _read_text(_get_access_token_path())
+    api_key = await _read_json(_get_api_key_path())
+
+    exists = bool(access_token) or bool(api_key)
+    has_access_token = bool(access_token)
+    expires_at = _parse_expires_at((api_key or {}).get("expires_at"))
+    expired = None if expires_at is None else time.time() >= expires_at
+
+    return CopilotAuthStatus(
+        provider="copilot",
+        auth_file=_get_access_token_path(),
+        exists=exists,
+        has_access_token=has_access_token,
+        account_id=None,
+        expires_at=expires_at,
+        expired=expired,
+    )

--- a/llm/copilot_auth.py
+++ b/llm/copilot_auth.py
@@ -263,9 +263,7 @@ async def _fetch_copilot_api_key(access_token: str) -> dict[str, Any]:
     reuse it on subsequent calls without a round-trip.
     """
     timeout = httpx.Timeout(_get_http_timeout_seconds())
-    async with httpx.AsyncClient(
-        timeout=timeout, headers=_github_headers(access_token)
-    ) as client:
+    async with httpx.AsyncClient(timeout=timeout, headers=_github_headers(access_token)) as client:
         try:
             resp = await client.get(GITHUB_COPILOT_API_KEY_URL)
             resp.raise_for_status()

--- a/llm/litellm_adapter.py
+++ b/llm/litellm_adapter.py
@@ -51,6 +51,10 @@ class LiteLLMAdapter:
             from .chatgpt_auth import configure_chatgpt_auth_env
 
             configure_chatgpt_auth_env()
+        elif self.provider == "github_copilot":
+            from .copilot_auth import configure_copilot_auth_env
+
+            configure_copilot_auth_env()
 
         logger.info(f"Initialized LiteLLM adapter for provider: {self.provider}, model: {model}")
 
@@ -100,19 +104,38 @@ class LiteLLMAdapter:
 
         await ensure_chatgpt_access_token(interactive=False)
 
+    @with_retry()
+    async def _ensure_copilot_access_token_with_retry(self) -> None:
+        from .copilot_auth import ensure_copilot_access_token
+
+        await ensure_copilot_access_token(interactive=False)
+
     async def _ensure_provider_ready(self) -> None:
-        if self.provider != "chatgpt":
+        if self.provider == "chatgpt":
+            from .chatgpt_auth import ChatGPTLoginRequiredError, configure_chatgpt_auth_env
+
+            configure_chatgpt_auth_env()
+            try:
+                await self._ensure_chatgpt_access_token_with_retry()
+            except ChatGPTLoginRequiredError as e:
+                raise RuntimeError(
+                    "ChatGPT is not logged in (or your session expired). "
+                    "Run `/login` to authenticate."
+                ) from e
             return
 
-        from .chatgpt_auth import ChatGPTLoginRequiredError, configure_chatgpt_auth_env
+        if self.provider == "github_copilot":
+            from .copilot_auth import CopilotLoginRequiredError, configure_copilot_auth_env
 
-        configure_chatgpt_auth_env()
-        try:
-            await self._ensure_chatgpt_access_token_with_retry()
-        except ChatGPTLoginRequiredError as e:
-            raise RuntimeError(
-                "ChatGPT is not logged in (or your session expired). Run `/login` to authenticate."
-            ) from e
+            configure_copilot_auth_env()
+            try:
+                await self._ensure_copilot_access_token_with_retry()
+            except CopilotLoginRequiredError as e:
+                raise RuntimeError(
+                    "GitHub Copilot is not logged in. "
+                    "Run `/login` and choose `copilot` to authenticate."
+                ) from e
+            return
 
     @with_retry()
     async def _make_api_call_async(self, **call_params):

--- a/llm/model_manager.py
+++ b/llm/model_manager.py
@@ -253,7 +253,7 @@ class ModelManager:
         if not model.model_id:
             return False, "Model ID is missing."
         if (
-            model.provider not in {"ollama", "localhost", "chatgpt"}
+            model.provider not in {"ollama", "localhost", "chatgpt", "github_copilot"}
             and not _is_local_api_base(model.api_base)
             and not (model.api_key or "").strip()
         ):

--- a/llm/oauth_model_catalog.py
+++ b/llm/oauth_model_catalog.py
@@ -2,9 +2,15 @@
 
 This file is intentionally deterministic and runtime-offline.
 
-To refresh from pi-ai's latest published model registry, run:
+To refresh the chatgpt provider from pi-ai's latest published model registry, run:
 
     python scripts/update_oauth_model_catalog.py
+
+The copilot provider list is curated manually from GitHub's supported-models
+reference. Refresh from:
+    https://docs.github.com/en/copilot/reference/ai-models/supported-models
+Only chat-mode models are included; `/responses`-mode codex variants are omitted
+because the adapter routes through LiteLLM's `acompletion` endpoint.
 """
 
 from __future__ import annotations
@@ -14,6 +20,8 @@ PI_AI_PROVIDER_ID = "openai-codex"
 
 # Synced from pi-ai openai-codex provider model IDs, filtered to those supported by
 # the pinned LiteLLM chatgpt provider, and mapped to ouro's chatgpt/* namespace.
+# Copilot entries target LiteLLM's built-in `github_copilot/*` namespace and cover
+# the chat-capable models exposed to Copilot subscribers.
 OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {
     "chatgpt": (
         "chatgpt/gpt-5.1",
@@ -21,6 +29,23 @@ OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {
         "chatgpt/gpt-5.1-codex-mini",
         "chatgpt/gpt-5.2",
         "chatgpt/gpt-5.2-codex",
+    ),
+    "copilot": (
+        # Anthropic (GA)
+        "github_copilot/claude-opus-4.7",
+        "github_copilot/claude-opus-4.6",
+        "github_copilot/claude-sonnet-4.6",
+        "github_copilot/claude-sonnet-4.5",
+        "github_copilot/claude-haiku-4.5",
+        # OpenAI (GA)
+        "github_copilot/gpt-5.4",
+        "github_copilot/gpt-5.4-mini",
+        "github_copilot/gpt-5.2",
+        # Google (GA + preview)
+        "github_copilot/gemini-2.5-pro",
+        "github_copilot/gemini-3.1-pro",
+        # xAI (GA)
+        "github_copilot/grok-code-fast-1",
     ),
 }
 

--- a/test/test_copilot_auth.py
+++ b/test/test_copilot_auth.py
@@ -1,0 +1,280 @@
+import json
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from llm.chatgpt_auth import (
+    get_all_auth_provider_statuses,
+    get_auth_provider_status,
+    get_supported_auth_providers,
+    is_auth_status_logged_in,
+    login_auth_provider,
+    logout_auth_provider,
+    normalize_auth_provider,
+)
+from llm.copilot_auth import (
+    CopilotAuthStatus,
+    CopilotLoginRequiredError,
+    _fetch_copilot_api_key,
+    _get_access_token_path,
+    _get_api_key_path,
+    _poll_for_github_access_token,
+    configure_copilot_auth_env,
+    ensure_copilot_access_token,
+    get_copilot_auth_status,
+    login_copilot,
+    logout_copilot,
+)
+
+
+def _seed_auth_dir(monkeypatch, tmp_path) -> Path:
+    auth_dir = tmp_path / "copilot-auth"
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN_DIR", str(auth_dir))
+    return auth_dir
+
+
+def test_normalize_auth_provider_includes_copilot():
+    assert normalize_auth_provider("copilot") == "copilot"
+    assert normalize_auth_provider("github") == "copilot"
+    assert normalize_auth_provider("github-copilot") == "copilot"
+    assert normalize_auth_provider("github_copilot") == "copilot"
+
+
+def test_get_supported_auth_providers_lists_copilot():
+    providers = get_supported_auth_providers()
+    assert "copilot" in providers
+    assert "chatgpt" in providers
+
+
+def test_configure_copilot_auth_env_uses_runtime_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_COPILOT_TOKEN_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # get_runtime_dir reads HOME at call time via os.path.expanduser
+    monkeypatch.setattr(
+        "llm.copilot_auth.get_runtime_dir", lambda: str(tmp_path / ".ouro")
+    )
+
+    token_dir = configure_copilot_auth_env()
+
+    assert token_dir.endswith("auth/copilot")
+    assert token_dir.startswith(str(tmp_path))
+
+
+def test_configure_copilot_auth_env_honors_override(tmp_path, monkeypatch):
+    override = str(tmp_path / "custom")
+    monkeypatch.setenv("GITHUB_COPILOT_TOKEN_DIR", override)
+
+    token_dir = configure_copilot_auth_env()
+
+    assert token_dir == override
+
+
+async def test_get_status_when_auth_file_missing(tmp_path, monkeypatch):
+    _seed_auth_dir(monkeypatch, tmp_path)
+
+    status = await get_copilot_auth_status()
+
+    assert isinstance(status, CopilotAuthStatus)
+    assert status.provider == "copilot"
+    assert status.exists is False
+    assert status.has_access_token is False
+    assert status.expired is None
+
+
+async def test_get_status_from_existing_tokens(tmp_path, monkeypatch):
+    auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
+    (auth_dir / "access-token").write_text("gh_access_xyz", encoding="utf-8")
+    (auth_dir / "api-key.json").write_text(
+        json.dumps({"token": "ck_abc", "expires_at": int(time.time()) + 1800}),
+        encoding="utf-8",
+    )
+
+    status = await get_copilot_auth_status()
+
+    assert status.exists is True
+    assert status.has_access_token is True
+    assert status.expired is False
+    assert is_auth_status_logged_in(status)
+
+
+async def test_get_status_reports_expired(tmp_path, monkeypatch):
+    auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
+    (auth_dir / "access-token").write_text("gh_access_xyz", encoding="utf-8")
+    (auth_dir / "api-key.json").write_text(
+        json.dumps({"token": "ck_abc", "expires_at": int(time.time()) - 60}),
+        encoding="utf-8",
+    )
+
+    status = await get_copilot_auth_status()
+
+    assert status.has_access_token is True
+    assert status.expired is True
+
+
+async def test_logout_removes_token_files(tmp_path, monkeypatch):
+    auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
+    (auth_dir / "access-token").write_text("gh_access_xyz", encoding="utf-8")
+    (auth_dir / "api-key.json").write_text(
+        json.dumps({"token": "ck_abc"}), encoding="utf-8"
+    )
+
+    removed = await logout_copilot()
+
+    assert removed is True
+    assert not (auth_dir / "access-token").exists()
+    assert not (auth_dir / "api-key.json").exists()
+
+    # Idempotent: second logout reports nothing to remove.
+    assert await logout_copilot() is False
+
+
+async def test_ensure_access_token_reuses_existing_file(tmp_path, monkeypatch):
+    auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
+    (auth_dir / "access-token").write_text("gh_access_existing", encoding="utf-8")
+
+    called = {"login": 0}
+
+    async def fake_login(**_kwargs):
+        called["login"] += 1
+        return "should-not-run"
+
+    monkeypatch.setattr("llm.copilot_auth._run_device_code_login", fake_login)
+
+    token = await ensure_copilot_access_token(interactive=False)
+
+    assert token == "gh_access_existing"
+    assert called["login"] == 0
+
+
+async def test_ensure_access_token_non_interactive_requires_login(tmp_path, monkeypatch):
+    _seed_auth_dir(monkeypatch, tmp_path)
+
+    with pytest.raises(CopilotLoginRequiredError):
+        await ensure_copilot_access_token(interactive=False)
+
+
+async def test_login_runs_device_code_flow_and_persists_token(tmp_path, monkeypatch):
+    auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
+    called = {"login": 0}
+
+    async def fake_login(**_kwargs):
+        called["login"] += 1
+        (auth_dir / "access-token").write_text("gh_access_new", encoding="utf-8")
+        return "gh_access_new"
+
+    monkeypatch.setattr("llm.copilot_auth._run_device_code_login", fake_login)
+
+    status = await login_copilot()
+
+    assert called["login"] == 1
+    assert status.exists is True
+    assert status.has_access_token is True
+    assert Path(_get_access_token_path()).read_text(encoding="utf-8") == "gh_access_new"
+
+
+async def test_provider_dispatch_routes_copilot(tmp_path, monkeypatch):
+    _seed_auth_dir(monkeypatch, tmp_path)
+
+    async def fake_login(**_kwargs):
+        auth_file = Path(_get_access_token_path())
+        auth_file.parent.mkdir(parents=True, exist_ok=True)
+        auth_file.write_text("gh_dispatch_token", encoding="utf-8")
+        return "gh_dispatch_token"
+
+    monkeypatch.setattr("llm.copilot_auth._run_device_code_login", fake_login)
+
+    status = await login_auth_provider("copilot")
+    assert isinstance(status, CopilotAuthStatus)
+
+    status_via_alias = await get_auth_provider_status("github")
+    assert isinstance(status_via_alias, CopilotAuthStatus)
+    assert status_via_alias.has_access_token is True
+
+    removed = await logout_auth_provider("copilot")
+    assert removed is True
+
+
+async def test_get_all_auth_provider_statuses_includes_copilot(tmp_path, monkeypatch):
+    _seed_auth_dir(monkeypatch, tmp_path)
+    # Also isolate chatgpt state so the test doesn't see real logins.
+    monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(tmp_path / "chatgpt-auth"))
+
+    statuses = await get_all_auth_provider_statuses()
+
+    assert set(statuses.keys()) == {"chatgpt", "copilot"}
+    assert statuses["copilot"].provider == "copilot"
+    assert statuses["copilot"].exists is False
+
+
+async def test_poll_honors_slow_down_and_returns_token(tmp_path, monkeypatch):
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr("llm.copilot_auth.asyncio.sleep", fake_sleep)
+
+    responses = [
+        httpx.Response(200, json={"error": "authorization_pending"}),
+        httpx.Response(200, json={"error": "slow_down"}),
+        httpx.Response(200, json={"access_token": "gh_polled"}),
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:  # noqa: ARG001
+        return responses.pop(0)
+
+    transport = httpx.MockTransport(handler)
+
+    async def fake_async_client(*args, **kwargs):  # noqa: ARG001
+        return httpx.AsyncClient(transport=transport, **{k: v for k, v in kwargs.items() if k != "transport"})
+
+    # Patch httpx.AsyncClient constructor used inside _poll_for_github_access_token.
+    original = httpx.AsyncClient
+
+    class _PatchedClient(original):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("llm.copilot_auth.httpx.AsyncClient", _PatchedClient)
+
+    token = await _poll_for_github_access_token(
+        device_code="dev_123", interval=1, max_attempts=5
+    )
+
+    assert token == "gh_polled"
+    # At least one authorization_pending + one slow_down wait.
+    assert len(sleeps) >= 2
+
+
+async def test_fetch_copilot_api_key_writes_record(tmp_path, monkeypatch):
+    _seed_auth_dir(monkeypatch, tmp_path)
+
+    expected_record = {
+        "token": "ck_from_github",
+        "expires_at": int(time.time()) + 1800,
+        "endpoints": {"api": "https://api.githubcopilot.com"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "token gh_access"
+        return httpx.Response(200, json=expected_record)
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.AsyncClient
+
+    class _PatchedClient(original):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("llm.copilot_auth.httpx.AsyncClient", _PatchedClient)
+
+    record = await _fetch_copilot_api_key("gh_access")
+
+    assert record["token"] == expected_record["token"]
+    on_disk = json.loads(Path(_get_api_key_path()).read_text(encoding="utf-8"))
+    assert on_disk["token"] == expected_record["token"]

--- a/test/test_copilot_auth.py
+++ b/test/test_copilot_auth.py
@@ -53,9 +53,7 @@ def test_configure_copilot_auth_env_uses_runtime_dir(tmp_path, monkeypatch):
     monkeypatch.delenv("GITHUB_COPILOT_TOKEN_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
     # get_runtime_dir reads HOME at call time via os.path.expanduser
-    monkeypatch.setattr(
-        "llm.copilot_auth.get_runtime_dir", lambda: str(tmp_path / ".ouro")
-    )
+    monkeypatch.setattr("llm.copilot_auth.get_runtime_dir", lambda: str(tmp_path / ".ouro"))
 
     token_dir = configure_copilot_auth_env()
 
@@ -117,9 +115,7 @@ async def test_get_status_reports_expired(tmp_path, monkeypatch):
 async def test_logout_removes_token_files(tmp_path, monkeypatch):
     auth_dir = _seed_auth_dir(monkeypatch, tmp_path)
     (auth_dir / "access-token").write_text("gh_access_xyz", encoding="utf-8")
-    (auth_dir / "api-key.json").write_text(
-        json.dumps({"token": "ck_abc"}), encoding="utf-8"
-    )
+    (auth_dir / "api-key.json").write_text(json.dumps({"token": "ck_abc"}), encoding="utf-8")
 
     removed = await logout_copilot()
 
@@ -229,7 +225,9 @@ async def test_poll_honors_slow_down_and_returns_token(tmp_path, monkeypatch):
     transport = httpx.MockTransport(handler)
 
     async def fake_async_client(*args, **kwargs):  # noqa: ARG001
-        return httpx.AsyncClient(transport=transport, **{k: v for k, v in kwargs.items() if k != "transport"})
+        return httpx.AsyncClient(
+            transport=transport, **{k: v for k, v in kwargs.items() if k != "transport"}
+        )
 
     # Patch httpx.AsyncClient constructor used inside _poll_for_github_access_token.
     original = httpx.AsyncClient
@@ -241,9 +239,7 @@ async def test_poll_honors_slow_down_and_returns_token(tmp_path, monkeypatch):
 
     monkeypatch.setattr("llm.copilot_auth.httpx.AsyncClient", _PatchedClient)
 
-    token = await _poll_for_github_access_token(
-        device_code="dev_123", interval=1, max_attempts=5
-    )
+    token = await _poll_for_github_access_token(device_code="dev_123", interval=1, max_attempts=5)
 
     assert token == "gh_polled"
     # At least one authorization_pending + one slow_down wait.

--- a/test/test_model_manager_chatgpt.py
+++ b/test/test_model_manager_chatgpt.py
@@ -25,6 +25,30 @@ def test_validate_chatgpt_model_without_api_key(tmp_path):
     assert error_message == ""
 
 
+def test_validate_copilot_model_without_api_key(tmp_path):
+    config_path = tmp_path / "models.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "models:",
+                "  github_copilot/claude-sonnet-4.5:",
+                "    timeout: 600",
+                "default: github_copilot/claude-sonnet-4.5",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    manager = ModelManager(config_path=str(config_path))
+    profile = manager.get_current_model()
+
+    assert profile is not None
+    is_valid, error_message = manager.validate_model(profile)
+    assert is_valid is True
+    assert error_message == ""
+
+
 def test_switch_model_persists_current_across_restart(tmp_path):
     config_path = tmp_path / "models.yaml"
     config_path.write_text(

--- a/test/test_oauth_model_catalog.py
+++ b/test/test_oauth_model_catalog.py
@@ -10,6 +10,15 @@ def test_chatgpt_catalog_includes_gpt52():
     assert "chatgpt/gpt-5.2-codex" in model_ids
 
 
+def test_copilot_catalog_includes_expected_models():
+    model_ids = get_oauth_provider_model_ids("copilot")
+
+    assert "github_copilot/claude-opus-4.7" in model_ids
+    assert "github_copilot/claude-sonnet-4.6" in model_ids
+    assert "github_copilot/gpt-5.4" in model_ids
+    assert all(mid.startswith("github_copilot/") for mid in model_ids)
+
+
 def test_catalog_rejects_unsupported_provider():
     with pytest.raises(ValueError, match="Unsupported provider"):
         get_oauth_provider_model_ids("unknown")


### PR DESCRIPTION
## Summary

Wires LiteLLM's `github_copilot` provider into ouro's YAML-first model selection UX so Copilot subscribers can log in via `/login` and use their included models (Claude, GPT-5.x, Gemini, Grok) without a separate API key.

- New `llm/copilot_auth.py` — async GitHub Device Code OAuth flow
- Tokens stored under `~/.ouro/auth/copilot/{access-token, api-key.json}`; `GITHUB_COPILOT_TOKEN_DIR` is pointed at the same dir so LiteLLM reuses the access token and auto-refreshes the short-lived Copilot API key
- Catalog curated from [GitHub's supported-models reference](https://docs.github.com/en/copilot/reference/ai-models/supported-models) (`claude-opus-4.7/4.6`, `claude-sonnet-4.6/4.5`, `claude-haiku-4.5`, `gpt-5.4/5.4-mini/5.2`, `gemini-2.5-pro`, `gemini-3.1-pro`, `grok-code-fast-1`)

## Scope

- Goals:
  - `/login` lists `copilot` alongside `chatgpt`; completing it seeds `~/.ouro/models.yaml` with `github_copilot/*` profiles
  - `/logout copilot` is idempotent and removes both the access token and cached API key
  - LiteLLM `acompletion` calls with a `github_copilot/*` model work after login without any per-request API key config
- Non-goals:
  - `/responses`-mode codex variants (`gpt-5.3-codex`, `gpt-5.1-codex-max`) — they don't flow through `acompletion` and need a separate adapter branch
  - Embedding models

## Invariants (Must Not Regress)

- [x] ChatGPT OAuth login/logout/status still works (see `test_chatgpt_auth.py`: 19 tests)
- [x] `sync_oauth_models(..., "chatgpt")` still seeds chatgpt entries and strips stale OAuth-managed models (`test_oauth_model_sync.py`)
- [x] `validate_model` still rejects non-OAuth providers without an API key
- [x] `/login` and `/logout` interactive flows still accept `chatgpt`
- [x] `main.py --login chatgpt` / `--logout chatgpt` still work (`test_main_auth_cli.py`)

## Acceptance Criteria

- [x] `get_supported_auth_providers()` returns `("chatgpt", "copilot")`
- [x] `normalize_auth_provider("copilot" | "github" | "github-copilot" | "github_copilot")` → `"copilot"`
- [x] `get_auth_provider_status("copilot")` / `login_auth_provider("copilot")` / `logout_auth_provider("copilot")` route to the new module
- [x] `github_copilot/*` models validate without `api_key`
- [x] LiteLLM adapter constructor and `_ensure_provider_ready` handle `github_copilot`

## Test Plan

- [x] Targeted: `./scripts/dev.sh test -q test/test_copilot_auth.py test/test_oauth_model_catalog.py test/test_model_manager_chatgpt.py test/test_oauth_model_sync.py` → **26 passed**
- [x] Related: `./scripts/dev.sh test -q test/test_chatgpt_auth.py test/test_litellm_adapter.py test/test_interactive_auth_commands.py test/test_main_auth_cli.py` → **56 passed**
- [x] Full: `./scripts/dev.sh check` → **604 passed, 1 skipped**
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` → no issues

## Smoke Run (Real CLI)

Not executed in CI: requires a real GitHub Copilot subscription. Manual smoke on a dev box would be:

```bash
python main.py --login          # pick `copilot`, visit verification URL, enter code
python main.py --task "hello" --verify   # uses github_copilot/<model> from models.yaml
python main.py --logout         # pick `copilot`
```

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?** ChatGPT dispatch is the biggest risk — the return type of `get_auth_provider_status` / `login_auth_provider` was widened to `ChatGPTAuthStatus | CopilotAuthStatus`. Callers only read shared attributes (`.exists`, `.has_access_token`, `.account_id`, `.auth_file`), and existing tests still pass.
- **Worst-case input/output size?** Device-code polling caps at 60 attempts × 5s = 5 min, bounded by `COPILOT_DEFAULT_POLL_ATTEMPTS`. HTTP bodies are truncated to 2000 chars in error messages.
- **Secrets/logging risks?** Access tokens are written with `0o600` and never logged. `_http_error_details` truncates response bodies but could still contain sensitive data — same pattern as `chatgpt_auth.py`.
- **Async/blocking I/O on hot paths?** LiteLLM's internal `github_copilot` authenticator is synchronous and runs inside `acompletion`; on a cold start it does a blocking refresh. Our login path pre-warms `api-key.json`, so the first request hits the cached key.
- **User-facing error on failure?** If token is missing at request time: `"GitHub Copilot is not logged in. Run `/login` and choose `copilot` to authenticate."` — actionable.

## Docs / Compatibility

- [x] No secrets committed
- [x] No generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)