### PR TITLE
feat(bot): show WeChat typing indicator while agent is working

### DIFF
--- a/bot/WECHAT.md
+++ b/bot/WECHAT.md
@@ -37,7 +37,7 @@ Once authenticated, anyone who sends a message to the bot's WeChat account will 
 ## Limitations
 
 - **Text only**: Currently only text messages are processed. Images, voice, video, and file attachments are ignored.
-- **No reactions**: WeChat does not support emoji reactions on messages, so the 👀/✅ processing indicators are not shown.
+- **No reactions**: WeChat does not support emoji reactions on messages, so the 👀/✅ processing indicators are not shown. Instead, the bot shows a native "typing…" hint in the conversation while ouro is working on a reply.
 - **No file sending**: The SDK does not support sending files/images back to users.
 - **Session expiry**: If the session expires (error code `-14`), the bot will need to re-authenticate. Restart the bot to trigger a new QR code.
 

--- a/bot/channel/base.py
+++ b/bot/channel/base.py
@@ -106,3 +106,15 @@ class Channel(Protocol):
     ) -> None:
         """Remove an emoji reaction from a message."""
         ...
+
+    async def send_typing(self, conversation_id: str) -> None:
+        """Show the 'typing…' indicator in a conversation. No-op where unsupported.
+
+        Implementations may need to be called repeatedly to keep the indicator
+        visible; ``BotServer`` refreshes periodically while the agent is busy.
+        """
+        ...
+
+    async def stop_typing(self, conversation_id: str) -> None:
+        """Clear the 'typing…' indicator. No-op where unsupported."""
+        ...

--- a/bot/channel/lark.py
+++ b/bot/channel/lark.py
@@ -116,6 +116,12 @@ class LarkChannel:
         if reaction_id:
             await asyncio.to_thread(self._delete_reaction_sync, message_id, reaction_id)
 
+    async def send_typing(self, conversation_id: str) -> None:
+        """Lark provides 👀 reactions as the processing indicator — no-op."""
+
+    async def stop_typing(self, conversation_id: str) -> None:
+        """Lark provides 👀 reactions as the processing indicator — no-op."""
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/bot/channel/slack.py
+++ b/bot/channel/slack.py
@@ -197,6 +197,12 @@ class SlackChannel:
         except Exception:
             logger.warning("Error removing Slack reaction", exc_info=True)
 
+    async def send_typing(self, conversation_id: str) -> None:
+        """Slack has no typing indicator via Socket Mode — no-op."""
+
+    async def stop_typing(self, conversation_id: str) -> None:
+        """Slack has no typing indicator via Socket Mode — no-op."""
+
     async def send_file(
         self,
         conversation_id: str,

--- a/bot/channel/wechat.py
+++ b/bot/channel/wechat.py
@@ -146,6 +146,37 @@ class WeChatChannel:
     ) -> None:
         """WeChat does not support message reactions — no-op."""
 
+    async def send_typing(self, conversation_id: str) -> None:
+        """Show 'typing…' to the WeChat user via the bot SDK.
+
+        The SDK caches a ``context_token`` per user when a message is received,
+        so this is only meaningful after at least one incoming message from the
+        target user. Errors are swallowed — typing is a UX hint, not
+        load-bearing.
+        """
+        await self._run_on_bot_loop("send_typing", conversation_id)
+
+    async def stop_typing(self, conversation_id: str) -> None:
+        """Clear the 'typing…' indicator for the WeChat user."""
+        await self._run_on_bot_loop("stop_typing", conversation_id)
+
+    async def _run_on_bot_loop(self, method: str, user_id: str) -> None:
+        """Invoke ``bot.<method>(user_id)`` on the SDK's own event loop."""
+        bot = self._bot
+        if bot is None:
+            return
+        fn = getattr(bot, method, None)
+        if fn is None:
+            return
+        try:
+            if self._bot_loop is not None and self._bot_loop.is_running():
+                future = asyncio.run_coroutine_threadsafe(fn(user_id), self._bot_loop)
+                await asyncio.to_thread(future.result, 15)
+            else:
+                await fn(user_id)
+        except Exception:
+            logger.debug("WeChat %s failed for %s", method, user_id, exc_info=True)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/bot/server.py
+++ b/bot/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import sys
 from typing import TYPE_CHECKING
@@ -450,6 +451,12 @@ class BotServer:
     _PROCESSING_EMOJI = "eyes"
     _DONE_EMOJI = "white_check_mark"
 
+    # How often to re-send a typing indicator while the agent is working.
+    # Channels like WeChat expire the hint after a few seconds, so we refresh
+    # periodically. Low enough to avoid visible gaps, high enough to keep the
+    # extra API traffic modest.
+    _TYPING_REFRESH_SECONDS = 4.0
+
     async def _process_message(self, channel: Channel, msg: IncomingMessage) -> None:
         """Command check -> 👀 reaction -> enqueue for debounced batch processing."""
         try:
@@ -551,9 +558,15 @@ class BotServer:
                 first.conversation_id,
                 task_text[:80],
             )
+            typing_task = asyncio.create_task(self._typing_loop(channel, first.conversation_id))
             try:
                 result = await agent.run(task_text, images=all_images or None)
             finally:
+                typing_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await typing_task
+                with contextlib.suppress(Exception):
+                    await channel.stop_typing(first.conversation_id)
                 if send_file_ctx is not None:
                     send_file_ctx.clear()
                 if tmp_dir is not None:
@@ -611,6 +624,22 @@ class BotServer:
             await coro
         except Exception:
             logger.debug("Reaction operation failed", exc_info=True)
+
+    async def _typing_loop(self, channel: Channel, conversation_id: str) -> None:
+        """Keep the 'typing…' indicator visible until cancelled.
+
+        Channels that don't support typing (Lark, Slack) see this as a stream
+        of no-ops, so it's safe to run unconditionally.
+        """
+        try:
+            while True:
+                try:
+                    await channel.send_typing(conversation_id)
+                except Exception:
+                    logger.debug("send_typing failed", exc_info=True)
+                await asyncio.sleep(self._TYPING_REFRESH_SECONDS)
+        except asyncio.CancelledError:
+            raise
 
     async def _periodic_cleanup(self) -> None:
         """Periodically delete stale sessions from disk."""

--- a/test/test_bot_server.py
+++ b/test/test_bot_server.py
@@ -32,6 +32,8 @@ class FakeChannel:
         self.sent_files: list[dict] = []
         self.reactions_added: list[tuple[str, str, str]] = []  # (conv_id, msg_id, emoji)
         self.reactions_removed: list[tuple[str, str, str, str | None]] = []
+        self.typing_starts: list[str] = []
+        self.typing_stops: list[str] = []
         self._callback = None
         self._started = False
         self._stopped = False
@@ -78,6 +80,12 @@ class FakeChannel:
         reaction_id: str | None = None,
     ) -> None:
         self.reactions_removed.append((conversation_id, message_id, emoji, reaction_id))
+
+    async def send_typing(self, conversation_id: str) -> None:
+        self.typing_starts.append(conversation_id)
+
+    async def stop_typing(self, conversation_id: str) -> None:
+        self.typing_stops.append(conversation_id)
 
     async def inject_message(self, msg: IncomingMessage) -> None:
         """Simulate an incoming message from the IM platform."""
@@ -188,6 +196,56 @@ async def test_process_message_error_sends_error_message(bot_server, fake_channe
 
     # Processing reaction should have been cleaned up
     assert any(r[:3] == ("conv_err", "ts_err", "eyes") for r in fake_channel.reactions_removed)
+
+
+async def test_process_message_shows_typing_indicator(bot_server, fake_channel, mock_router):
+    """While the agent is running, the channel should receive typing hints."""
+    # Force agent.run to take a bit so the typing loop ticks at least once.
+    bot_server._TYPING_REFRESH_SECONDS = 0.01
+    agent = await mock_router.get_or_create_agent("test", "conv_typing")
+
+    async def slow_run(*_args, **_kwargs):
+        await asyncio.sleep(0.05)
+        return "done"
+
+    agent.run = AsyncMock(side_effect=slow_run)
+
+    msg = IncomingMessage(
+        channel="test",
+        conversation_id="conv_typing",
+        user_id="user_1",
+        text="Do something slow",
+        message_id="msg_typing",
+        platform_message_id="ts_typing",
+    )
+
+    await bot_server._process_message(fake_channel, msg)
+    await asyncio.sleep(_TEST_DEBOUNCE + 0.2)
+
+    assert fake_channel.typing_starts, "send_typing should have been called at least once"
+    assert all(c == "conv_typing" for c in fake_channel.typing_starts)
+    assert fake_channel.typing_stops == ["conv_typing"]
+
+
+async def test_process_message_stops_typing_on_error(bot_server, fake_channel, mock_router):
+    """stop_typing must still run if the agent raises."""
+    bot_server._TYPING_REFRESH_SECONDS = 0.01
+    agent = await mock_router.get_or_create_agent("test", "conv_fail")
+    agent.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+    msg = IncomingMessage(
+        channel="test",
+        conversation_id="conv_fail",
+        user_id="user_1",
+        text="Do something",
+        message_id="msg_fail",
+        platform_message_id="ts_fail",
+    )
+
+    await bot_server._process_message(fake_channel, msg)
+    await asyncio.sleep(_TEST_DEBOUNCE + 0.1)
+
+    assert fake_channel.typing_stops == ["conv_fail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Give WeChat users immediate feedback that ouro received their message:
while `agent.run()` is processing, the WeChat conversation now shows a
native "typing…" hint. It clears as soon as the reply is sent — or on
error.

Motivation: on WeChat the bot has no 👀/✅ reactions to signal "I got it,
working on it," so long-running replies can feel like nothing is
happening.

## Scope

- Goals:
  - Surface a visible "processing" signal to WeChat users during `agent.run()`.
  - Keep the indicator fresh (WeChat's hint is short-lived).
  - Guarantee cleanup on both success and error paths.
- Non-goals:
  - Adding typing support for Slack / Lark (they keep existing behavior).
  - Changing message coalescing, debounce, or batching logic.

## Invariants (Must Not Regress)

- [x] Lark's 👀 / ✅ reaction flow is unchanged (`send_typing`/`stop_typing` are no-ops there).
- [x] Slack's reaction flow and Socket Mode behavior are unchanged.
- [x] Agent reply text is unchanged — typing is a side-channel hint only.
- [x] Errors still surface the user-visible "something went wrong" message.
- [x] Channel `Protocol` still recognizes Lark/Slack/WeChat channels at runtime (new methods added to all three).

## Acceptance Criteria

- [x] `Channel` protocol exposes `send_typing(conversation_id)` and `stop_typing(conversation_id)`.
- [x] `WeChatChannel.send_typing` / `stop_typing` dispatch to `WeixinBot` on its own event loop.
- [x] `BotServer._process_batch` starts a refresh task around `agent.run()` and stops typing in `finally`.
- [x] Typing is stopped even when `agent.run()` raises.
- [x] `LarkChannel` and `SlackChannel` provide no-op implementations.

## Test Plan

- [x] New tests in `test/test_bot_server.py`:
  - `test_process_message_shows_typing_indicator` — asserts `send_typing` is called while the agent is running and `stop_typing` is called once afterward.
  - `test_process_message_stops_typing_on_error` — `stop_typing` still fires if `agent.run()` raises.
- [x] `./scripts/dev.sh test -q` (621 passed, 1 skipped)
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` (clean)

## Smoke Run (Real CLI)

- [ ] Not run: requires a logged-in WeChat account (QR scan on a real phone). The behavior is exercised via the unit tests on `FakeChannel`; the WeChat glue is a thin wrapper over the SDK's documented `send_typing`/`stop_typing`.

## Adversarial Review

- **What could break?** The typing refresh task is per-batch and cancelled in `finally`; a leaked task would only log a debug message. The bridging uses the existing `_bot_loop` pattern already used by `send_message`.
- **Worst-case size?** A very long agent run sends one extra SDK call every 4s. At e.g. 5 minutes that's ~75 typing pings per user — modest.
- **Secrets/logging?** None added. All failures log at `debug` level.
- **Async/blocking I/O?** `send_typing` calls are async and scheduled on the SDK's own loop via `run_coroutine_threadsafe`; the main loop awaits via `asyncio.to_thread(future.result, 15)`, matching the existing `send_message` pattern.
- **User-visible failure?** If typing fails, the user just doesn't see the hint — the reply still arrives.

## Docs / Compatibility

- [x] Updated `bot/WECHAT.md` to note the typing hint.
- [x] No secrets committed, no generated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)