### PR TITLE
docs: add per-layer README + link them from the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ export OURO_API_KEY=<your-api-key>
 
 Extra flags are forwarded to `harbor run`, so any Harbor CLI option works. See [ouro_harbor/README.md](ouro_harbor/README.md) for full details.
 
+## Architecture
+
+Ouro is a three-layer namespace package. Imports flow downward only;
+boundaries are enforced by `import-linter`. Each layer has its own
+README — start with the umbrella overview, then drill in:
+
+- **[Architecture overview](ouro/README.md)** -- the three layers and how they fit together
+- [`ouro.core`](ouro/core/README.md) -- agent loop + LLM primitives + hook protocol (Python SDK)
+- [`ouro.capabilities`](ouro/capabilities/README.md) -- `AgentBuilder`, tools, memory, skills, verification (Python SDK)
+- [`ouro.interfaces`](ouro/interfaces/README.md) -- CLI / TUI / bot entry points (no SDK)
+
 ## Documentation
 
 - **[CLI Guide](docs/cli-guide.md)** -- interactive mode, task mode, commands, shortcuts

--- a/ouro/README.md
+++ b/ouro/README.md
@@ -1,0 +1,74 @@
+# `ouro` — Package Architecture
+
+Ouro is organized into three namespace subpackages. Imports flow downward
+only; reverse imports are forbidden and enforced by `import-linter`
+(see `.importlinter` at repo root).
+
+```
+ouro.interfaces   user-facing: CLI / TUI / bot         no SDK
+       ↓
+ouro.capabilities tools, memory, skills, verification  Python SDK
+       ↓
+ouro.core         agent loop + LLM primitives          Python SDK
+```
+
+## Layer guides
+
+| Layer | What it gives you | Read |
+|---|---|---|
+| **`ouro.core`** | Agent loop class, hook protocol, LLM types, LiteLLM client | [ouro/core/README.md](core/README.md) |
+| **`ouro.capabilities`** | `AgentBuilder` / `ComposedAgent`, builtin tools, memory hook, verification hook, skills | [ouro/capabilities/README.md](capabilities/README.md) |
+| **`ouro.interfaces`** | CLI entry, interactive TUI, bot webhook server + channels | [ouro/interfaces/README.md](interfaces/README.md) |
+
+## Picking the right layer for new code
+
+- **Adding an LLM provider, a new stop reason, or a hook lifecycle method?**
+  → `ouro.core`
+- **Adding a tool, a memory strategy, a skill, or a verification rule?**
+  → `ouro.capabilities`
+- **Adding a CLI flag, a slash command, or a new bot channel?**
+  → `ouro.interfaces`
+
+## Boundary verification
+
+```bash
+./scripts/dev.sh importlint
+# Contracts: 3 kept, 0 broken.
+```
+
+The contract:
+
+1. `ouro.interfaces` → `ouro.capabilities` → `ouro.core` (downward only).
+2. `ouro.core` may not import `ouro.capabilities`.
+3. `ouro.capabilities` may not import `ouro.interfaces`.
+
+UI side concerns reach capabilities through the
+`ouro.core.loop.ProgressSink` Protocol (the TUI ships
+`TuiProgressSink`; headless callers use `NullProgressSink`). The bot's
+`CronScheduler` plugs into `ouro.capabilities.tools.builtins.cron_tool`
+through a capability-local Protocol.
+
+## SDK quickstart
+
+```python
+import asyncio
+
+from ouro.capabilities import AgentBuilder
+from ouro.capabilities.tools.builtins.shell import ShellTool
+from ouro.core.llm import LiteLLMAdapter
+
+async def main() -> None:
+    agent = (
+        AgentBuilder()
+        .with_llm(LiteLLMAdapter(model="openai/gpt-4o"))
+        .with_memory()
+        .with_tool(ShellTool())
+        .build()
+    )
+    print(await agent.run("List files in the current directory."))
+
+asyncio.run(main())
+```
+
+For the `ouro` CLI itself, see the [root README](../README.md) and the
+[CLI Guide](../docs/cli-guide.md).

--- a/ouro/capabilities/README.md
+++ b/ouro/capabilities/README.md
@@ -1,0 +1,209 @@
+# `ouro.capabilities` — Tools, Memory, Skills, Verification
+
+The middle layer. Built on `ouro.core`. The canonical Python SDK most
+users interact with.
+
+## What's inside
+
+```
+ouro.capabilities
+├── builder.py               # AgentBuilder + ComposedAgent (start here)
+├── tools/                   # BaseTool + ToolExecutor + 13 builtins
+│   ├── base.py
+│   ├── executor.py          # implements ouro.core ToolRegistry
+│   └── builtins/            # FileReadTool, ShellTool, GrepTool, …
+├── memory/                  # MemoryManager + MemoryHook
+│   ├── manager.py           # short/long-term + persistence
+│   ├── compressor.py        # LLM-driven compaction
+│   ├── long_term/           # ~/.ouro/memory/*.md daily notes
+│   ├── store/               # YAML session persistence
+│   └── hook.py              # MemoryHook (loop integration)
+├── skills/                  # progressive-disclosure skill registry
+├── verification/            # Verifier + LLMVerifier + VerificationHook (Ralph)
+├── todo/                    # TodoList state
+├── context/                 # platform/git/cwd context formatter
+└── prompts/                 # DEFAULT_SYSTEM_PROMPT
+```
+
+## Public SDK
+
+```python
+from ouro.capabilities import (
+    AgentBuilder,
+    ComposedAgent,
+
+    # Tools
+    BaseTool,
+    ToolExecutor,
+
+    # Memory
+    MemoryManager,
+    MemoryHook,
+    ShortTermMemory,
+    WorkingMemoryCompressor,
+    TokenTracker,
+    LongTermMemoryManager,
+
+    # Skills
+    SkillsRegistry,
+    SkillInfo,
+    render_skills_section,
+
+    # Verification
+    Verifier,
+    LLMVerifier,
+    VerificationResult,
+    VerificationHook,
+
+    # Other
+    TodoList,
+    DEFAULT_SYSTEM_PROMPT,
+    format_context_prompt,
+)
+```
+
+Builtin tools are imported by name from
+`ouro.capabilities.tools.builtins.*`:
+`FileReadTool`, `FileWriteTool`, `GlobTool`, `GrepTool`, `ShellTool`,
+`SmartEditTool`, `WebSearchTool`, `WebFetchTool`, `MultiTaskTool`,
+`SendFileTool`, `CronTool`, `SessionManagerTool`, `TodoTool`,
+`CodeStructureTool`.
+
+## AgentBuilder
+
+`AgentBuilder` is the canonical assembly path. Fluent `with_*` methods
+configure pieces, `.build()` returns a fully wired `ComposedAgent`.
+
+```python
+import asyncio
+
+from ouro.capabilities import AgentBuilder, SkillsRegistry
+from ouro.capabilities.tools.builtins.file_ops import FileReadTool, FileWriteTool
+from ouro.capabilities.tools.builtins.shell import ShellTool
+from ouro.core.llm import LiteLLMAdapter, ModelManager
+
+async def main() -> None:
+    mm = ModelManager()
+    profile = mm.get_current_model()
+    llm = LiteLLMAdapter(
+        model=profile.model_id,
+        api_key=profile.api_key,
+        api_base=profile.api_base,
+    )
+
+    skills = SkillsRegistry()
+    await skills.load()
+
+    agent = (
+        AgentBuilder()
+        .with_llm(llm, model_manager=mm)
+        .with_max_iterations(20)
+        .with_memory(sessions_dir=None, memory_dir=None)  # ~/.ouro defaults
+        .with_skills(skills)
+        .with_verification(max_iterations=3)              # Ralph outer loop
+        .with_tools([FileReadTool(), FileWriteTool(), ShellTool()])
+        .build()
+    )
+
+    print(await agent.run("Summarize the README in three bullet points."))
+
+asyncio.run(main())
+```
+
+`TodoTool` is auto-injected on every build so the agent always has
+`manage_todo_list`.
+
+## ComposedAgent
+
+`ComposedAgent` wraps `ouro.core.loop.Agent` and exposes back-compat
+proxies the TUI/bot rely on:
+
+```python
+agent.memory                 # MemoryManager (or None if .without_memory())
+agent.tool_executor          # ToolExecutor (implements ToolRegistry)
+agent.todo_list              # TodoList
+agent.set_reasoning_effort("high")
+agent.switch_model("anthropic/claude-3-5-sonnet-20241022")
+await agent.load_session(session_id)
+agent.get_memory_stats()
+agent.get_current_model_info()
+```
+
+`agent.run(task, *, verify=False, images=None)` handles:
+- system prompt assembly (default + context + LTM + skills + soul) on
+  the first turn,
+- multimodal user message construction when `images` are provided,
+- placeholder substitution for image blocks before persistence so
+  saved YAML sessions stay small,
+- memory stats + flush at the end.
+
+## Hooks
+
+Two first-party hooks ship with this layer. Both are wired
+automatically by `AgentBuilder`:
+
+### MemoryHook
+
+Adapts `MemoryManager` into the loop:
+
+- `before_call`: substitutes `messages` with
+  `memory.get_context_for_llm()` and registers tool schemas for
+  compaction accounting.
+- `after_call`: persists the assistant response with usage.
+- `after_tool`: persists the tool result message.
+- `on_compact_check`: returns `CompactionDecision` when memory says
+  it needs compression; the cache-safe fork call is performed by the
+  core loop.
+
+### VerificationHook
+
+Ralph-style outer loop:
+
+- `on_run_start`: resets per-run state.
+- `on_iteration_end(finished=True)`: runs the verifier; returns
+  `STOP` if complete, `RETRY_WITH_FEEDBACK` if not, `STOP` once
+  `max_iterations` is reached.
+
+Bring your own verifier by passing `Verifier`-conforming objects:
+
+```python
+class MyVerifier:
+    async def verify(self, task, result, iteration, previous_results):
+        return VerificationResult(complete="DONE" in result.upper(), reason="")
+
+builder.with_verification(max_iterations=3, verifier=MyVerifier())
+```
+
+## Adding a builtin tool
+
+1. Subclass `BaseTool` under `tools/builtins/`. Implement `name`,
+   `description`, `parameters`, and `async execute(**kwargs) -> str`.
+   Set `readonly = True` if it doesn't mutate state — that unlocks
+   parallel dispatch when multiple readonly tools fire in one turn.
+2. Re-export from `ouro/capabilities/tools/__init__.py` if you want
+   it on the public SDK.
+3. Add to `ouro/interfaces/cli/factory.py` if it should ship in the
+   default CLI/bot toolset.
+4. Add a focused unit test under `test/`.
+
+## Memory persistence
+
+| Path | Format | Owner |
+|---|---|---|
+| `~/.ouro/sessions/<YYYY-MM-DD_uuid>/session.yaml` | YAML | `MemoryManager` |
+| `~/.ouro/memory/memory.md` | Markdown | `LongTermMemoryManager` (durable) |
+| `~/.ouro/memory/daily/YYYY-MM-DD.md` | Markdown | `LongTermMemoryManager` (rolling) |
+| `~/.ouro/skills/<skill-name>/SKILL.md` | Markdown + frontmatter | `SkillsRegistry` |
+
+Sessions persist incrementally on `add_message` and on `save_memory()`
+flush; resuming is `await ComposedAgent.load_session(session_id)` or
+`MemoryManager.from_session(session_id, llm, ...)`.
+
+## See also
+
+- [Capabilities layer agent instructions](CLAUDE.md) — rules for editing this layer.
+- [Memory invariants](memory/CLAUDE.md) — serialization and compaction guarantees.
+- [Tool contracts](tools/CLAUDE.md) — how to write a `BaseTool`.
+- [Memory Management guide](../../docs/memory-management.md) — user-side memory model.
+- [Extending guide](../../docs/extending.md) — adding tools, agents, providers.
+- [Core layer README](../core/README.md) — what capabilities depends on.

--- a/ouro/core/README.md
+++ b/ouro/core/README.md
@@ -1,0 +1,166 @@
+# `ouro.core` — Agent Loop + LLM Primitives
+
+The bottom layer. Pure SDK with no UI dependencies. Depends only on
+`litellm` and the standard library.
+
+## What's inside
+
+```
+ouro.core
+├── loop/                    # ReAct loop + hook protocol
+│   ├── agent.py             # the Agent class
+│   └── protocols.py         # Hook, ToolRegistry, ProgressSink, LoopContext
+├── llm/                     # LiteLLM client + message types
+│   ├── litellm_adapter.py   # LiteLLMAdapter
+│   ├── message_types.py     # LLMMessage, LLMResponse, ToolCall, ToolResult
+│   ├── model_manager.py     # ModelManager, ModelProfile
+│   ├── reasoning.py         # reasoning_effort plumbing
+│   ├── chatgpt_auth.py      # OAuth (ChatGPT Codex)
+│   └── copilot_auth.py      # OAuth (GitHub Copilot)
+├── runtime.py               # ~/.ouro/* path helpers
+├── log.py                   # logger setup
+└── model_pricing.py         # token cost lookups
+```
+
+## Public SDK
+
+```python
+from ouro.core import (
+    # Loop
+    Agent,
+    Hook,
+    ToolRegistry,
+    ProgressSink,
+    NullProgressSink,
+    LoopContext,
+    CompactionDecision,
+    ContinueDecision,
+    ContinueKind,
+
+    # LLM types
+    LLMMessage,
+    LLMResponse,
+    ToolCall,
+    ToolResult,
+    ToolCallBlock,
+    StopReason,
+
+    # LLM client
+    LiteLLMAdapter,
+    ModelManager,
+    ModelProfile,
+
+    # Helpers
+    REASONING_EFFORT_CHOICES,
+    extract_text,
+    get_runtime_dir,
+    get_logger,
+)
+```
+
+## Minimal usage — bare loop without memory or hooks
+
+```python
+import asyncio
+
+from ouro.core.llm import LiteLLMAdapter, LLMMessage
+from ouro.core.loop import Agent
+
+class NoTools:
+    def get_tool_schemas(self): return []
+    def is_tool_readonly(self, name): return True
+    async def execute_tool_call(self, name, arguments): raise NotImplementedError
+
+async def main() -> None:
+    llm = LiteLLMAdapter(model="openai/gpt-4o")
+    agent = Agent(llm=llm, tools=NoTools())
+    answer = await agent.run(
+        task="Say hello",
+        initial_messages=[LLMMessage(role="user", content="Say hello.")],
+    )
+    print(answer)
+
+asyncio.run(main())
+```
+
+Most users won't construct `Agent` directly — they go through
+`ouro.capabilities.AgentBuilder`, which wires memory, tools, and
+verification hooks for you.
+
+## The hook protocol
+
+`Hook` is a structural Protocol. Every method is **optional**: the loop
+resolves each call by `getattr(hook, name, None)`, so you only define
+what you care about.
+
+```python
+class TimingHook:
+    """Logs how long each LLM call takes."""
+
+    async def before_call(self, ctx, messages, tools):
+        ctx._t0 = time.monotonic()
+        return messages
+
+    async def after_call(self, ctx, response):
+        elapsed = time.monotonic() - ctx._t0
+        print(f"[iter {ctx.iteration}] LLM call: {elapsed:.2f}s")
+        return response
+```
+
+| Method | When | Composition |
+|---|---|---|
+| `on_run_start(ctx, messages) -> messages` | Once before the first iteration | Chain (left-to-right, return value threads) |
+| `before_call(ctx, messages, tools) -> messages` | Before every LLM call | Chain |
+| `after_call(ctx, response) -> response` | After every LLM call | Chain |
+| `before_tool(ctx, tool_call) -> tool_call` | Before each tool execution | Chain |
+| `after_tool(ctx, tool_call, result) -> result` | After each tool execution | Chain |
+| `on_compact_check(ctx, messages) -> CompactionDecision \| None` | Before each iteration | First non-None wins |
+| `on_iteration_end(ctx, response, finished) -> ContinueDecision` | End of each iteration | `STOP` > `RETRY` > `CONTINUE`; multiple RETRY feedback messages are concatenated |
+| `on_run_end(ctx, final_answer) -> None` | When the loop returns | Fan-out (side-effect only) |
+
+## ToolRegistry
+
+The loop never imports `BaseTool`. It only requires:
+
+```python
+class ToolRegistry(Protocol):
+    def get_tool_schemas(self) -> list[dict[str, Any]]: ...
+    def is_tool_readonly(self, name: str) -> bool: ...
+    async def execute_tool_call(self, name: str, arguments: dict[str, Any]) -> str: ...
+```
+
+`ouro.capabilities.tools.executor.ToolExecutor` implements this. You
+can plug in your own without depending on the capabilities layer.
+
+## ProgressSink
+
+UI-side rendering channel. Headless usage gets `NullProgressSink`
+(no-op). The TUI provides `TuiProgressSink`. Capabilities never import
+`terminal_ui` — they call into whatever sink they were given:
+
+```python
+class ProgressSink(Protocol):
+    def info(self, msg: str) -> None: ...
+    def thinking(self, text: str) -> None: ...
+    def assistant_message(self, content: Any) -> None: ...
+    def tool_call(self, name: str, arguments: dict[str, Any]) -> None: ...
+    def tool_result(self, result: str) -> None: ...
+    def final_answer(self, text: str) -> None: ...
+    def unfinished_answer(self, text: str) -> None: ...
+    def spinner(self, label: str, title: str | None = None) -> AbstractAsyncContextManager: ...
+```
+
+## Cache-safe compaction
+
+Memory compaction is cache-safe by construction: when a hook returns
+`CompactionDecision`, the loop appends the compaction prompt to the
+current messages and calls the LLM **itself**, then hands the summary
+back via `on_summary(...)`. Both the normal turn and the compaction
+fork share the same system + tools prefix, so the provider's prompt
+cache hits.
+
+## See also
+
+- [Core layer agent instructions](CLAUDE.md) — rules for editing the loop / LLM client.
+- [LLM provider safety + timeouts](llm/CLAUDE.md).
+- [Capabilities layer README](../capabilities/README.md) — the SDK most users start with.

--- a/ouro/interfaces/README.md
+++ b/ouro/interfaces/README.md
@@ -1,0 +1,124 @@
+# `ouro.interfaces` — CLI / TUI / Bot
+
+The top layer. User-facing entry points. Imports flow downward into
+`ouro.capabilities` and `ouro.core`. Nothing in those layers may
+import from here.
+
+This layer does **not** expose an SDK — it ships entry callables.
+
+## What's inside
+
+```
+ouro.interfaces
+├── cli/                     # argparse + dispatch
+│   ├── main.py              # CLI flag parsing + dispatch
+│   ├── factory.py           # create_agent() — wires AgentBuilder
+│   └── entry.py             # `[project.scripts] ouro` shim
+├── tui/                     # interactive REPL
+│   ├── interactive.py       # InteractiveSession (slash commands, status bar)
+│   ├── input_handler.py     # prompt_toolkit input
+│   ├── command_registry.py  # /help, /reset, /stats, /resume, /model, /skills, /reasoning, /login, /logout, /theme
+│   ├── status_bar.py
+│   ├── theme.py
+│   ├── components.py
+│   ├── progress.py          # AsyncSpinner
+│   ├── terminal_ui.py       # rich-based console
+│   ├── tui_progress.py      # TuiProgressSink (the ProgressSink injected into capabilities)
+│   ├── slash_autocomplete.py
+│   ├── model_ui.py / oauth_ui.py / reasoning_ui.py / skills_ui.py
+└── bot/                     # webhook server + IM channels
+    ├── server.py            # aiohttp app, route registration, cron loop
+    ├── session_router.py    # per-conversation ComposedAgent factory
+    ├── message_queue.py     # debounce / coalesce bursty inputs
+    ├── proactive.py         # CronScheduler + ProactiveExecutor
+    ├── soul.py              # ~/.ouro/bot/soul.md
+    └── channel/             # base.py, lark.py, slack.py, wechat.py
+```
+
+## CLI entry
+
+Stable user-facing surface (unchanged across the refactor):
+
+```bash
+ouro                                         # interactive TUI (default)
+ouro --task "<…>"                            # one-shot
+ouro --task "<…>" --verify                   # one-shot + Ralph outer loop
+ouro --resume latest                         # resume most-recent session
+ouro --resume <session-id-prefix>            # resume by id prefix
+ouro --model openai/gpt-4o                   # pick model for this run
+ouro --reasoning-effort high                 # off | minimal | low | medium | high | xhigh
+ouro --login   /  --logout                   # OAuth (ChatGPT Codex, Copilot)
+ouro --bot                                   # webhook daemon (Lark / Slack / WeChat)
+ouro --version
+```
+
+Internally `ouro` resolves to `ouro.interfaces.cli.entry:main`.
+
+`ouro.interfaces.cli.factory.create_agent(model_id=None, sessions_dir=None,
+memory_dir=None)` is the canonical assembly path — both the CLI and the
+bot factory call it. It wires `AgentBuilder` with the standard tool set
+plus `TuiProgressSink`, then post-injects `MultiTaskTool(agent)`.
+
+See the [CLI Guide](../../docs/cli-guide.md) for the slash-command
+catalog and keyboard shortcuts.
+
+## TUI
+
+`InteractiveSession` (in `tui/interactive.py`) drives the REPL:
+
+- prompt_toolkit input with history (`~/.ouro/.history`),
+- slash commands resolved by `CommandRegistry`,
+- status bar shows current model + memory stats,
+- `Ctrl+C` cancels the in-flight task; `Ctrl+L` clears; `Ctrl+T`
+  toggles thinking; `Ctrl+S` toggles stats.
+
+`TuiProgressSink` is the bridge between capabilities and rich UI: it
+implements the `ouro.core.loop.ProgressSink` Protocol and renders via
+`terminal_ui` + `AsyncSpinner`. When you pass `--bot` (or call
+`AgentBuilder` yourself with a quieter sink), capabilities' UI calls
+become no-ops automatically.
+
+## Bot
+
+`ouro --bot` starts an aiohttp webhook server. Each enabled channel
+(`LARK_*`, `SLACK_*`, `WECHAT_ENABLED` env vars) registers routes; the
+`SessionRouter` maps `{channel}:{conversation_id}` → a per-conversation
+`ComposedAgent` with its own memory.
+
+```
+~/.ouro/bot/
+├── soul.md                 # personality / tone (load_soul)
+├── cron_jobs.json          # CronScheduler persistence
+└── conversation_map.yaml   # conv-id → session-id, survives restarts
+```
+
+`CronScheduler` (in `bot/proactive.py`) drives recurring and one-time
+tasks. The `manage_cron` tool plugged into each agent talks to it
+through a capabilities-local `CronScheduler` Protocol — capabilities
+never imports the interface implementation.
+
+See the [Bot Guide](../../docs/bot-guide.md) for channel setup
+(Lark / Slack / WeChat), proactive tasks, and the soul file.
+
+## Adding a new channel
+
+1. Subclass `Channel` in `bot/channel/<your_channel>.py` with
+   `IncomingMessage` / `OutgoingMessage` round-tripping.
+2. Register it in `bot/server.py:run_bot` next to the existing
+   Lark / Slack / WeChat blocks (gated on a sensible env-var check).
+3. Add a focused test under `test/test_<your_channel>.py`.
+
+## Adding a new slash command
+
+1. Add the spec in `tui/command_registry.py`.
+2. Implement the handler on `InteractiveSession` in `tui/interactive.py`.
+3. Update [docs/cli-guide.md](../../docs/cli-guide.md).
+4. Add a unit test under `test/test_slash_*.py`.
+
+## See also
+
+- [Interfaces layer agent instructions](CLAUDE.md) — rules for editing this layer.
+- [TUI UX stability](tui/CLAUDE.md) — autocomplete + skills test discipline.
+- [CLI Guide](../../docs/cli-guide.md) — full slash-command + shortcut reference.
+- [Bot Guide](../../docs/bot-guide.md) — channel setup + proactive tasks.
+- [Capabilities layer README](../capabilities/README.md) — what this layer assembles.


### PR DESCRIPTION
## Summary

The three-layer refactor (#170) didn't add user-facing intro docs for
each layer. This PR:

- adds **`ouro/README.md`** — umbrella overview of the three layers,
  layer-picker table, boundary verification command, SDK quickstart;
- adds **`ouro/core/README.md`** — what core provides, public SDK
  list, hook-protocol table, ToolRegistry / ProgressSink contracts,
  cache-safe compaction note;
- adds **`ouro/capabilities/README.md`** — `AgentBuilder` walkthrough,
  `ComposedAgent` proxies, MemoryHook + VerificationHook composition,
  recipe for adding a builtin tool, memory persistence paths;
- adds **`ouro/interfaces/README.md`** — CLI flag reference, TUI
  architecture, bot channel + cron wiring, recipes for a new channel
  / slash command;
- updates the **root README** with a new "Architecture" section that
  links to all four.

These complement (don't replace) the existing per-layer `CLAUDE.md` /
`AGENTS.md` files, which remain focused on agent-editing discipline.

## Scope

- Goals: surface the three-layer architecture in user-facing docs;
  give SDK consumers a starting point under each layer; keep the root
  README scannable.
- Non-goals: no code changes; no changes to `CLAUDE.md` per-layer
  agent instructions; no changes to existing `docs/*.md` guides.

## Invariants (Must Not Regress)

- [x] Existing root README sections (Quick Start / Features /
      Evaluation / Documentation / Contributing / License) are
      untouched except for the new "Architecture" block inserted
      before "Documentation".
- [x] All cross-links between the new READMEs resolve to existing
      files (verified via a path-resolution sweep).
- [x] `pre-commit run --all-files` passes (no whitespace / EOF
      regressions).

## Acceptance Criteria

- [x] `ouro/README.md`, `ouro/core/README.md`,
      `ouro/capabilities/README.md`, `ouro/interfaces/README.md` exist
      and link to each other + to the relevant `docs/*.md` guides.
- [x] Root README's "Architecture" section links to all four layer
      READMEs.

## Test Plan

- [x] `pre-commit run --all-files` (passed).
- [x] Internal-link resolution for every `[text](path.md)` in the new
      READMEs (passed; see commit message).
- [x] Manual visual review of the four new files.

## Smoke Run (Real CLI)

N/A — docs-only PR; no executable surface changes.

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?** None. Documentation-
  only PR; no Python imports, no scripts, no settings touched.
- **Worst-case input/output size?** N/A.
- **Secrets/logging risks?** None.
- **Async/blocking I/O on hot paths?** N/A.
- **Error message on failure?** Markdown render only — no runtime
  failure mode.

## Docs / Compatibility

- [x] Root `README.md` updated with the new "Architecture" section.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)