### PR TITLE
feat: make max_tokens optional, default to no limit

### DIFF
--- a/ouro/core/llm/litellm_adapter.py
+++ b/ouro/core/llm/litellm_adapter.py
@@ -151,7 +151,7 @@ class LiteLLMAdapter:
         self,
         messages: List[LLMMessage],
         tools: Optional[List[Dict[str, Any]]],
-        max_tokens: int,
+        max_tokens: int | None,
         **kwargs,
     ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         """Prepare LiteLLM call parameters and converted messages."""
@@ -160,9 +160,10 @@ class LiteLLMAdapter:
         call_params: Dict[str, Any] = {
             "model": self.model,
             "messages": litellm_messages,
-            "max_tokens": max_tokens,
             "timeout": self.timeout,
         }
+        if max_tokens is not None:
+            call_params["max_tokens"] = max_tokens
 
         # Add API key if provided
         if self.api_key:
@@ -185,7 +186,7 @@ class LiteLLMAdapter:
         self,
         messages: List[LLMMessage],
         tools: Optional[List[Dict[str, Any]]] = None,
-        max_tokens: int = 4096,
+        max_tokens: int | None = None,
         **kwargs,
     ) -> LLMResponse:
         """Async LLM call via LiteLLM with automatic retry."""

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -38,7 +38,7 @@ class Agent:
         tools: ToolRegistry,
         hooks: Sequence[Hook] = (),
         max_iterations: int = 1000,
-        max_tokens_per_call: int = 4096,
+        max_tokens_per_call: int | None = None,
         progress: ProgressSink | None = None,
     ) -> None:
         self.llm = llm
@@ -83,16 +83,18 @@ class Agent:
             async with self.progress.spinner(
                 "Analyzing request..." if ctx.iteration == 1 else "Processing results..."
             ):
-                response = await self.llm.call_async(
-                    messages=outgoing,
-                    tools=tool_schemas,
-                    max_tokens=self.max_tokens_per_call,
+                call_kwargs: dict[str, Any] = {
+                    "messages": outgoing,
+                    "tools": tool_schemas,
                     **(
                         {"reasoning_effort": self._reasoning_effort}
                         if self._reasoning_effort is not None
                         else {}
                     ),
-                )
+                }
+                if self.max_tokens_per_call is not None:
+                    call_kwargs["max_tokens"] = self.max_tokens_per_call
+                response = await self.llm.call_async(**call_kwargs)
             ctx.stop_reason_last = response.stop_reason
             ctx.add_usage(getattr(response, "usage", None))
 


### PR DESCRIPTION
- Change max_tokens_per_call default from 4096 to None in Agent
- Change max_tokens default from 4096 to None in LiteLLMAdapter
- Only include max_tokens in API call when explicitly set
- Allows model/provider to decide output length by default