### PR TITLE
docs: recommend uv tool / pipx install over plain pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,26 @@ Ouro ships with a unified agent core and two deployment modes:
 | | **CLI Mode** | **Bot Mode** |
 |---|---|---|
 | **What** | Interactive REPL + one-shot task execution | Persistent IM assistant (Lark, Slack) |
-| **Install** | `pip install ouro-ai` | `pip install ouro-ai[bot]` |
+| **Install** | `uv tool install ouro-ai` | `uv tool install 'ouro-ai[bot]'` |
 | **Run** | `ouro` | `ouro --bot` |
 | **Guide** | [CLI Guide](docs/cli-guide.md) | [Bot Guide](docs/bot-guide.md) |
 
 ## Quick Start
 
-Prerequisites: Python 3.12+.
+Prerequisites: Python 3.12+ and one of [`uv`](https://docs.astral.sh/uv/) (recommended) or [`pipx`](https://pipx.pypa.io/).
 
 ```bash
-pip install ouro-ai
+# Recommended: installs ouro in an isolated environment and exposes a global `ouro` command
+uv tool install ouro-ai
+
+# Alternative
+pipx install ouro-ai
+
+# Upgrading later
+uv tool upgrade ouro-ai      # or: pipx upgrade ouro-ai
 ```
+
+> Plain `pip install ouro-ai` also works but is **not recommended** — it mixes ouro's dependencies into your active Python environment. Use `uv tool` / `pipx` so the `ouro` binary is on `$PATH` without needing to activate a venv.
 
 On first run, `~/.ouro/models.yaml` is created. Add your API key:
 
@@ -112,13 +121,17 @@ README — start with the umbrella overview, then drill in:
 
 Contributions are welcome! Please open an [issue](https://github.com/ouro-ai-labs/ouro/issues) or submit a pull request.
 
-For development setup, see the [Quick Start](#quick-start) section (install from source):
+For development setup (install from source):
 
 ```bash
 git clone https://github.com/ouro-ai-labs/ouro.git
 cd ouro
-./scripts/bootstrap.sh   # requires uv
+./scripts/bootstrap.sh         # creates .venv and installs editable + dev deps
+source .venv/bin/activate
+./scripts/dev.sh check         # precommit + typecheck + tests
 ```
+
+End-users should prefer `uv tool install ouro-ai` (see [Quick Start](#quick-start)); the source checkout is only needed when contributing.
 
 ## License
 

--- a/docs/bot-guide.md
+++ b/docs/bot-guide.md
@@ -6,9 +6,14 @@ Bot data is isolated under `~/.ouro/bot/` (sessions, memory, skills) so it never
 
 ## Installation
 
+Prerequisites: Python 3.12+ and one of [`uv`](https://docs.astral.sh/uv/) or [`pipx`](https://pipx.pypa.io/).
+
 ```bash
-pip install ouro-ai[bot]
+uv tool install 'ouro-ai[bot]'      # recommended
+# or: pipx install 'ouro-ai[bot]'
 ```
+
+The `[bot]` extra pulls in `aiohttp`, `lark-oapi`, `slack-sdk`, and `weixin-bot-sdk`. Upgrade later with `uv tool upgrade ouro-ai` (or `pipx upgrade ouro-ai`).
 
 ## Configure Models
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -4,11 +4,14 @@ Ouro's CLI mode gives you a coding agent right in your terminal — interactive 
 
 ## Installation
 
-Prerequisites: Python 3.12+.
+Prerequisites: Python 3.12+ and one of [`uv`](https://docs.astral.sh/uv/) or [`pipx`](https://pipx.pypa.io/).
 
 ```bash
-pip install ouro-ai
+uv tool install ouro-ai      # recommended
+# or: pipx install ouro-ai
 ```
+
+Both install ouro in an isolated environment and put the `ouro` binary on `$PATH` — no venv activation needed. Upgrade later with `uv tool upgrade ouro-ai` (or `pipx upgrade ouro-ai`).
 
 Or install from source (for development):
 
@@ -16,6 +19,7 @@ Or install from source (for development):
 git clone https://github.com/ouro-ai-labs/ouro.git
 cd ouro
 ./scripts/bootstrap.sh   # requires uv
+source .venv/bin/activate
 ```
 
 ## Configure Models

--- a/ouro/interfaces/bot/LARK.md
+++ b/ouro/interfaces/bot/LARK.md
@@ -5,7 +5,7 @@ This guide walks you through connecting ouro to Lark as an IM bot.
 ## Prerequisites
 
 - A [Lark Open Platform](https://open.feishu.cn/app) account (enterprise admin or developer)
-- `pip install ouro-ai[bot]`
+- `uv tool install 'ouro-ai[bot]'` (or `pipx install 'ouro-ai[bot]'`)
 
 ## 1. Create a Lark App
 

--- a/ouro/interfaces/bot/README.md
+++ b/ouro/interfaces/bot/README.md
@@ -5,7 +5,7 @@ Bot mode turns ouro into a persistent IM assistant. Each chat conversation maps 
 ## Quick Start
 
 ```bash
-pip install ouro-ai[bot]
+uv tool install 'ouro-ai[bot]'      # or: pipx install 'ouro-ai[bot]'
 ```
 
 Add credentials to `~/.ouro/config` (see [LARK.md](LARK.md) / [SLACK.md](SLACK.md)):

--- a/ouro/interfaces/bot/SLACK.md
+++ b/ouro/interfaces/bot/SLACK.md
@@ -5,7 +5,7 @@ This guide walks you through connecting ouro to Slack as an IM bot via Socket Mo
 ## Prerequisites
 
 - A [Slack workspace](https://slack.com/) where you can install apps
-- `pip install ouro-ai[bot]`
+- `uv tool install 'ouro-ai[bot]'` (or `pipx install 'ouro-ai[bot]'`)
 
 ## 1. Create a Slack App
 

--- a/ouro/interfaces/bot/WECHAT.md
+++ b/ouro/interfaces/bot/WECHAT.md
@@ -5,7 +5,7 @@ This guide walks you through connecting ouro to WeChat as an IM bot via the [wei
 ## Prerequisites
 
 - A personal WeChat account (used for the bot)
-- `pip install ouro-ai[bot]`
+- `uv tool install 'ouro-ai[bot]'` (or `pipx install 'ouro-ai[bot]'`)
 
 ## 1. Enable WeChat Channel
 
@@ -47,5 +47,5 @@ Once authenticated, anyone who sends a message to the bot's WeChat account will 
 |-------|----------|
 | QR code not showing | Make sure your terminal supports the QR display. Try a wider terminal window. |
 | Session expired | Restart the bot (`ouro --bot`) and scan the QR code again. |
-| `weixin-bot-sdk not installed` | Run `pip install weixin-bot-sdk` or `pip install ouro-ai[bot]`. |
+| `weixin-bot-sdk not installed` | Reinstall with the `[bot]` extra: `uv tool install --force 'ouro-ai[bot]'` (or `pipx install --force 'ouro-ai[bot]'`). |
 | Messages not received | Check that the WeChat account is logged in and the bot thread is running (check logs). |


### PR DESCRIPTION
## Summary

Switch all user-facing install instructions from `pip install ouro-ai` to `uv tool install ouro-ai` (with `pipx install ouro-ai` as an equally-supported alternative). Both approaches install ouro into an isolated environment and put the `ouro` binary on `$PATH`, so users no longer need to activate a venv just to run the CLI.

## Scope

- Goals:
  - Make "I just want to run `ouro`" work without venv ceremony
  - Keep docs consistent — no page should still say `pip install ouro-ai`
- Non-goals:
  - No code changes (entry point `ouro = "ouro.interfaces.cli.entry:main"` was already correct)
  - No new release / version bump
  - CHANGELOG / RFC history left unchanged (intentional)

## Invariants (Must Not Regress)

- [x] `ouro` console script still resolves via `[project.scripts]` in `pyproject.toml`
- [x] `[bot]` extra still works (`uv tool install 'ouro-ai[bot]'` — brackets quoted for zsh)
- [x] Source-install path (`./scripts/bootstrap.sh`) still documented for contributors
- [x] No code paths or imports touched

## Acceptance Criteria

- [x] `uv tool install ouro-ai` succeeds against the current PyPI release (0.3.1) and produces a working `ouro -h`
- [x] README, CLI guide, Bot guide, and per-platform bot docs (Lark/Slack/WeChat/bot README) all show the new install command
- [x] `grep -rn "pip install ouro-ai" --include="*.md"` returns only intentional references (CHANGELOG history, RFC history, README's "not recommended" callout)

## Test Plan

- [x] `./scripts/dev.sh precommit` (passes — fix end of files, trim trailing whitespace, yaml, black, isort, ruff)
- [x] Manual: `uv tool install ouro-ai` → `which ouro` → `ouro -h` (verified locally, binary at `~/.local/bin/ouro`)
- [n/a] `./scripts/dev.sh test -q` — docs-only diff, no behavior change
- [n/a] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — docs-only diff

## Smoke Run (Real CLI)

- [x] `uv tool install ouro-ai && ouro -h` from a clean shell — works

## Adversarial Review

- **What could this break?** Users following older blog posts / cached docs that say `pip install ouro-ai` will still succeed; we keep that working and merely de-recommend it. The `[bot]` extra requires quoting in zsh (`'ouro-ai[bot]'`) — all examples now quote it correctly.
- **Worst-case input/output?** N/A (docs).
- **Secrets/logging risks?** None.
- **Async/blocking I/O on hot paths?** None.
- **Error message on failure?** If `uv` / `pipx` aren't installed, the user gets a clear shell "command not found" — we now list both with links to their install docs, so the fix is one click away.

## Docs / Compatibility

- [x] Updated `README.md`, `docs/cli-guide.md`, `docs/bot-guide.md`, `ouro/interfaces/bot/{README,LARK,SLACK,WECHAT}.md`
- [x] No secrets, no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)