### PR TITLE
feat(cli)!: split ouro into ouro-cli and ouro-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ouro ships with a unified agent core and two deployment modes:
 |---|---|---|
 | **What** | Interactive REPL + one-shot task execution | Persistent IM assistant (Lark, Slack) |
 | **Install** | `uv tool install ouro-ai` | `uv tool install 'ouro-ai[bot]'` |
-| **Run** | `ouro` | `ouro --bot` |
+| **Run** | `ouro-cli` | `ouro-bot` |
 | **Guide** | [CLI Guide](docs/cli-guide.md) | [Bot Guide](docs/bot-guide.md) |
 
 ## Quick Start
@@ -30,7 +30,8 @@ Ouro ships with a unified agent core and two deployment modes:
 Prerequisites: Python 3.12+ and one of [`uv`](https://docs.astral.sh/uv/) (recommended) or [`pipx`](https://pipx.pypa.io/).
 
 ```bash
-# Recommended: installs ouro in an isolated environment and exposes a global `ouro` command
+# Recommended: installs ouro in an isolated environment and exposes global
+# `ouro-cli` and `ouro-bot` commands
 uv tool install ouro-ai
 
 # Alternative
@@ -40,7 +41,7 @@ pipx install ouro-ai
 uv tool upgrade ouro-ai      # or: pipx upgrade ouro-ai
 ```
 
-> Plain `pip install ouro-ai` also works but is **not recommended** — it mixes ouro's dependencies into your active Python environment. Use `uv tool` / `pipx` so the `ouro` binary is on `$PATH` without needing to activate a venv.
+> Plain `pip install ouro-ai` also works but is **not recommended** — it mixes ouro's dependencies into your active Python environment. Use `uv tool` / `pipx` so the `ouro-cli` / `ouro-bot` binaries are on `$PATH` without needing to activate a venv.
 
 On first run, `~/.ouro/models.yaml` is created. Add your API key:
 
@@ -56,13 +57,13 @@ Then run:
 
 ```bash
 # Interactive mode
-ouro
+ouro-cli
 
 # Single task
-ouro --task "Calculate 123 * 456"
+ouro-cli --task "Calculate 123 * 456"
 
 # Bot mode (requires ouro-ai[bot])
-ouro --bot
+ouro-bot
 ```
 
 See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for the full provider list.

--- a/docs/bot-guide.md
+++ b/docs/bot-guide.md
@@ -53,7 +53,7 @@ SLACK_APP_TOKEN=xapp-xxx
 ```
 
 ```bash
-ouro --bot
+ouro-bot
 ```
 
 ## Session Persistence

--- a/ouro/interfaces/CLAUDE.md
+++ b/ouro/interfaces/CLAUDE.md
@@ -13,7 +13,7 @@ by `import-linter`.
   --login / --logout / --resume / etc.).
 - `cli/factory.py` — builds a `ComposedAgent` for the standard CLI/bot
   via `AgentBuilder`. The TUI sink (`TuiProgressSink`) is wired here.
-- `cli/entry.py` — thin shim registered as `[project.scripts] ouro`.
+- `cli/entry.py` — thin shim registered as `[project.scripts] ouro-cli`.
 - `tui/interactive.py` — `InteractiveSession`, slash commands,
   prompt_toolkit input loop.
 - `tui/{terminal_ui, progress, theme, status_bar, components, …}` — UI
@@ -38,15 +38,17 @@ by `import-linter`.
 
 ## CLI entry
 
-Stable user-facing command:
+Stable user-facing commands:
 
 ```bash
-ouro                                 # interactive
-ouro --task "..."                    # one-shot
-ouro --task "..." --verify           # one-shot + Ralph outer loop
-ouro --bot                           # webhook daemon
-ouro --login | --logout              # OAuth flows
-ouro --resume [latest|<prefix>]      # restore a saved session
+ouro-cli                                 # interactive
+ouro-cli --task "..."                    # one-shot
+ouro-cli --task "..." --verify           # one-shot + Ralph outer loop
+ouro-bot                                 # webhook daemon
+ouro-cli --login | --logout              # OAuth flows
+ouro-cli --resume [latest|<prefix>]      # restore a saved session
 ```
 
-Internally `ouro` resolves to `ouro.interfaces.cli.entry:main`.
+Internally:
+- `ouro-cli` resolves to `ouro.interfaces.cli.entry:main`.
+- `ouro-bot` resolves to `ouro.interfaces.bot.entry:main`.

--- a/ouro/interfaces/README.md
+++ b/ouro/interfaces/README.md
@@ -13,7 +13,7 @@ ouro.interfaces
 ├── cli/                     # argparse + dispatch
 │   ├── main.py              # CLI flag parsing + dispatch
 │   ├── factory.py           # create_agent() — wires AgentBuilder
-│   └── entry.py             # `[project.scripts] ouro` shim
+│   └── entry.py             # `[project.scripts] ouro-cli` shim
 ├── tui/                     # interactive REPL
 │   ├── interactive.py       # InteractiveSession (slash commands, status bar)
 │   ├── input_handler.py     # prompt_toolkit input
@@ -27,6 +27,8 @@ ouro.interfaces
 │   ├── slash_autocomplete.py
 │   ├── model_ui.py / oauth_ui.py / reasoning_ui.py / skills_ui.py
 └── bot/                     # webhook server + IM channels
+    ├── main.py              # bot CLI flag parsing + dispatch
+    ├── entry.py             # `[project.scripts] ouro-bot` shim
     ├── server.py            # aiohttp app, route registration, cron loop
     ├── session_router.py    # per-conversation ComposedAgent factory
     ├── message_queue.py     # debounce / coalesce bursty inputs
@@ -40,19 +42,22 @@ ouro.interfaces
 Stable user-facing surface (unchanged across the refactor):
 
 ```bash
-ouro                                         # interactive TUI (default)
-ouro --task "<…>"                            # one-shot
-ouro --task "<…>" --verify                   # one-shot + Ralph outer loop
-ouro --resume latest                         # resume most-recent session
-ouro --resume <session-id-prefix>            # resume by id prefix
-ouro --model openai/gpt-4o                   # pick model for this run
-ouro --reasoning-effort high                 # off | minimal | low | medium | high | xhigh
-ouro --login   /  --logout                   # OAuth (ChatGPT Codex, Copilot)
-ouro --bot                                   # webhook daemon (Lark / Slack / WeChat)
-ouro --version
+ouro-cli                                     # interactive TUI (default)
+ouro-cli --task "<…>"                        # one-shot
+ouro-cli --task "<…>" --verify               # one-shot + Ralph outer loop
+ouro-cli --resume latest                     # resume most-recent session
+ouro-cli --resume <session-id-prefix>        # resume by id prefix
+ouro-cli --model openai/gpt-4o               # pick model for this run
+ouro-cli --reasoning-effort high             # off | minimal | low | medium | high | xhigh
+ouro-cli --login   /  --logout               # OAuth (ChatGPT Codex, Copilot)
+ouro-bot                                     # webhook daemon (Lark / Slack / WeChat)
+ouro-bot --model openai/gpt-4o               # pick model for this bot run
+ouro-cli --version  /  ouro-bot --version
 ```
 
-Internally `ouro` resolves to `ouro.interfaces.cli.entry:main`.
+Internally:
+- `ouro-cli` resolves to `ouro.interfaces.cli.entry:main`.
+- `ouro-bot` resolves to `ouro.interfaces.bot.entry:main`.
 
 `ouro.interfaces.cli.factory.create_agent(model_id=None, sessions_dir=None,
 memory_dir=None)` is the canonical assembly path — both the CLI and the
@@ -77,12 +82,12 @@ implements the `ouro.core.loop.ProgressSink` Protocol and renders via
 `terminal_ui` + `AsyncSpinner`. The interactive shell still prints the
 final returned answer itself; the sink is mainly for incremental
 progress events (thinking, tool calls/results, spinners, completion
-markers). When you pass `--bot` (or call `AgentBuilder` yourself with a
+markers). When you run `ouro-bot` (or call `AgentBuilder` yourself with a
 quieter sink), capabilities' UI calls become no-ops automatically.
 
 ## Bot
 
-`ouro --bot` starts an aiohttp webhook server. Each enabled channel
+`ouro-bot` starts an aiohttp webhook server. Each enabled channel
 (`LARK_*`, `SLACK_*`, `WECHAT_ENABLED` env vars) registers routes; the
 `SessionRouter` maps `{channel}:{conversation_id}` → a per-conversation
 `ComposedAgent` with its own memory.

--- a/ouro/interfaces/bot/LARK.md
+++ b/ouro/interfaces/bot/LARK.md
@@ -38,7 +38,7 @@ Go to **Events & Callbacks** -> **Event Configuration** -> Add event:
 |-------|------------|
 | Receive message | `im.message.receive_v1` |
 
-**Note**: The app must be running (`ouro --bot`) when you save event subscriptions, because Lark verifies the WebSocket connection is active.
+**Note**: The app must be running (`ouro-bot`) when you save event subscriptions, because Lark verifies the WebSocket connection is active.
 
 ## 6. Add Permissions
 
@@ -71,7 +71,7 @@ LARK_APP_SECRET=your_app_secret
 Then start:
 
 ```bash
-ouro --bot
+ouro-bot
 ```
 
 You should see:
@@ -105,4 +105,4 @@ The bot app is missing the `im:resource` permission. Go to **Permissions & Scope
 
 ### Event subscription fails with "app has not established long connection"
 
-Make sure `ouro --bot` is running **before** you save the event subscription in the Lark console. Lark needs to verify the WebSocket connection is active.
+Make sure `ouro-bot` is running **before** you save the event subscription in the Lark console. Lark needs to verify the WebSocket connection is active.

--- a/ouro/interfaces/bot/README.md
+++ b/ouro/interfaces/bot/README.md
@@ -18,7 +18,7 @@ LARK_APP_SECRET=your_secret
 Then start:
 
 ```bash
-ouro --bot
+ouro-bot
 ```
 
 ## Architecture

--- a/ouro/interfaces/bot/SLACK.md
+++ b/ouro/interfaces/bot/SLACK.md
@@ -63,7 +63,7 @@ SLACK_APP_TOKEN=xapp-your-app-token
 Then start:
 
 ```bash
-ouro --bot
+ouro-bot
 ```
 
 You should see:

--- a/ouro/interfaces/bot/WECHAT.md
+++ b/ouro/interfaces/bot/WECHAT.md
@@ -18,7 +18,7 @@ WECHAT_ENABLED=true
 ## 2. Start the Bot
 
 ```bash
-ouro --bot
+ouro-bot
 ```
 
 On first launch, a **QR code** will be displayed in the terminal. Scan it with the WeChat app on your phone to authenticate. Credentials are cached at `~/.weixin-bot/credentials.json` so you won't need to scan again unless the session expires.
@@ -46,6 +46,6 @@ Once authenticated, anyone who sends a message to the bot's WeChat account will 
 | Issue | Solution |
 |-------|----------|
 | QR code not showing | Make sure your terminal supports the QR display. Try a wider terminal window. |
-| Session expired | Restart the bot (`ouro --bot`) and scan the QR code again. |
+| Session expired | Restart the bot (`ouro-bot`) and scan the QR code again. |
 | `weixin-bot-sdk not installed` | Reinstall with the `[bot]` extra: `uv tool install --force 'ouro-ai[bot]'` (or `pipx install --force 'ouro-ai[bot]'`). |
 | Messages not received | Check that the WeChat account is logged in and the bot thread is running (check logs). |

--- a/ouro/interfaces/bot/entry.py
+++ b/ouro/interfaces/bot/entry.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Command-line shim for the ouro bot server (`ouro-bot`)."""
+
+
+def main():
+    """Bot CLI entry point."""
+    from ouro.interfaces.bot.main import main as run_main
+
+    run_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/ouro/interfaces/bot/main.py
+++ b/ouro/interfaces/bot/main.py
@@ -1,0 +1,56 @@
+"""Entry point for the ouro bot server."""
+
+import argparse
+import asyncio
+import importlib.metadata
+import warnings
+
+from rich.console import Console
+
+from ouro.config import Config
+from ouro.core.log import setup_logger
+from ouro.core.runtime import ensure_runtime_dirs
+from ouro.interfaces.bot.server import run_bot
+from ouro.interfaces.tui import terminal_ui
+
+warnings.filterwarnings("ignore", message="Pydantic serializer warnings.*", category=UserWarning)
+
+
+def main():
+    """Bot CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Run ouro as a bot server, receiving messages via IM channels (Lark, Slack, WeChat, etc.)"
+    )
+
+    try:
+        version = importlib.metadata.version("ouro-ai")
+    except importlib.metadata.PackageNotFoundError:
+        version = "dev"
+    parser.add_argument("--version", "-V", action="version", version=f"ouro-bot {version}")
+
+    parser.add_argument(
+        "--model",
+        "-m",
+        type=str,
+        help="Model to use (LiteLLM model ID, e.g. openai/gpt-4o)",
+    )
+
+    args = parser.parse_args()
+
+    # Bot is a long-running daemon — always enable file logging and suppress
+    # interactive Rich UI.
+    terminal_ui.console = Console(quiet=True)
+    ensure_runtime_dirs(create_logs=True)
+    setup_logger()
+
+    try:
+        Config.validate()
+    except ValueError as e:
+        terminal_ui.print_error(str(e), title="Configuration Error")
+        return
+
+    asyncio.run(run_bot(model_id=args.model))
+
+
+if __name__ == "__main__":
+    main()

--- a/ouro/interfaces/cli/main.py
+++ b/ouro/interfaces/cli/main.py
@@ -140,12 +140,6 @@ def main():
         default="default",
         help="Run-scoped reasoning level (LiteLLM/OpenAI-style). Use 'default' to omit the parameter, or 'off' as an alias for 'none'.",
     )
-    parser.add_argument(
-        "--bot",
-        action="store_true",
-        default=False,
-        help="Start as a bot server, receiving messages via IM channels (Lark, Slack, etc.)",
-    )
 
     args = parser.parse_args()
 
@@ -158,24 +152,6 @@ def main():
     # Initialize logging in verbose mode or when LLM-history debugging is on.
     if args.verbose or debug_history:
         setup_logger()
-
-    # Bot mode: start webhook server (before login/logout/task checks)
-    if args.bot:
-        terminal_ui.console = Console(quiet=True)
-        # Bot is a long-running daemon — always enable file logging.
-        ensure_runtime_dirs(create_logs=True)
-        setup_logger()
-
-        try:
-            Config.validate()
-        except ValueError as e:
-            terminal_ui.print_error(str(e), title="Configuration Error")
-            return
-
-        from ouro.interfaces.bot.server import run_bot
-
-        asyncio.run(run_bot(model_id=args.model))
-        return
 
     if args.login and args.logout:
         terminal_ui.print_error("Use only one of --login or --logout.", title="Invalid Arguments")

--- a/ouro_harbor/ouro_agent.py
+++ b/ouro_harbor/ouro_agent.py
@@ -44,7 +44,7 @@ def _build_models_yaml(model_name: str, api_key: str, api_base: str | None) -> s
 
     The key under ``models`` is the LiteLLM model ID (e.g.
     ``anthropic/claude-sonnet-4-5-20250929``).  ``default`` must reference
-    the same key so that ``ouro --model <key>`` resolves correctly.
+    the same key so that ``ouro-cli --model <key>`` resolves correctly.
     """
     timeout = os.environ.get("OURO_TIMEOUT", "600")
     lines = [
@@ -95,7 +95,7 @@ class OuroAgent(BaseInstalledAgent):
         # Run ouro in single-task mode and tee output for log collection
         escaped_model = shlex.quote(model_name)
         run_command = (
-            f"ouro --model {escaped_model} --task {escaped_instruction} "
+            f"ouro-cli --model {escaped_model} --task {escaped_instruction} "
             f"2>&1 | tee /logs/agent/ouro-output.txt; "
             # Copy session files to logs dir for debugging (best-effort)
             "cp -r ~/.ouro/sessions /logs/agent/sessions 2>/dev/null || true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,8 @@ Repository = "https://github.com/ouro-ai-labs/ouro"
 Issues = "https://github.com/ouro-ai-labs/ouro/issues"
 
 [project.scripts]
-ouro = "ouro.interfaces.cli.entry:main"
+ouro-cli = "ouro.interfaces.cli.entry:main"
+ouro-bot = "ouro.interfaces.bot.entry:main"
 
 [tool.setuptools]
 packages = [

--- a/test/test_main_auth_cli.py
+++ b/test/test_main_auth_cli.py
@@ -16,7 +16,7 @@ def _setup_common(monkeypatch, argv: list[str]):
     calls = {"error": [], "info": [], "success": [], "warning": []}
     console = _DummyConsole()
 
-    monkeypatch.setattr(sys, "argv", ["ouro", *argv])
+    monkeypatch.setattr(sys, "argv", ["ouro-cli", *argv])
     monkeypatch.setattr(ouro_main, "ensure_runtime_dirs", lambda create_logs=False: None)
     monkeypatch.setattr(ouro_main, "setup_logger", lambda: None)
 


### PR DESCRIPTION
## Summary

- Replace the single `ouro` script with two binaries: **`ouro-cli`** (interactive / one-shot) and **`ouro-bot`** (webhook daemon).
- Each command now has its own argparse, so bot mode no longer carries unrelated CLI-only flags in its help output.
- Update README, bot/LARK/SLACK/WECHAT guides, harbor runner, and the CLI auth test to use the new entry-point names.

## Scope

- Goals:
  - Cleaner UX: `ouro-cli` vs `ouro-bot` instead of `ouro` / `ouro --bot`.
  - Independent argument surfaces per binary.
- Non-goals:
  - No behavior change inside the agent loop, factory, or `run_bot()`.
  - No version bump (stays `0.4.0`).

## Invariants (Must Not Regress)

- [x] `ouro-cli` interactive mode, `--task`, `--verify`, `--resume`, `--login/--logout`, `--reasoning-effort`, `--model` all parse and dispatch the same as before.
- [x] `ouro-bot` starts the aiohttp webhook server with `Config.validate()` + file logging + `Console(quiet=True)` exactly like the old `--bot` branch did.
- [x] Three-layer importlint contracts stay green (`interfaces → capabilities → core`).
- [x] No new dependencies; same packaging surface (`ouro.interfaces.bot` was already in `[tool.setuptools] packages`).

## Acceptance Criteria

- [x] `pip install -e .` exposes `ouro-cli` and `ouro-bot` on `$PATH`; the old `ouro` script is gone.
- [x] `ouro-cli -h` no longer lists `--bot`; `ouro-bot -h` shows only `--model` + `--version`.
- [x] `./scripts/dev.sh check` is fully green.

## Test Plan

- [x] Targeted: `pytest test/test_main_auth_cli.py -q` (9 passed).
- [x] `./scripts/dev.sh test -q` (585 passed, 1 skipped).
- [x] `./scripts/dev.sh importlint` (3 contracts kept).
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check`.

## Smoke Run (Real CLI)

- [x] `ouro-cli -h` and `ouro-bot -h` both render the expected argparse output.
- [ ] Live bot smoke run not executed locally (no IM creds in this dev env); behavior preserved by routing through unchanged `run_bot(model_id=...)`.

## Adversarial Review

- **Breakage**: anyone with muscle memory or scripts calling `ouro` / `ouro --bot` will break. Mitigation: the change is called out in README, the per-mode guides (LARK/SLACK/WECHAT/bot-guide), and the harbor runner — all updated in this PR. Version stays at 0.4.0 per maintainer's call.
- **Worst-case I/O**: none — pure argparse / entry-point reshuffle.
- **Secrets/logging**: no change. Bot still calls `ensure_runtime_dirs(create_logs=True)` + `setup_logger()` exactly as before.
- **Async/blocking**: no new I/O on hot paths. `asyncio.run(run_bot(...))` block lifted verbatim into `bot/main.py`.
- **Error messages**: `Config.validate()` failure still surfaces via `terminal_ui.print_error(..., title="Configuration Error")`.

## Docs / Compatibility

- [x] README quick-start + "Two Modes" table updated.
- [x] `docs/bot-guide.md`, `ouro/interfaces/bot/{README,LARK,SLACK,WECHAT}.md` updated.
- [x] `ouro/interfaces/CLAUDE.md` + `ouro/interfaces/README.md` updated (entry points, script tree).
- [x] `ouro_harbor/ouro_agent.py` invokes `ouro-cli` instead of `ouro`.
- [x] No secrets / generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)