### PR TITLE
fix(loop): wire LLM usage into TokenTracker so status bar reflects real tokens

### DIFF
--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -217,6 +217,7 @@ class AgentBuilder:
             hooks=hooks,
             max_iterations=self.max_iterations,
             progress=self.progress,
+            usage_callback=(memory.token_tracker.record_usage if memory is not None else None),
         )
 
         return ComposedAgent(

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any, Sequence
+from typing import Any, Callable, Sequence
 
 from ouro.core.llm import LLMMessage, LLMResponse, StopReason, ToolCall, ToolResult
 from ouro.core.llm.reasoning import normalize_reasoning_effort
@@ -41,6 +41,7 @@ class Agent:
         max_iterations: int = 1000,
         max_tokens_per_call: int | None = None,
         progress: ProgressSink | None = None,
+        usage_callback: Callable[[dict[str, int]], None] | None = None,
     ) -> None:
         self.llm = llm
         self.tools = tools
@@ -49,6 +50,7 @@ class Agent:
         self.max_tokens_per_call = max_tokens_per_call
         self.progress: ProgressSink = progress or NullProgressSink()
         self._reasoning_effort: str | None = None
+        self._usage_callback = usage_callback
 
     def set_reasoning_effort(self, value: str | None) -> None:
         self._reasoning_effort = normalize_reasoning_effort(value)
@@ -68,7 +70,7 @@ class Agent:
         # for unit tests and one-shot uses.
         if context is None:
             context = MessageListContext()
-        ctx = RunStatistic(task=task, progress=self.progress)
+        ctx = RunStatistic(task=task, progress=self.progress, usage_callback=self._usage_callback)
         messages = context.detached
         await self._fanout_async("on_run_start", ctx, messages)
 

--- a/ouro/core/loop/context.py
+++ b/ouro/core/loop/context.py
@@ -16,7 +16,7 @@ the context itself.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Callable, Iterable
 
 from ouro.core.llm import LLMMessage
 from ouro.core.loop.message_list import MessageList
@@ -26,12 +26,19 @@ from ouro.core.loop.protocols import ProgressSink
 class RunStatistic:
     """Mutable run state. Exposed to hooks via the LoopContext Protocol view."""
 
-    def __init__(self, task: str, progress: ProgressSink) -> None:
+    def __init__(
+        self,
+        task: str,
+        progress: ProgressSink,
+        *,
+        usage_callback: Callable[[dict[str, int]], None] | None = None,
+    ) -> None:
         self.task = task
         self.iteration = 0
         self.usage_total: dict[str, int] = {}
         self.stop_reason_last: str | None = None
         self.progress = progress
+        self._usage_callback = usage_callback
 
     def add_usage(self, usage: dict[str, int] | None) -> None:
         if not usage:
@@ -39,6 +46,8 @@ class RunStatistic:
         for k, v in usage.items():
             if isinstance(v, int):
                 self.usage_total[k] = self.usage_total.get(k, 0) + v
+        if self._usage_callback is not None:
+            self._usage_callback(usage)
 
 
 class MessageListContext:

--- a/test/test_loop_usage_callback.py
+++ b/test/test_loop_usage_callback.py
@@ -1,0 +1,73 @@
+"""Regression tests for usage_callback wiring in the core loop.
+
+Locks in the fix for the bug where ``TokenTracker.record_usage`` was
+never called after the Hook protocol was slimmed in #175, leaving the
+TUI status bar permanently at ``Total: 0↓ 0↑``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouro.capabilities.tools.executor import ToolExecutor
+from ouro.core.llm import LLMResponse, StopReason
+from ouro.core.loop import Agent, NullProgressSink
+
+
+class _StubLLM:
+    """Minimal LLM stub returning a single STOP response with usage."""
+
+    model = "stub-model"
+
+    def __init__(self) -> None:
+        self.calls: int = 0
+
+    async def call_async(self, **kwargs) -> LLMResponse:
+        self.calls += 1
+        return LLMResponse(
+            content="hi",
+            stop_reason=StopReason.STOP,
+            usage={"input_tokens": 11, "output_tokens": 7},
+        )
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse) -> list:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_agent_invokes_usage_callback_on_llm_response():
+    received: list[dict[str, int]] = []
+    agent = Agent(
+        llm=_StubLLM(),
+        tools=ToolExecutor([]),
+        hooks=(),
+        progress=NullProgressSink(),
+        usage_callback=lambda usage: received.append(dict(usage)),
+    )
+    await agent.run("hello")
+    assert received == [{"input_tokens": 11, "output_tokens": 7}]
+
+
+@pytest.mark.asyncio
+async def test_agent_builder_wires_usage_into_memory_token_tracker(tmp_path):
+    from ouro.capabilities.builder import AgentBuilder
+
+    builder = (
+        AgentBuilder()
+        .with_llm(_StubLLM())  # type: ignore[arg-type]
+        .with_memory(
+            sessions_dir=str(tmp_path / "sessions"),
+            memory_dir=str(tmp_path / "memory"),
+        )
+    )
+    composed = builder.build()
+    assert composed.memory is not None
+
+    await composed.run("hi")
+
+    stats = composed.get_memory_stats()
+    assert stats["total_input_tokens"] == 11
+    assert stats["total_output_tokens"] == 7


### PR DESCRIPTION
## Summary

The TUI status bar has been showing `Total: 0↓ 0↑` regardless of how many turns / tokens the session burned. Same for `/stats` and the bot's token report. Cost calculation in `MemoryManager.get_stats()` also reads zero.

Root cause: PR #175 (`c66a279`) slimmed the `Hook` protocol from 8 methods to 3, removing `on_llm_call_end` — the only thing that fed `TokenTracker.record_usage`. The tracker has been disconnected ever since.

This PR restores the wiring by threading an optional `usage_callback` through `Agent` → `RunStatistic.add_usage`. Hooking into `add_usage` (rather than directly at the call site in `Agent.run`) means we automatically capture **both** the main LLM call's usage *and* the compaction LLM call's usage, since `CompactionHook` also funnels through `ctx.add_usage(usage)`. `AgentBuilder.build()` wires `memory.token_tracker.record_usage` as the callback whenever memory is enabled.

The callback is a plain `Callable`, so the core → capabilities import direction stays clean (importlint: 3/3 contracts kept).

## Scope

- Goals: status bar / `/stats` / bot stats / cost reporting reflect actual token usage again; compaction LLM tokens also accounted for.
- Non-goals: redesigning the hook protocol; adding new hook lifecycle methods; changing the layer architecture.

## Invariants (Must Not Regress)

- [x] `ctx.usage_total` still accumulates the same way for in-loop stats.
- [x] `Agent`'s public signature is backward-compatible (`usage_callback` is keyword-only and defaults to `None`).
- [x] `RunStatistic(task=..., progress=...)` keyword construction in existing tests still works.
- [x] Loop never imports from `ouro.capabilities` or `ouro.interfaces` (importlint kept).
- [x] Compaction LLM-call usage continues to be tracked into `ctx.usage_total` and now flows into `TokenTracker` too.

## Acceptance Criteria

- [x] After a non-empty LLM exchange, `memory.token_tracker.total_input_tokens` and `total_output_tokens` are > 0.
- [x] `ComposedAgent.get_memory_stats()` returns non-zero `total_input_tokens` / `total_output_tokens` / `total_cost`.
- [x] New regression test fails without the wiring and passes with it.

## Test Plan

- [x] Targeted tests:
  - [x] `test/test_loop_usage_callback.py` (new — locks both the loop-level callback and the builder wiring)
  - [x] `test/memory/test_token_tracker.py`
  - [x] `test/memory/test_memory_manager.py`
  - [x] `test/test_parallel_tools.py`
  - [x] `test/test_ralph_loop.py`
- [x] `./scripts/dev.sh test -q` — 587 passed, 1 skipped.
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues found in 110 source files.
- [x] `./scripts/dev.sh importlint` — 3/3 contracts kept.
- [x] `./scripts/dev.sh check` — all gates green.

## Smoke Run (Real CLI)

Not run (interactive TUI session needed to observe the live status bar; covered by the new regression test which exercises `ComposedAgent.run` end-to-end with a stub LLM and asserts that `get_memory_stats()` returns the recorded token counts).

## Adversarial Review

- **Existing behavior at risk?** Tracker counts go from `0` to the real numbers — anywhere that branched on "is this still zero?" would notice, but no such code exists (greps for `total_input_tokens == 0` come back empty).
- **Worst-case input?** `usage` dicts are bounded small (a handful of int keys); the callback is a single function call per LLM response. No new allocations, no I/O.
- **Secrets / logging risks?** None — token counts only.
- **Async / blocking I/O on hot paths?** None — `record_usage` is pure integer arithmetic.
- **Error message on failure?** No new failure modes; if a future callback raises, it would bubble out of `RunStatistic.add_usage` and abort the run loudly (acceptable, surfaces bugs early). The builder only passes a memory-tracker method which can't fail.

## Docs / Compatibility

- [x] No doc changes needed (the wiring is an internal contract).
- [x] No secrets or generated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)