### PR TITLE
fix(loop): break self-reinforcing tool-call death loops

### DIFF
--- a/ouro/capabilities/compaction/compressor.py
+++ b/ouro/capabilities/compaction/compressor.py
@@ -31,9 +31,13 @@ class WorkingMemoryCompressor:
     COMPRESSION_PROMPT = """You are a memory compression system. Summarize the following conversation messages while preserving:
 1. Key decisions and outcomes
 2. Important facts, data, and findings
-3. Tool usage patterns and results
+3. Useful tool results that informed progress
 4. User intent and goals
 5. Critical context needed for future interactions
+
+IMPORTANT: If the conversation contains repeated identical tool calls whose results did not
+advance the task, do NOT describe them as a pattern to follow. Instead, flag them clearly as
+wasted iterations and instruct the future assistant NOT to repeat those calls.
 
 Original messages ({count} messages, ~{tokens} tokens):
 
@@ -47,9 +51,14 @@ Original messages ({count} messages, ~{tokens} tokens):
         "Summarize the conversation above while preserving:\n"
         "1. Key decisions and outcomes\n"
         "2. Important facts, data, and findings\n"
-        "3. Tool usage patterns and results\n"
+        "3. Useful tool results that informed progress\n"
         "4. User intent and goals\n"
         "5. Critical context needed for future interactions\n"
+        "\n"
+        "IMPORTANT: If the conversation contains repeated identical tool calls whose results "
+        "did not advance the task, do NOT describe them as a pattern to follow. Instead, flag "
+        "them clearly as wasted iterations and instruct the future assistant NOT to repeat "
+        "those calls.\n"
         "\n"
         "Target length: {target_tokens} tokens. Be concise but include concrete details."
     )

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -8,6 +8,7 @@ memory, BaseTool, verification, or terminal UI — those plug in via
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from typing import Any, Callable, Sequence
 
@@ -42,6 +43,8 @@ class Agent:
         max_tokens_per_call: int | None = None,
         progress: ProgressSink | None = None,
         usage_callback: Callable[[dict[str, int]], None] | None = None,
+        repeat_tool_call_threshold: int = 3,
+        repeat_tool_call_max: int = 5,
     ) -> None:
         self.llm = llm
         self.tools = tools
@@ -51,6 +54,11 @@ class Agent:
         self.progress: ProgressSink = progress or NullProgressSink()
         self._reasoning_effort: str | None = None
         self._usage_callback = usage_callback
+        # Soft intercept at `repeat_tool_call_threshold` consecutive identical
+        # tool-call iterations; hard terminate at `repeat_tool_call_max`.
+        # Setting threshold <= 0 disables the circuit breaker entirely.
+        self.repeat_tool_call_threshold = repeat_tool_call_threshold
+        self.repeat_tool_call_max = repeat_tool_call_max
 
     def set_reasoning_effort(self, value: str | None) -> None:
         self._reasoning_effort = normalize_reasoning_effort(value)
@@ -76,6 +84,11 @@ class Agent:
 
         tool_schemas = self.tools.get_tool_schemas()
         final_answer: str = ""
+        # Per-run state for the repeated-tool-call circuit breaker. Tracks the
+        # last iteration's tool-call signature and how many iterations in a
+        # row have emitted the same signature. See `_tool_call_iter_signature`.
+        last_iter_sig: tuple[tuple[str, str], ...] | None = None
+        repeat_count: int = 0
         for ctx.iteration in range(1, self.max_iterations + 1):
             # Hooks may mutate ``context`` in place here (e.g.
             # ``CompactionHook`` compresses ``context.detached``).
@@ -139,6 +152,81 @@ class Agent:
                 # dispatching, so the tool result messages we append
                 # below sit in the correct chronological order.
                 messages.append(response.to_message())
+
+                # Repeated-tool-call circuit breaker. Compaction summaries
+                # can re-inject pathological tool-call patterns as if they
+                # were task state, so when the model emits the same
+                # (name, arguments) iteration N times in a row we either
+                # synthesize a "stop repeating" tool_result (soft) or
+                # terminate the run (hard).
+                iter_sig = _tool_call_iter_signature(tool_calls)
+                if last_iter_sig is not None and iter_sig == last_iter_sig:
+                    repeat_count += 1
+                else:
+                    last_iter_sig = iter_sig
+                    repeat_count = 1
+
+                if (
+                    self.repeat_tool_call_threshold > 0
+                    and repeat_count >= self.repeat_tool_call_max
+                ):
+                    for tc in tool_calls:
+                        messages.append(
+                            LLMMessage(
+                                role="tool",
+                                content=(
+                                    f"[ouro] Same tool_call(s) repeated {repeat_count} "
+                                    "times consecutively with no progress. Terminating "
+                                    "to prevent runaway loop."
+                                ),
+                                tool_call_id=tc.id,
+                                name=tc.name,
+                            )
+                        )
+                    logger.warning(
+                        "Agent.run: hard-stopping after %d consecutive identical "
+                        "tool_call iterations on iteration %d (names=%s)",
+                        repeat_count,
+                        ctx.iteration,
+                        [tc.name for tc in tool_calls],
+                    )
+                    final_answer = (
+                        "[ouro] Halted: the model repeated the same tool call "
+                        f"{repeat_count} times without progress "
+                        f"({[tc.name for tc in tool_calls]}). Please rephrase your "
+                        "request or restart the session."
+                    )
+                    self.progress.unfinished_answer(final_answer)
+                    return final_answer
+
+                if (
+                    self.repeat_tool_call_threshold > 0
+                    and repeat_count >= self.repeat_tool_call_threshold
+                ):
+                    feedback = (
+                        f"[ouro] This exact tool_call has now been issued {repeat_count} "
+                        "times consecutively. The result has not changed. Stop repeating: "
+                        "either choose a different action, ask the user for clarification, "
+                        "or finish the task."
+                    )
+                    for tc in tool_calls:
+                        messages.append(
+                            LLMMessage(
+                                role="tool",
+                                content=feedback,
+                                tool_call_id=tc.id,
+                                name=tc.name,
+                            )
+                        )
+                    logger.warning(
+                        "Agent.run: intercepted %d-times-repeated tool_call(s) on "
+                        "iteration %d (names=%s)",
+                        repeat_count,
+                        ctx.iteration,
+                        [tc.name for tc in tool_calls],
+                    )
+                    continue
+
                 tool_results = await self._dispatch_tools(ctx, tool_calls)
                 for tc, tr in zip(tool_calls, tool_results):
                     messages.append(
@@ -313,6 +401,27 @@ class Agent:
         if retries:
             return ContinueDecision.retry_with_feedback(*retries)
         return decision
+
+
+def _tool_call_iter_signature(
+    tool_calls: list[ToolCall],
+) -> tuple[tuple[str, str], ...]:
+    """Build a deterministic fingerprint for one iteration's tool_calls.
+
+    Used by the repeated-tool-call circuit breaker to detect when the model
+    is emitting the exact same (name, arguments) batch iteration after
+    iteration. Arguments are serialized with ``sort_keys=True`` so key order
+    is normalized; non-JSON-safe values fall back to ``str(...)`` so the
+    helper never raises on exotic argument types.
+    """
+    sigs: list[tuple[str, str]] = []
+    for tc in tool_calls:
+        try:
+            args_repr = json.dumps(tc.arguments, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            args_repr = repr(tc.arguments)
+        sigs.append((tc.name, args_repr))
+    return tuple(sigs)
 
 
 def _log_outgoing_messages(iteration: int, messages: list[LLMMessage]) -> None:

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Literal, NamedTuple, Sequence
 
 from ouro.core.llm import LLMMessage, LLMResponse, StopReason, ToolCall, ToolResult
 from ouro.core.llm.reasoning import normalize_reasoning_effort
@@ -153,78 +153,20 @@ class Agent:
                 # below sit in the correct chronological order.
                 messages.append(response.to_message())
 
-                # Repeated-tool-call circuit breaker. Compaction summaries
-                # can re-inject pathological tool-call patterns as if they
-                # were task state, so when the model emits the same
-                # (name, arguments) iteration N times in a row we either
-                # synthesize a "stop repeating" tool_result (soft) or
-                # terminate the run (hard).
-                iter_sig = _tool_call_iter_signature(tool_calls)
-                if last_iter_sig is not None and iter_sig == last_iter_sig:
-                    repeat_count += 1
-                else:
-                    last_iter_sig = iter_sig
-                    repeat_count = 1
-
-                if (
-                    self.repeat_tool_call_threshold > 0
-                    and repeat_count >= self.repeat_tool_call_max
-                ):
-                    for tc in tool_calls:
-                        messages.append(
-                            LLMMessage(
-                                role="tool",
-                                content=(
-                                    f"[ouro] Same tool_call(s) repeated {repeat_count} "
-                                    "times consecutively with no progress. Terminating "
-                                    "to prevent runaway loop."
-                                ),
-                                tool_call_id=tc.id,
-                                name=tc.name,
-                            )
-                        )
-                    logger.warning(
-                        "Agent.run: hard-stopping after %d consecutive identical "
-                        "tool_call iterations on iteration %d (names=%s)",
-                        repeat_count,
-                        ctx.iteration,
-                        [tc.name for tc in tool_calls],
-                    )
-                    final_answer = (
-                        "[ouro] Halted: the model repeated the same tool call "
-                        f"{repeat_count} times without progress "
-                        f"({[tc.name for tc in tool_calls]}). Please rephrase your "
-                        "request or restart the session."
-                    )
+                guard = self._apply_repeated_tool_call_guard(
+                    tool_calls=tool_calls,
+                    messages=messages,
+                    last_iter_sig=last_iter_sig,
+                    repeat_count=repeat_count,
+                    iteration=ctx.iteration,
+                )
+                last_iter_sig = guard.last_iter_sig
+                repeat_count = guard.repeat_count
+                if guard.action == "halted":
+                    final_answer = guard.final_answer or ""
                     self.progress.unfinished_answer(final_answer)
                     return final_answer
-
-                if (
-                    self.repeat_tool_call_threshold > 0
-                    and repeat_count >= self.repeat_tool_call_threshold
-                ):
-                    feedback = (
-                        f"[ouro] This exact tool_call has now been issued {repeat_count} "
-                        "times consecutively. The result has not changed. Stop repeating: "
-                        "either choose a different action, ask the user for clarification, "
-                        "or finish the task."
-                    )
-                    for tc in tool_calls:
-                        messages.append(
-                            LLMMessage(
-                                role="tool",
-                                content=feedback,
-                                tool_call_id=tc.id,
-                                name=tc.name,
-                            )
-                        )
-                    logger.warning(
-                        "Agent.run: intercepted %d-times-repeated tool_call(s) on "
-                        "iteration %d (names=%s)",
-                        repeat_count,
-                        ctx.iteration,
-                        [tc.name for tc in tool_calls],
-                    )
+                if guard.action == "intercepted":
                     continue
 
                 tool_results = await self._dispatch_tools(ctx, tool_calls)
@@ -274,6 +216,90 @@ class Agent:
 
         logger.warning("Agent.run reached max_iterations=%d without STOP", self.max_iterations)
         return final_answer
+
+    def _apply_repeated_tool_call_guard(
+        self,
+        *,
+        tool_calls: list[ToolCall],
+        messages: MessageList,
+        last_iter_sig: tuple[tuple[str, str], ...] | None,
+        repeat_count: int,
+        iteration: int,
+    ) -> _RepeatGuardOutcome:
+        """Track consecutive identical tool_call iterations and intercept loops.
+
+        Compaction summaries can re-inject pathological tool-call patterns as
+        if they were task state, so when the model emits the same
+        ``(name, arguments)`` iteration N times in a row we either synthesize
+        a "stop repeating" tool_result (soft intercept) or terminate the run
+        (hard stop).  This method updates ``messages`` in place with the
+        synthesized tool_results when intercepting; the caller routes on
+        ``outcome.action``.
+        """
+        iter_sig = _tool_call_iter_signature(tool_calls)
+        if last_iter_sig is not None and iter_sig == last_iter_sig:
+            new_repeat_count = repeat_count + 1
+        else:
+            new_repeat_count = 1
+
+        if self.repeat_tool_call_threshold <= 0:
+            return _RepeatGuardOutcome("dispatch", iter_sig, new_repeat_count, None)
+
+        if new_repeat_count >= self.repeat_tool_call_max:
+            for tc in tool_calls:
+                messages.append(
+                    LLMMessage(
+                        role="tool",
+                        content=(
+                            f"[ouro] Same tool_call(s) repeated {new_repeat_count} "
+                            "times consecutively with no progress. Terminating "
+                            "to prevent runaway loop."
+                        ),
+                        tool_call_id=tc.id,
+                        name=tc.name,
+                    )
+                )
+            logger.warning(
+                "Agent.run: hard-stopping after %d consecutive identical "
+                "tool_call iterations on iteration %d (names=%s)",
+                new_repeat_count,
+                iteration,
+                [tc.name for tc in tool_calls],
+            )
+            final_answer = (
+                "[ouro] Halted: the model repeated the same tool call "
+                f"{new_repeat_count} times without progress "
+                f"({[tc.name for tc in tool_calls]}). Please rephrase your "
+                "request or restart the session."
+            )
+            return _RepeatGuardOutcome("halted", iter_sig, new_repeat_count, final_answer)
+
+        if new_repeat_count >= self.repeat_tool_call_threshold:
+            feedback = (
+                f"[ouro] This exact tool_call has now been issued {new_repeat_count} "
+                "times consecutively. The result has not changed. Stop repeating: "
+                "either choose a different action, ask the user for clarification, "
+                "or finish the task."
+            )
+            for tc in tool_calls:
+                messages.append(
+                    LLMMessage(
+                        role="tool",
+                        content=feedback,
+                        tool_call_id=tc.id,
+                        name=tc.name,
+                    )
+                )
+            logger.warning(
+                "Agent.run: intercepted %d-times-repeated tool_call(s) on "
+                "iteration %d (names=%s)",
+                new_repeat_count,
+                iteration,
+                [tc.name for tc in tool_calls],
+            )
+            return _RepeatGuardOutcome("intercepted", iter_sig, new_repeat_count, None)
+
+        return _RepeatGuardOutcome("dispatch", iter_sig, new_repeat_count, None)
 
     async def _dispatch_tools(
         self,
@@ -401,6 +427,21 @@ class Agent:
         if retries:
             return ContinueDecision.retry_with_feedback(*retries)
         return decision
+
+
+class _RepeatGuardOutcome(NamedTuple):
+    """Result of one iteration's repeated-tool-call check.
+
+    ``action`` routes the caller:
+    - ``"dispatch"``: not a repeat (or breaker disabled); run the tools normally.
+    - ``"intercepted"``: synthesized tool_results already appended; ``continue``.
+    - ``"halted"``: synthesized tool_results already appended; return ``final_answer``.
+    """
+
+    action: Literal["dispatch", "intercepted", "halted"]
+    last_iter_sig: tuple[tuple[str, str], ...]
+    repeat_count: int
+    final_answer: str | None
 
 
 def _tool_call_iter_signature(

--- a/test/test_repeat_tool_call_circuit_breaker.py
+++ b/test/test_repeat_tool_call_circuit_breaker.py
@@ -1,0 +1,195 @@
+"""Regression tests for the repeated-tool-call circuit breaker in Agent.
+
+Locks in the fix for the death loop where compaction summaries describe
+prior repetitive tool calls as "patterns", causing the model to resume
+emitting the identical call iteration after iteration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouro.capabilities.tools.base import BaseTool
+from ouro.capabilities.tools.executor import ToolExecutor
+from ouro.core.llm import LLMResponse, StopReason, ToolCall
+from ouro.core.loop import Agent, NullProgressSink
+from ouro.core.loop.agent import _tool_call_iter_signature
+
+
+class _NoopTool(BaseTool):
+    readonly = True
+
+    def __init__(self, name: str = "read_file") -> None:
+        self._name = name
+        self.invocations: int = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "stub"
+
+    @property
+    def parameters(self):
+        return {}
+
+    async def execute(self, **kwargs) -> str:
+        self.invocations += 1
+        return "stub-result"
+
+
+class _ScriptedLLM:
+    """LLM stub that emits a fixed list of responses, then a STOP."""
+
+    model = "stub-model"
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: int = 0
+
+    async def call_async(self, **kwargs) -> LLMResponse:
+        self.calls += 1
+        if self._responses:
+            return self._responses.pop(0)
+        return LLMResponse(content="done", stop_reason=StopReason.STOP)
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]:
+        return list(response.tool_calls or [])
+
+
+def _tool_call_response(call_id: str, name: str, args: dict) -> LLMResponse:
+    return LLMResponse(
+        content=None,
+        stop_reason=StopReason.TOOL_CALLS,
+        tool_calls=[ToolCall(id=call_id, name=name, arguments=args)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _tool_call_iter_signature
+# ---------------------------------------------------------------------------
+
+
+def test_signature_normalizes_argument_key_order():
+    a = ToolCall(id="1", name="read_file", arguments={"file_path": "/x", "offset": 0})
+    b = ToolCall(id="2", name="read_file", arguments={"offset": 0, "file_path": "/x"})
+    assert _tool_call_iter_signature([a]) == _tool_call_iter_signature([b])
+
+
+def test_signature_differs_when_arguments_differ():
+    a = ToolCall(id="1", name="read_file", arguments={"file_path": "/x"})
+    b = ToolCall(id="2", name="read_file", arguments={"file_path": "/y"})
+    assert _tool_call_iter_signature([a]) != _tool_call_iter_signature([b])
+
+
+def test_signature_handles_non_json_safe_arguments():
+    # Should not raise on exotic values; falls back to string repr.
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    tc = ToolCall(id="1", name="x", arguments={"v": Weird()})
+    assert _tool_call_iter_signature([tc])  # smoke test: doesn't raise
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_third_identical_call_is_intercepted_with_synthetic_feedback():
+    """At threshold=3, the 3rd identical iteration short-circuits dispatch."""
+    args = {"file_path": "/m.py", "offset": 0, "limit": 100}
+    tool = _NoopTool("read_file")
+    llm = _ScriptedLLM(
+        [
+            _tool_call_response("c1", "read_file", args),
+            _tool_call_response("c2", "read_file", args),
+            _tool_call_response("c3", "read_file", args),  # intercepted
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([tool]),
+        hooks=(),
+        progress=NullProgressSink(),
+    )
+    answer = await agent.run("test")
+    assert answer == "ok"
+    # 1st & 2nd dispatched; 3rd intercepted → tool actually ran only twice.
+    assert tool.invocations == 2
+
+
+@pytest.mark.asyncio
+async def test_fifth_identical_call_hard_stops_run():
+    """At max=5, the run terminates with an explanatory final answer."""
+    args = {"file_path": "/m.py", "offset": 0, "limit": 100}
+    tool = _NoopTool("read_file")
+    llm = _ScriptedLLM([_tool_call_response(f"c{i}", "read_file", args) for i in range(1, 7)])
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([tool]),
+        hooks=(),
+        progress=NullProgressSink(),
+    )
+    answer = await agent.run("test")
+    assert "Halted" in answer
+    assert "read_file" in answer
+    # 1st & 2nd dispatched; 3rd & 4th intercepted; 5th hard-stops.
+    assert tool.invocations == 2
+    # LLM was called 5 times before the breaker fired.
+    assert llm.calls == 5
+
+
+@pytest.mark.asyncio
+async def test_changing_arguments_resets_repeat_counter():
+    """Same tool name but different args is NOT a repeat."""
+    tool = _NoopTool("read_file")
+    llm = _ScriptedLLM(
+        [
+            _tool_call_response("c1", "read_file", {"file_path": "/a.py"}),
+            _tool_call_response("c2", "read_file", {"file_path": "/a.py"}),
+            _tool_call_response("c3", "read_file", {"file_path": "/b.py"}),
+            _tool_call_response("c4", "read_file", {"file_path": "/b.py"}),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([tool]),
+        hooks=(),
+        progress=NullProgressSink(),
+    )
+    answer = await agent.run("test")
+    assert answer == "ok"
+    # No interception — all 4 calls dispatched.
+    assert tool.invocations == 4
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_disabled_by_zero_threshold():
+    """Setting threshold=0 disables the safety net (back to old behavior)."""
+    args = {"file_path": "/m.py"}
+    tool = _NoopTool("read_file")
+    llm = _ScriptedLLM(
+        [_tool_call_response(f"c{i}", "read_file", args) for i in range(1, 4)]
+        + [LLMResponse(content="ok", stop_reason=StopReason.STOP)]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([tool]),
+        hooks=(),
+        progress=NullProgressSink(),
+        repeat_tool_call_threshold=0,
+    )
+    answer = await agent.run("test")
+    assert answer == "ok"
+    # All 3 dispatched (no interception).
+    assert tool.invocations == 3


### PR DESCRIPTION
## Summary

When the model emits the same `(name, arguments)` tool_call iteration after iteration, ouro had no safeguard: `max_iterations=1000` was the only ceiling, and the existing LENGTH-stop death-loop guard only covers `max_tokens` truncation. Worse, when compaction fires mid-loop, the summary faithfully records "reading the same file 60+ times" as a *tool-usage pattern*, which the post-compaction model rehydrates as a current instruction — turning a transient model glitch into a stable, token-burning fixed point.

Verified against a real session: `~/.ouro/sessions/2026-05-20_02532c62/session.yaml` contained a `[Previous conversation summary]` describing 60+ duplicate `read_file(manager.py, 0, 100)` calls, immediately followed by three more identical calls before the model finally recovered. This PR catches that on the 3rd call.

## Scope

- **Goals**: prevent the agent loop from getting stuck repeating identical tool_calls; stop compaction summaries from documenting that pathological behavior as a pattern to follow.
- **Non-goals**: detecting non-identical-but-equivalent loops (e.g. alternating A→B→A→B), adapting threshold to model behavior, or any change to memory/long-term/skills layers.

## Invariants (Must Not Regress)

- [x] Normal tool dispatch path unchanged when threshold not reached.
- [x] Parallel batching (`_build_batches`) and conflict-key logic unchanged.
- [x] `usage_callback` wiring (#183) still fires on every LLM response.
- [x] `StopReason.LENGTH` partial-answer death-loop guard still active.
- [x] Compaction's tool-pair preservation (`_find_tool_pairs`, `_separate_messages`) unchanged.

## Acceptance Criteria

- [x] 3rd consecutive identical tool_call iteration short-circuits real dispatch and synthesizes a "stop repeating, change strategy" tool_result.
- [x] 5th consecutive identical iteration hard-stops `agent.run()` with an explanatory final answer.
- [x] Different argument values reset the consecutive counter.
- [x] `repeat_tool_call_threshold=0` disables the breaker entirely.
- [x] `COMPACTION_PROMPT` and `COMPRESSION_PROMPT` explicitly tell the summarizer to flag repeated identical calls as wasted iterations.

## Test Plan

- [x] Targeted tests: `test/test_repeat_tool_call_circuit_breaker.py` — **7/7 pass** (signature normalization x3, soft intercept, hard stop, args-change reset, threshold=0 disable).
- [x] `./scripts/dev.sh test -q` — **594 passed, 1 skipped**.
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — 7 errors all in `ouro/interfaces/bot/channel/slack.py`, **pre-existing on `origin/main`**, unrelated to this PR.

## Smoke Run (Real CLI)

- [ ] Not run: the original session that produced the loop required a non-deterministic model glitch under specific compaction history that's hard to reproduce on demand. Unit tests with a scripted LLM cover the same code path deterministically.

## Adversarial Review

- **What existing behavior could this break?**
  - Legitimate retry patterns (e.g. polling a tool that's expected to return the same result several times) could trip the breaker. Mitigation: threshold is 3 + 2 more before hard stop, and the soft intercept *continues* the conversation rather than aborting — the model can clarify or retry with different args.
  - A tool whose arguments include a non-JSON-serializable object would have its signature fall back to `repr()`. That's still deterministic but not as collision-resistant; unlikely in practice since ouro's tool args go through LLM JSON.

- **Worst-case input/output size?** Signature is a tuple of `(name, sorted_json_args)` strings per iteration. Synthetic tool_result is ~300 chars. No buffer growth — `last_iter_sig` and `repeat_count` are scalar per-run state.

- **Secrets/logging risks?** New `logger.warning` lines log tool names and iteration counts. Tool *arguments* are not logged (only their signature drives the comparison, and even that is not serialized to logs).

- **Async/blocking I/O added?** None. Pure synchronous comparison in the existing async loop body.

- **What error message does the user see on failure?** Soft intercept: model continues with feedback in conversation. Hard stop: `[ouro] Halted: the model repeated the same tool call N times without progress (['read_file']). Please rephrase your request or restart the session.` — surfaced via `progress.unfinished_answer`.

## Docs / Compatibility

- No docs change needed; defaults are conservative (3/5) and the parameters are constructor-only, not exposed via CLI.
- No secrets / generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)