### PR TITLE
chore: release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-05-20
+
+### Added
+
+- **mem0 integration**: optional vector-memory backend via mem0. Enable
+  by installing the `mem0` extra (`pip install ouro-ai[mem0]`) and
+  configuring it in `~/.ouro/config`. A new `BaseLongTermMemory` ABC
+  unifies the contract across the in-tree memory store and mem0.
+
+### Fixed
+
+- **Loop death loops**: detect and break self-reinforcing tool-call
+  loops where compaction summaries re-encode repeated tool calls as
+  "patterns" and feed them back into the model (#185).
+- **Token tracker**: wire actual LLM usage into `TokenTracker` so the
+  status bar reflects real token counts instead of stale/zero values (#183).
+
+### Docs
+
+- Updated README and `docs/memory-management.md` to cover the mem0
+  backend and configuration (#186).
+
+## [0.4.1] - 2026-05-08
+
+### Fixed
+
+- **Packaging**: include `ouro.capabilities.compaction` in the wheel
+  and add an invariant check so missing subpackages fail the build
+  rather than silently breaking PyPI installs (#182).
+
 ## [0.4.0] - 2026-04-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ouro-ai"
-version = "0.4.1"
+version = "0.4.2"
 description = "General AI Agent System"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bump version to 0.4.2
- Add CHANGELOG entries for 0.4.1 (packaging fix) and 0.4.2

## Scope

- Goals:
  - Cut a PyPI release covering mem0 integration + recent loop fixes
- Non-goals:
  - No code changes; pure metadata/changelog

## Changes since v0.4.1

- feat: integrate mem0 as optional vector-memory backend (#184)
- fix(loop): wire LLM usage into TokenTracker so status bar reflects real tokens (#183)
- fix(loop): break self-reinforcing tool-call death loops (#185)
- docs: update README and docs for mem0 integration (#186)

## Invariants (Must Not Regress)

- [x] `./scripts/dev.sh check` passes (precommit + importlint + typecheck + 607 tests)
- [x] Three-layer import boundaries kept
- [x] No code changes outside `pyproject.toml` / `CHANGELOG.md`

## Acceptance Criteria

- [x] `pyproject.toml` shows `version = "0.4.2"`
- [x] CHANGELOG documents both 0.4.1 and 0.4.2 entries

## Test Plan

- [x] `./scripts/dev.sh check`

## Smoke Run

- N/A — metadata-only change; smoke covered by existing 0.4.1 install workflows.

## Adversarial Review

- Breakage risk: zero runtime change. Only risk is mis-stating the changelog scope.
- Secrets/logging: none.
- Publish step is gated separately after merge.

## Docs / Compatibility

- [x] CHANGELOG updated
- [x] No secrets / no generated artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)