### PR TITLE
feat(memory): conversation_search tool backed by SQLite FTS5

### DIFF
--- a/ouro/capabilities/memory/manager.py
+++ b/ouro/capabilities/memory/manager.py
@@ -66,6 +66,11 @@ class MemoryManager:
         self.token_tracker = TokenTracker()
         self._compaction = CompactionManager(llm)
 
+        # Conversation recall (FTS5 over historical messages — no embedder).
+        # Created lazily on first save_memory; only when feature is enabled.
+        self._recall_index: Any = None
+        self._recall_memory_dir = memory_dir
+
         self._long_term: BaseLongTermMemory | None = None
         if Config.LONG_TERM_MEMORY_ENABLED:
             from .long_term import LongTermMemoryManager
@@ -207,7 +212,32 @@ class MemoryManager:
             system_messages=sys_msgs,
             messages=messages,
         )
+        # Reindex FTS recall — best-effort, never blocks the save path.
+        if Config.LTM_CONVERSATION_SEARCH_ENABLED:
+            try:
+                index = self._get_recall_index()
+                if index is not None:
+                    await index.reindex_session(self.session_id, messages)
+            except Exception:
+                logger.warning("Failed to reindex recall FTS", exc_info=True)
         logger.info(f"Saved memory state for session {self.session_id}")
+
+    def _get_recall_index(self) -> Any:
+        """Lazy-instantiate the FTS recall index. Returns None when disabled."""
+        if not Config.LTM_CONVERSATION_SEARCH_ENABLED:
+            return None
+        if self._recall_index is None:
+            from ouro.capabilities.memory.recall import RecallIndex
+            from ouro.core.runtime import get_memory_dir
+
+            memory_dir = self._recall_memory_dir or get_memory_dir()
+            self._recall_index = RecallIndex(memory_dir)
+        return self._recall_index
+
+    @property
+    def recall_index(self) -> Any:
+        """Public accessor for the recall index (or None when disabled)."""
+        return self._get_recall_index()
 
     def get_stats(self, *, context: MessageListContext) -> dict[str, Any]:
         """Return token usage + cost stats for the current run.

--- a/ouro/capabilities/memory/recall/__init__.py
+++ b/ouro/capabilities/memory/recall/__init__.py
@@ -1,0 +1,10 @@
+"""Recall memory — keyword search over historical conversation messages.
+
+SQLite FTS5 backed; no embedder required. Built on the OS-paging idea from
+Letta/MemGPT: keep recent messages in context, page older messages out to
+an indexed store, search them on demand via a tool call.
+"""
+
+from ouro.capabilities.memory.recall.sqlite_fts import RecallIndex
+
+__all__ = ["RecallIndex"]

--- a/ouro/capabilities/memory/recall/sqlite_fts.py
+++ b/ouro/capabilities/memory/recall/sqlite_fts.py
@@ -1,0 +1,255 @@
+"""SQLite FTS5-backed recall index for conversation messages.
+
+The index lives at ``<memory_dir>/recall.db`` and contains a single FTS5
+virtual table with one row per message. Writes are best-effort: an indexing
+failure must never break the loop. Reads are scoped by ``session_id`` when
+provided.
+
+Threading: ``sqlite3`` connections are not safe to share between threads, so
+every operation opens a fresh connection inside ``asyncio.to_thread``. WAL
+mode is enabled so concurrent readers/writers don't block each other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sqlite3
+from typing import Any, Iterable
+
+from ouro.core.llm.message_types import LLMMessage
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DB_NAME = "recall.db"
+
+
+def _flatten_content(content: Any) -> str:
+    """Flatten LLMMessage.content into a single searchable string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                elif "content" in block and isinstance(block["content"], str):
+                    parts.append(block["content"])
+        return "\n".join(p for p in parts if p)
+    return str(content)
+
+
+class RecallIndex:
+    """FTS5-backed message store keyed by ``(session_id, message_idx)``.
+
+    Use ``reindex_session`` to replace all rows for a session in one go —
+    that's the natural fit for ``save_memory`` which writes the full
+    snapshot. ``add_message`` is provided for incremental writes.
+    """
+
+    def __init__(self, memory_dir: str, db_name: str = _DEFAULT_DB_NAME) -> None:
+        self.memory_dir = memory_dir
+        self.db_path = os.path.join(memory_dir, db_name)
+
+    # ---- sync helpers (run inside asyncio.to_thread) ---------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        os.makedirs(self.memory_dir, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, isolation_level=None, timeout=10.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        return conn
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        # FTS5 virtual table — content is searchable; the rest is UNINDEXED metadata.
+        conn.execute(
+            """
+            CREATE VIRTUAL TABLE IF NOT EXISTS messages USING fts5(
+                session_id UNINDEXED,
+                msg_idx UNINDEXED,
+                role UNINDEXED,
+                timestamp UNINDEXED,
+                content
+            )
+            """
+        )
+
+    def _reindex_session_sync(
+        self,
+        session_id: str,
+        messages: list[tuple[int, str, str, str]],
+    ) -> None:
+        """Replace all rows for session_id with the given messages.
+
+        Args:
+            session_id: Session UUID.
+            messages: list of (msg_idx, role, timestamp, content).
+        """
+        conn = self._connect()
+        try:
+            self._ensure_schema(conn)
+            conn.execute("BEGIN")
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            if messages:
+                conn.executemany(
+                    "INSERT INTO messages (session_id, msg_idx, role, timestamp, content) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    [(session_id, idx, role, ts, content) for idx, role, ts, content in messages],
+                )
+            conn.execute("COMMIT")
+        finally:
+            conn.close()
+
+    def _add_message_sync(
+        self,
+        session_id: str,
+        msg_idx: int,
+        role: str,
+        timestamp: str,
+        content: str,
+    ) -> None:
+        conn = self._connect()
+        try:
+            self._ensure_schema(conn)
+            conn.execute(
+                "INSERT INTO messages (session_id, msg_idx, role, timestamp, content) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (session_id, msg_idx, role, timestamp, content),
+            )
+        finally:
+            conn.close()
+
+    def _search_sync(
+        self,
+        query: str,
+        session_id: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        if not os.path.isfile(self.db_path):
+            return []
+        conn = self._connect()
+        try:
+            cur = conn.cursor()
+            # bm25() ranking — lower is more relevant
+            if session_id:
+                cur.execute(
+                    "SELECT session_id, msg_idx, role, timestamp, content, bm25(messages) AS rank "
+                    "FROM messages WHERE messages MATCH ? AND session_id = ? "
+                    "ORDER BY rank LIMIT ?",
+                    (query, session_id, limit),
+                )
+            else:
+                cur.execute(
+                    "SELECT session_id, msg_idx, role, timestamp, content, bm25(messages) AS rank "
+                    "FROM messages WHERE messages MATCH ? "
+                    "ORDER BY rank LIMIT ?",
+                    (query, limit),
+                )
+            rows = cur.fetchall()
+            return [
+                {
+                    "session_id": r[0],
+                    "msg_idx": r[1],
+                    "role": r[2],
+                    "timestamp": r[3],
+                    "content": r[4],
+                    "score": r[5],
+                }
+                for r in rows
+            ]
+        finally:
+            conn.close()
+
+    def _delete_session_sync(self, session_id: str) -> int:
+        if not os.path.isfile(self.db_path):
+            return 0
+        conn = self._connect()
+        try:
+            self._ensure_schema(conn)
+            cur = conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            return cur.rowcount or 0
+        finally:
+            conn.close()
+
+    # ---- async API -------------------------------------------------------
+
+    async def reindex_session(
+        self,
+        session_id: str,
+        messages: Iterable[LLMMessage],
+        *,
+        timestamp: str = "",
+    ) -> None:
+        """Atomically replace all FTS rows for *session_id* with *messages*.
+
+        Empty-content messages are skipped (no point indexing tool-call
+        scaffolding). Failures are logged but not raised — recall is
+        non-critical.
+        """
+        rows: list[tuple[int, str, str, str]] = []
+        for idx, msg in enumerate(messages):
+            content = _flatten_content(msg.content)
+            if not content.strip():
+                continue
+            rows.append((idx, msg.role, timestamp, content))
+        try:
+            await asyncio.to_thread(self._reindex_session_sync, session_id, rows)
+        except Exception:
+            logger.warning("FTS recall reindex failed for session %s", session_id, exc_info=True)
+
+    async def add_message(
+        self,
+        session_id: str,
+        msg_idx: int,
+        message: LLMMessage,
+        *,
+        timestamp: str = "",
+    ) -> None:
+        content = _flatten_content(message.content)
+        if not content.strip():
+            return
+        try:
+            await asyncio.to_thread(
+                self._add_message_sync,
+                session_id,
+                msg_idx,
+                message.role,
+                timestamp,
+                content,
+            )
+        except Exception:
+            logger.warning("FTS recall add_message failed", exc_info=True)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        session_id: str | None = None,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Run an FTS5 MATCH query, scoped to *session_id* if given.
+
+        Returns at most *limit* hits ordered by bm25 relevance.
+        """
+        if not query or not query.strip():
+            return []
+        try:
+            return await asyncio.to_thread(self._search_sync, query, session_id, limit)
+        except sqlite3.OperationalError as e:
+            # Common cause: malformed FTS query syntax. Surface a clean empty result.
+            logger.debug("FTS recall search syntax error for query %r: %s", query, e)
+            return []
+        except Exception:
+            logger.warning("FTS recall search failed", exc_info=True)
+            return []
+
+    async def delete_session(self, session_id: str) -> int:
+        try:
+            return await asyncio.to_thread(self._delete_session_sync, session_id)
+        except Exception:
+            logger.warning("FTS recall delete_session failed", exc_info=True)
+            return 0

--- a/ouro/capabilities/tools/builtins/conversation_search.py
+++ b/ouro/capabilities/tools/builtins/conversation_search.py
@@ -1,0 +1,105 @@
+"""Conversation search tool — keyword search over historical messages.
+
+Backed by the SQLite FTS5 ``RecallIndex``. Returns the most relevant past
+messages for a query, optionally scoped to a single session.
+
+This is the "recall memory" layer in the Letta/MemGPT sense: messages that
+have been paged out of context can be searched on demand and pulled back
+in as tool output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouro.capabilities.memory.recall import RecallIndex
+from ouro.core.runtime import get_memory_dir
+
+from ..base import BaseTool
+
+_DEFAULT_LIMIT = 5
+_MAX_LIMIT = 20
+_SNIPPET_LEN = 400
+
+
+class ConversationSearchTool(BaseTool):
+    """Search past conversation messages by keyword."""
+
+    readonly = True
+
+    def __init__(self, memory_dir: str | None = None) -> None:
+        self._memory_dir = memory_dir or get_memory_dir()
+        self._index = RecallIndex(self._memory_dir)
+
+    @property
+    def name(self) -> str:
+        return "conversation_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search past conversation messages by keyword. Returns the most "
+            "relevant snippets (ranked by BM25) from any session, or a single "
+            "session if `session_id` is given. Use this to recall what was "
+            "said in earlier turns that are no longer in your context."
+        )
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "query": {
+                "type": "string",
+                "description": (
+                    "FTS5 MATCH query — plain keywords, phrases in double quotes, "
+                    "or boolean operators (AND/OR/NOT)."
+                ),
+            },
+            "session_id": {
+                "type": "string",
+                "description": (
+                    "Optional session UUID to restrict the search. Omit to search "
+                    "across all sessions."
+                ),
+                "default": "",
+            },
+            "limit": {
+                "type": "integer",
+                "description": f"Max results (default {_DEFAULT_LIMIT}, max {_MAX_LIMIT}).",
+                "default": _DEFAULT_LIMIT,
+            },
+        }
+
+    async def execute(
+        self,
+        query: str,
+        session_id: str = "",
+        limit: int = _DEFAULT_LIMIT,
+    ) -> str:
+        query = (query or "").strip()
+        if not query:
+            return "No query provided."
+
+        try:
+            limit_int = max(1, min(_MAX_LIMIT, int(limit)))
+        except (TypeError, ValueError):
+            limit_int = _DEFAULT_LIMIT
+
+        results = await self._index.search(
+            query,
+            session_id=session_id or None,
+            limit=limit_int,
+        )
+        if not results:
+            return f"No matches for {query!r}."
+
+        lines = [f"Found {len(results)} match(es) for {query!r}:\n"]
+        for i, r in enumerate(results, 1):
+            snippet = (r["content"] or "").strip().replace("\n", " ")
+            if len(snippet) > _SNIPPET_LEN:
+                snippet = snippet[:_SNIPPET_LEN] + "…"
+            sid = r["session_id"][:8] if r.get("session_id") else "?"
+            lines.append(
+                f"[{i}] session={sid} role={r.get('role','?')} idx={r.get('msg_idx','?')}\n"
+                f"    {snippet}"
+            )
+        return "\n".join(lines)

--- a/ouro/capabilities/tools/builtins/conversation_search.py
+++ b/ouro/capabilities/tools/builtins/conversation_search.py
@@ -38,10 +38,8 @@ class ConversationSearchTool(BaseTool):
     @property
     def description(self) -> str:
         return (
-            "Search past conversation messages by keyword. Returns the most "
-            "relevant snippets (ranked by BM25) from any session, or a single "
-            "session if `session_id` is given. Use this to recall what was "
-            "said in earlier turns that are no longer in your context."
+            "Search past conversation messages by keyword. Use this to recall "
+            "what was said in earlier turns that are no longer in your context."
         )
 
     @property
@@ -49,10 +47,7 @@ class ConversationSearchTool(BaseTool):
         return {
             "query": {
                 "type": "string",
-                "description": (
-                    "FTS5 MATCH query — plain keywords, phrases in double quotes, "
-                    "or boolean operators (AND/OR/NOT)."
-                ),
+                "description": "Keywords, double-quoted phrases, or AND/OR/NOT.",
             },
             "session_id": {
                 "type": "string",

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -20,6 +20,10 @@ MAX_ITERATIONS=1000
 
 # Ralph Loop (outer verification loop — re-checks task completion)
 # RALPH_LOOP_MAX_ITERATIONS=3
+
+# Conversation recall — keyword search over historical messages via SQLite FTS5.
+# No embedder required. Enables the `conversation_search` tool.
+# LTM_CONVERSATION_SEARCH_ENABLED=false
 """
 
 
@@ -102,6 +106,11 @@ class Config:
     )
     LONG_TERM_MEMORY_DAILY_WINDOW = int(_cfg.get("LONG_TERM_MEMORY_DAILY_WINDOW", "2"))
     LONG_TERM_MEMORY_DAILY_RETENTION = int(_cfg.get("LONG_TERM_MEMORY_DAILY_RETENTION", "30"))
+
+    # Conversation recall (SQLite FTS5 over past messages — no embedder needed)
+    LTM_CONVERSATION_SEARCH_ENABLED = (
+        _cfg.get("LTM_CONVERSATION_SEARCH_ENABLED", "false").lower() == "true"
+    )
 
     # Logging Configuration
     # Note: Logging is now controlled via --verbose flag

--- a/ouro/interfaces/cli/factory.py
+++ b/ouro/interfaces/cli/factory.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from ouro.capabilities import AgentBuilder, ComposedAgent
 from ouro.capabilities.tools.builtins.advanced_file_ops import GlobTool, GrepTool
+from ouro.capabilities.tools.builtins.conversation_search import ConversationSearchTool
 from ouro.capabilities.tools.builtins.file_ops import FileReadTool, FileWriteTool
 from ouro.capabilities.tools.builtins.multi_task import MultiTaskTool
 from ouro.capabilities.tools.builtins.shell import ShellTool
@@ -76,24 +77,26 @@ def create_agent(
         timeout=current_profile.timeout,
     )
 
+    tools = [
+        FileReadTool(),
+        FileWriteTool(),
+        WebSearchTool(),
+        WebFetchTool(),
+        GlobTool(),
+        GrepTool(),
+        SmartEditTool(),
+        ShellTool(),
+    ]
+    if Config.LTM_CONVERSATION_SEARCH_ENABLED:
+        tools.append(ConversationSearchTool(memory_dir=memory_dir))
+
     builder = (
         AgentBuilder()
         .with_llm(llm, model_manager=model_manager)
         .with_max_iterations(Config.MAX_ITERATIONS)
         .with_progress_sink(TuiProgressSink())
         .with_memory(sessions_dir=sessions_dir, memory_dir=memory_dir)
-        .with_tools(
-            [
-                FileReadTool(),
-                FileWriteTool(),
-                WebSearchTool(),
-                WebFetchTool(),
-                GlobTool(),
-                GrepTool(),
-                SmartEditTool(),
-                ShellTool(),
-            ]
-        )
+        .with_tools(tools)
     )
 
     agent = builder.build()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ packages = [
     "ouro.capabilities.context",
     "ouro.capabilities.memory",
     "ouro.capabilities.memory.long_term",
+    "ouro.capabilities.memory.recall",
     "ouro.capabilities.memory.store",
     "ouro.capabilities.prompts",
     "ouro.capabilities.skills",

--- a/rfc/letta-inspired-memory.md
+++ b/rfc/letta-inspired-memory.md
@@ -1,0 +1,147 @@
+# RFC: Letta-Inspired Improvements to LongTermMemoryManager
+
+- Status: Draft
+- Authors: yixin
+- Date: 2026-05-23
+
+## Summary
+
+Borrow two ideas from Letta/MemGPT to make ouro's long-term memory work without any external embedder: (1) a `conversation_search` tool backed by SQLite FTS5 over historical messages (recall memory), and (2) named, size-limited memory **blocks** edited via dedicated tools instead of a single `memory.md` file edited via generic `Edit`/`Write`. Both changes are additive, zero new model dependencies, and let users get useful cross-session memory without `MEM0_ENABLED=true` (which currently requires an OpenAI key for the embedder).
+
+## Problem
+
+`LongTermMemoryManager` (RFC 008) stores durable knowledge in `~/.ouro/memory/memory.md` + daily files and relies on the LLM editing them with generic file tools. Two real-world gaps:
+
+1. **No way to search past conversations.** Once a session ends or is compacted, the agent cannot recall *what was said*. The only escape today is enabling mem0 — which broke production (see traceback below) because mem0's default OpenAI embedder requires `OPENAI_API_KEY`, and our deployment only has Anthropic credentials.
+
+   ```
+   openai.OpenAIError: Missing credentials. Please pass an `api_key`, ...
+     File ".../ouro/capabilities/memory/store/mem0_memory_store.py", line 152
+     File ".../mem0/embeddings/openai.py", line 35
+   ```
+
+2. **Memory file is unbounded and unstructured.** `memory.md` grows monotonically until the threshold-based consolidator fires, and the LLM has to read the whole file → diff → write back for every update. There's no notion of "this block is about the user, this block is about the project" with independent size budgets.
+
+## Goals
+
+- Provide cross-session recall of past conversation content **without requiring an embedder**.
+- Replace the implicit "Edit memory.md" flow with explicit, bounded memory tools that fail loudly when limits are exceeded.
+- Stay backward-compatible: existing `~/.ouro/memory/memory.md` and daily files keep working; the new tools are opt-in.
+- Zero new external model dependencies (no embedder, no vector DB).
+
+## Non-goals
+
+- Replacing mem0 for users who *do* want semantic search across millions of memories.
+- Vector / archival memory tier (Letta's third layer). Users who need that can keep using mem0.
+- Multi-agent shared blocks. ouro has no multi-agent runtime today; adding shared blocks is premature.
+- Changing `CompactionManager` behavior. Memory pressure integration is out of scope for the first cut.
+
+## Proposed Behavior (User-Facing)
+
+### CLI / UX
+
+No new CLI flags. Two new builtin tools become visible to the agent:
+
+- `conversation_search(query: str, session_id: str | None = None, limit: int = 5)` — keyword search over all persisted messages. Returns excerpts with `session_id`, `timestamp`, `role`, `content_snippet`.
+- `memory_block_edit(block: str, operation: "replace" | "append", content: str, old: str | None = None)` — edit a named block. Fails if the block would exceed its token budget.
+
+Block layout under `~/.ouro/memory/blocks/`:
+
+```
+~/.ouro/memory/
+├── memory.md              # legacy, still loaded if present
+├── 2026-05-23.md          # legacy daily, unchanged
+└── blocks/
+    ├── user.md            # ~2KB cap — user identity, preferences
+    ├── project.md         # ~4KB cap — durable project facts
+    └── scratch.md         # ~8KB cap — recent decisions / WIP context
+```
+
+### Config
+
+```
+LONG_TERM_MEMORY_ENABLED=true     # already exists
+LTM_BLOCKS_ENABLED=true           # new, default false (opt-in)
+LTM_CONVERSATION_SEARCH_ENABLED=true  # new, default false (opt-in)
+LTM_BLOCK_BUDGETS=user:2000,project:4000,scratch:8000  # tokens
+```
+
+When `LTM_BLOCKS_ENABLED=true`, block contents are injected into the system prompt in place of `memory.md` (legacy file still appended if it exists, to preserve old data during migration).
+
+### Output / logging
+
+- One log line per `memory_block_edit` call: `block=user op=replace tokens=1820/2000`.
+- One log line per `conversation_search` call with hit count.
+
+## Invariants (Must Not Regress)
+
+- Existing `~/.ouro/memory/memory.md` + daily file behavior unchanged when both new flags are off.
+- `Config.MEM0_ENABLED` remains the gate for mem0; this RFC does not touch the mem0 code path.
+- No new imports from `ouro.interfaces` into `ouro.capabilities` (import-linter contract).
+- All new I/O is async or routed through `asyncio.to_thread`; no blocking calls on the loop hot path.
+- SQLite FTS index is created lazily on first write; absence of the index file is not an error.
+
+## Design Sketch (Minimal)
+
+### Recall memory (`conversation_search`)
+
+- New `ouro/capabilities/memory/recall/sqlite_fts.py`: thin wrapper around `sqlite3` with FTS5 virtual table:
+  ```sql
+  CREATE VIRTUAL TABLE messages USING fts5(
+      session_id, role, content, timestamp UNINDEXED
+  );
+  ```
+- Hook into `YamlFileMemoryStore.save_message` (and `Mem0MemoryStore.save_message` for parity) to upsert into the FTS index. This is the *only* edit to existing stores.
+- New builtin tool `ouro/capabilities/tools/builtins/conversation_search.py` implementing `BaseTool`, wired into `cli/factory.py`'s default toolset.
+- Index lives at `~/.ouro/memory/recall.db`.
+
+### Memory blocks
+
+- New `ouro/capabilities/memory/blocks/` subpackage:
+  - `store.py` — read/write/list blocks from `blocks/*.md`, enforce token budget via existing `TokenTracker`-compatible counter.
+  - `__init__.py` — `MemoryBlockManager` facade with `load_and_format()` returning a system-prompt section.
+- New tool `ouro/capabilities/tools/builtins/memory_block_edit.py`.
+- `LongTermMemoryManager.load_and_format()` gains a branch: if `LTM_BLOCKS_ENABLED`, render block contents; otherwise current behavior.
+
+### Layering
+
+All new code lives in `ouro.capabilities.memory.*` and `ouro.capabilities.tools.builtins.*`. Interfaces layer only changes in `cli/factory.py` (toolset registration). Matches the layer contract in `ouro/CLAUDE.md`.
+
+## Alternatives Considered
+
+- **A. Switch to mem0 with HuggingFace embedder.** Solves the OpenAI-key issue but adds heavy deps (`sentence-transformers`, torch) and still doesn't fix `memory.md` editing ergonomics. Rejected.
+- **B. Adopt Letta wholesale.** Letta is a separate server with its own DB and agent runtime. Too much surface area for our single-process bot. Rejected.
+- **C. Vector recall via local Chroma.** Smaller than mem0 but still requires an embedder. Rejected per "no new model deps" goal.
+- **D. Do nothing, document `MEM0_ENABLED=false` as the answer.** Cheapest, but leaves the "search past conversations" gap. Rejected.
+
+## Test Plan
+
+- Unit tests:
+  - `test/memory/test_sqlite_fts.py` — index create/upsert/query/empty-db cases.
+  - `test/memory/test_blocks.py` — block budget enforcement (replace exceeds limit → raises), append vs replace semantics, missing-block fallback.
+  - `test/tools/test_conversation_search_tool.py` — tool contract, scoping by `session_id`, hit-formatting.
+  - `test/tools/test_memory_block_edit_tool.py` — tool contract, budget violation surfaces as actionable error to the LLM.
+- Targeted runs:
+  - `./scripts/dev.sh test -q test/memory/ test/tools/`
+  - `./scripts/dev.sh importlint`
+- Smoke run:
+  - `python main.py --task "remember that I prefer rust over go, then in a follow-up session ask what language I prefer"` across two `ouro-cli` invocations with `LTM_BLOCKS_ENABLED=true`.
+
+## Rollout / Migration
+
+- Both features ship behind feature flags, default off. Existing users see no change.
+- When `LTM_BLOCKS_ENABLED=true` is set the first time, `memory.md` is **not** auto-migrated — its contents are still loaded into the system prompt alongside the blocks until the user (or agent) moves them. A one-shot helper `python -m ouro.capabilities.memory.blocks.migrate` can split `memory.md` into block files; documented but not run automatically.
+- Rollback: flip flags off; new files in `blocks/` and `recall.db` are inert when disabled.
+
+## Risks & Mitigations
+
+- **FTS index drift** (rows missing if write fails mid-flight): wrap upsert in best-effort try/except, log warnings; recall is non-critical so degradation is acceptable.
+- **Token-budget enforcement misjudges size** if we use a cheap tokenizer: prefer `litellm.token_counter` shared with `TokenTracker` so the count matches what the loop sees.
+- **Tool sprawl**: two new builtins is small; gate via `LTM_BLOCKS_ENABLED` and `LTM_CONVERSATION_SEARCH_ENABLED` so they're not always advertised.
+- **Concurrent writes to SQLite from bot multi-conversation traffic**: open with `isolation_level=None` + `PRAGMA journal_mode=WAL`; or serialize behind an `asyncio.Lock` per process.
+
+## Open Questions
+
+- Should `conversation_search` index *messages* or *compacted summaries* or both? Indexing raw messages gives best recall but more storage; summaries are smaller but lossy.
+- Do we expose block edits to the LLM via one tool with an `operation` arg, or two tools (`memory_block_replace` / `memory_block_append`)? Two tools is more discoverable; one tool is fewer schema tokens. Default to two for now.
+- Should we add a "memory pressure" hook (Letta's killer feature) as a follow-up RFC, or fold it in here? Recommend follow-up — keeps this RFC scoped.

--- a/test/memory/test_recall_fts.py
+++ b/test/memory/test_recall_fts.py
@@ -1,0 +1,103 @@
+"""Unit tests for the SQLite FTS5 recall index."""
+
+import os
+
+import pytest
+
+from ouro.capabilities.memory.recall.sqlite_fts import RecallIndex, _flatten_content
+from ouro.core.llm.message_types import LLMMessage
+
+
+@pytest.fixture
+def index(tmp_path):
+    return RecallIndex(memory_dir=str(tmp_path / "memdir"))
+
+
+class TestFlattenContent:
+    def test_string(self):
+        assert _flatten_content("hello") == "hello"
+
+    def test_none(self):
+        assert _flatten_content(None) == ""
+
+    def test_text_blocks(self):
+        content = [
+            {"type": "text", "text": "alpha"},
+            {"type": "tool_use", "id": "x"},  # no text key — skipped
+            {"type": "text", "text": "beta"},
+        ]
+        assert "alpha" in _flatten_content(content)
+        assert "beta" in _flatten_content(content)
+
+
+class TestEmptyDb:
+    async def test_search_on_missing_db(self, index):
+        # File does not exist yet — search must return empty, never raise.
+        assert not os.path.isfile(index.db_path)
+        assert await index.search("anything") == []
+
+    async def test_blank_query_returns_empty(self, index):
+        await index.reindex_session("s1", [LLMMessage(role="user", content="hello world")])
+        assert await index.search("   ") == []
+
+
+class TestReindexAndSearch:
+    async def test_basic_match(self, index):
+        msgs = [
+            LLMMessage(role="user", content="I love rust language"),
+            LLMMessage(role="assistant", content="Rust is memory-safe."),
+            LLMMessage(role="user", content="What about go?"),
+        ]
+        await index.reindex_session("session-1", msgs)
+        hits = await index.search("rust")
+        assert len(hits) >= 1
+        # Most relevant hit should mention rust
+        assert "rust" in hits[0]["content"].lower()
+
+    async def test_scope_by_session(self, index):
+        await index.reindex_session("sess-a", [LLMMessage(role="user", content="alpha topic")])
+        await index.reindex_session("sess-b", [LLMMessage(role="user", content="alpha topic")])
+        scoped = await index.search("alpha", session_id="sess-a")
+        assert all(h["session_id"] == "sess-a" for h in scoped)
+        assert len(scoped) == 1
+
+        global_hits = await index.search("alpha")
+        assert len(global_hits) == 2
+
+    async def test_reindex_replaces_old_rows(self, index):
+        await index.reindex_session("s", [LLMMessage(role="user", content="original content")])
+        await index.reindex_session("s", [LLMMessage(role="user", content="replaced content")])
+        hits = await index.search("original")
+        assert hits == []
+        hits = await index.search("replaced")
+        assert len(hits) == 1
+
+    async def test_empty_content_skipped(self, index):
+        await index.reindex_session(
+            "s",
+            [
+                LLMMessage(role="user", content=""),
+                LLMMessage(role="user", content="real message"),
+            ],
+        )
+        hits = await index.search("real")
+        assert len(hits) == 1
+        # idx in stored row is the original list index of the kept message
+        assert hits[0]["msg_idx"] == 1
+
+    async def test_malformed_query_returns_empty(self, index):
+        await index.reindex_session("s", [LLMMessage(role="user", content="hello world")])
+        # Unmatched quote — FTS5 raises OperationalError; tool must swallow.
+        assert await index.search('"unterminated') == []
+
+    async def test_add_message_incremental(self, index):
+        await index.add_message("s", 0, LLMMessage(role="user", content="incremental write"))
+        hits = await index.search("incremental")
+        assert len(hits) == 1
+        assert hits[0]["msg_idx"] == 0
+
+    async def test_delete_session(self, index):
+        await index.reindex_session("s", [LLMMessage(role="user", content="to be deleted")])
+        removed = await index.delete_session("s")
+        assert removed == 1
+        assert await index.search("deleted") == []

--- a/test/test_conversation_search_tool.py
+++ b/test/test_conversation_search_tool.py
@@ -1,0 +1,73 @@
+"""Unit tests for ConversationSearchTool."""
+
+import pytest
+
+from ouro.capabilities.memory.recall import RecallIndex
+from ouro.capabilities.tools.builtins.conversation_search import ConversationSearchTool
+from ouro.core.llm.message_types import LLMMessage
+
+
+@pytest.fixture
+def tool(tmp_path):
+    return ConversationSearchTool(memory_dir=str(tmp_path / "memdir"))
+
+
+@pytest.fixture
+async def populated_tool(tmp_path):
+    memdir = str(tmp_path / "memdir")
+    idx = RecallIndex(memdir)
+    await idx.reindex_session(
+        "session-xxxxxxxx-1",
+        [
+            LLMMessage(role="user", content="I prefer rust over go"),
+            LLMMessage(role="assistant", content="Noted. Rust offers memory safety."),
+        ],
+    )
+    await idx.reindex_session(
+        "session-yyyyyyyy-2",
+        [LLMMessage(role="user", content="Tell me about kubernetes")],
+    )
+    return ConversationSearchTool(memory_dir=memdir)
+
+
+class TestSchema:
+    def test_name_and_readonly(self, tool):
+        assert tool.name == "conversation_search"
+        assert tool.readonly is True
+
+    def test_parameters_have_query(self, tool):
+        params = tool.parameters
+        assert "query" in params
+        assert "session_id" in params
+        assert "limit" in params
+
+    def test_anthropic_schema_required_only_query(self, tool):
+        schema = tool.to_anthropic_schema()
+        assert schema["input_schema"]["required"] == ["query"]
+
+
+class TestExecute:
+    async def test_empty_query(self, tool):
+        out = await tool.execute(query="   ")
+        assert "No query" in out
+
+    async def test_no_index_yet(self, tool):
+        out = await tool.execute(query="anything")
+        assert "No matches" in out
+
+    async def test_match(self, populated_tool):
+        out = await populated_tool.execute(query="rust")
+        assert "rust" in out.lower()
+        assert "session=session-" in out
+
+    async def test_scope_by_session_id(self, populated_tool):
+        # Restrict to session 2 — "rust" only lives in session 1 so should be empty.
+        out = await populated_tool.execute(query="rust", session_id="session-yyyyyyyy-2")
+        assert "No matches" in out
+
+    async def test_limit_clamped(self, populated_tool):
+        # Bogus limit values must not crash.
+        out = await populated_tool.execute(query="rust", limit=9999)
+        assert "rust" in out.lower()
+        out = await populated_tool.execute(query="rust", limit=-5)
+        assert "rust" in out.lower()


### PR DESCRIPTION
## Summary

Add a **recall memory** layer to ouro inspired by Letta/MemGPT: every saved
message gets indexed into a local SQLite FTS5 database, and the agent can
keyword-search past conversations via a new `conversation_search` tool.
Zero new model dependencies — fills the gap that previously forced users
onto mem0 (which requires `OPENAI_API_KEY` for its default embedder and
broke our wechat bot in production).

First of two PRs from [RFC: letta-inspired-memory](https://github.com/ouro-ai-labs/ouro/blob/pr1-conversation-search/rfc/letta-inspired-memory.md).
The second (memory blocks) follows once this lands.

## Scope

- **Goals**: cross-session message recall without an embedder; opt-in, additive.
- **Non-goals**: replacing mem0; vector/archival tier; memory pressure signal.

## Invariants (Must Not Regress)

- [x] Existing `~/.ouro/memory/memory.md` + daily file behavior unchanged when flag is off.
- [x] `Config.MEM0_ENABLED` remains untouched; mem0 code path not modified.
- [x] No new imports from `ouro.interfaces` into `ouro.capabilities` (import-linter OK).
- [x] All new I/O routed through `asyncio.to_thread`; no blocking calls on hot path.
- [x] Index creation is lazy — absence of `recall.db` is not an error.

## Acceptance Criteria

- [x] `LTM_CONVERSATION_SEARCH_ENABLED=true` adds `conversation_search` to the toolset.
- [x] `MemoryManager.save_memory` reindexes the session's FTS rows best-effort.
- [x] Search returns BM25-ranked hits with `session_id`, `role`, `msg_idx`, content snippet.
- [x] Search can be scoped to a single `session_id` or span all sessions.
- [x] Malformed FTS queries (e.g. unmatched quotes) return empty instead of raising.
- [x] CJK content is indexed and retrievable.

## Test Plan

- [x] `test/memory/test_recall_fts.py` (12 tests)
- [x] `test/test_conversation_search_tool.py` (8 tests)
- [x] `./scripts/dev.sh test -q` — **627 passed, 1 skipped**
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues
- [x] `./scripts/dev.sh importlint` — 3 contracts kept, 0 broken

## Smoke Run

```python
# RecallIndex + ConversationSearchTool end-to-end (CJK)
await idx.reindex_session('sess', [
    LLMMessage(role='user', content='我喜欢 rust 多过 go'),
    LLMMessage(role='assistant', content='好的，记下来'),
])
await tool.execute(query='rust')
# → Found 1 match(es) for 'rust':
#   [1] session=sess role=user idx=0
#       我喜欢 rust 多过 go
```

## Adversarial Review

- **What could break?** Default behavior unchanged (flag off). With flag on,
  the only new I/O is one SQLite `BEGIN/DELETE/INSERT/COMMIT` per `save_memory`
  call; wrapped in `try/except` and logged at warning level — never raised.
- **Worst-case size?** One FTS row per persisted message; `content` is plain
  text. For a bot user with thousands of messages, single-digit MB.
- **Secrets/logging?** Indexes message content as-is. Same trust boundary as
  the existing session YAML files — both live under `~/.ouro/`.
- **Async/blocking?** All sqlite3 calls inside `asyncio.to_thread`.
- **User-visible error?** Search failures log a warning and return empty
  results; the tool prints `No matches for <query>.`

## Docs / Compatibility

- Config flag documented inline in `~/.ouro/config` default template.
- No breaking changes; rollback = unset the flag (or revert).