### PR TITLE
feat(loop): pluggable Rule abstraction for deterministic pre-dispatch guards

### DIFF
--- a/ouro/core/CLAUDE.md
+++ b/ouro/core/CLAUDE.md
@@ -67,19 +67,22 @@ added on demand — keep dead extension points out.
 
 `Rule` (`loop/rules.py`) is a separate extension point from `Hook`: a
 deterministic check the loop runs over the model's proposed tool calls
-*before* dispatch. A rule blocks individual calls (the loop substitutes
-its feedback message as that call's `tool_result`) or halts the run —
-trading a probabilistic LLM mistake for a deterministic guarantee. See
-`rfc/loop-rules.md`.
+*before* dispatch. A rule blocks individual calls — the loop substitutes
+its feedback message as that call's `tool_result` so the model
+self-corrects next turn — trading a probabilistic LLM mistake for a
+deterministic guarantee. A rule **only replaces results; it never stops
+the loop** (runaway protection is the loop's job via `max_iterations`).
+See `rfc/loop-rules.md`.
 
 - Contract: `on_run_start()` (reset per-run state), `check(ctx,
-  tool_calls) -> RuleOutcome` (verdict; no LLM/I/O), `observe(ctx,
-  executed)` (post-dispatch state update from real results).
-- The loop aggregates all rules in `Agent._apply_rules`, appends one
-  `tool_result` per call (synthetic for blocked, real for dispatched,
-  in the model's original order), then halts if any rule asked to.
+  tool_calls) -> RuleOutcome` (which calls to block; no LLM/I/O),
+  `observe(ctx, executed)` (post-dispatch state update from real results).
+- The loop aggregates all rules in `Agent._apply_rules` (union of blocked
+  ids), dispatches only unblocked calls, then appends one `tool_result`
+  per call in the model's original order (synthetic for blocked, real for
+  dispatched).
 - Core rules stay tool-agnostic (only `ToolCall`/`ToolResult`).
-  `RepeatedToolCallRule` ships on by default (governed by the
-  `repeat_tool_call_*` kwargs). Tool-aware rules (e.g. read-before-write)
-  belong in `ouro.capabilities` and are injected via the Agent `rules=`
-  arg / `AgentBuilder`.
+  `RepeatedToolCallRule` ships on by default (governed by
+  `repeat_tool_call_threshold`; warns on repeats, never halts). Tool-aware
+  rules (e.g. read-before-write) belong in `ouro.capabilities` and are
+  injected via the Agent `rules=` arg / `AgentBuilder`.

--- a/ouro/core/CLAUDE.md
+++ b/ouro/core/CLAUDE.md
@@ -63,26 +63,29 @@ added on demand — keep dead extension points out.
 4. Update `ouro/core/README.md` and `ouro/CLAUDE.md` if the
    contract for hook composition changes.
 
-## Rules (deterministic pre-dispatch guards)
+## Rules (deterministic per-tool-call checks)
 
 `Rule` (`loop/rules.py`) is a separate extension point from `Hook`: a
-deterministic check the loop runs over the model's proposed tool calls
-*before* dispatch. A rule blocks individual calls — the loop substitutes
-its feedback message as that call's `tool_result` so the model
-self-corrects next turn — trading a probabilistic LLM mistake for a
-deterministic guarantee. A rule **only replaces results; it never stops
-the loop** (runaway protection is the loop's job via `max_iterations`).
-See `rfc/loop-rules.md`.
+deterministic check the loop runs *around each individual tool call*. A
+rule **only blocks or rewrites a call's result; it never stops the loop**
+(runaway protection is the loop's job via `max_iterations`). See
+`rfc/loop-rules.md`.
 
-- Contract: `on_run_start()` (reset per-run state), `check(ctx,
-  tool_calls) -> RuleOutcome` (which calls to block; no LLM/I/O),
-  `observe(ctx, executed)` (post-dispatch state update from real results).
-- The loop aggregates all rules in `Agent._apply_rules` (union of blocked
-  ids), dispatches only unblocked calls, then appends one `tool_result`
-  per call in the model's original order (synthetic for blocked, real for
-  dispatched).
+- Contract — two optional methods, the loop duck-types via `getattr`:
+  - `before_toolcall(ctx, tool_call) -> str | None`: runs before dispatch;
+    return text to **block** the call (it is skipped and the text becomes
+    its `tool_result`), or `None` to let it run. This is the only way to
+    stop a side-effecting call (write/edit/delete) from happening.
+  - `after_toolcall(ctx, tool_call, tool_result) -> str | None`: runs after
+    a dispatched call; return text to **replace** its result, `None` to
+    leave it. Also the place to record state from real results.
+- No LLM/I/O in either; both are per-tool-call. The loop runs all
+  `before_toolcall`s (`Agent._rules_before`), dispatches only unblocked
+  calls, runs `after_toolcall`s (`Agent._rules_after`), then appends one
+  `tool_result` per call in the model's original order.
 - Core rules stay tool-agnostic (only `ToolCall`/`ToolResult`).
   `RepeatedToolCallRule` ships on by default (governed by
-  `repeat_tool_call_threshold`; warns on repeats, never halts). Tool-aware
-  rules (e.g. read-before-write) belong in `ouro.capabilities` and are
-  injected via the Agent `rules=` arg / `AgentBuilder`.
+  `repeat_tool_call_threshold`; warns on repeats via `before_toolcall`,
+  never halts; self-resets per run via `ctx.iteration`). Tool-aware rules
+  (e.g. read-before-write) belong in `ouro.capabilities` and are injected
+  via the Agent `rules=` arg / `AgentBuilder`.

--- a/ouro/core/CLAUDE.md
+++ b/ouro/core/CLAUDE.md
@@ -20,6 +20,9 @@ Never imports `ouro.capabilities` or `ouro.interfaces`.
 - `loop/protocols.py` — structural Protocols capabilities implement:
   `Hook`, `ToolRegistry`, `ProgressSink`, `LoopContext`. Plus the
   `ContinueDecision` return type used by `on_iteration_end`.
+- `loop/rules.py` — `Rule` protocol + `RuleOutcome` / `RuleViolation`
+  and the generic `RepeatedToolCallRule`. Rules are deterministic
+  pre-dispatch guards; see "Rules" below.
 - `llm/` — `LLMMessage`, `LLMResponse`, `ToolCall`, `ToolResult`,
   `LiteLLMAdapter`, `ModelManager`, content/compat/reasoning helpers,
   OAuth (chatgpt, copilot).
@@ -59,3 +62,24 @@ added on demand — keep dead extension points out.
    are fine).
 4. Update `ouro/core/README.md` and `ouro/CLAUDE.md` if the
    contract for hook composition changes.
+
+## Rules (deterministic pre-dispatch guards)
+
+`Rule` (`loop/rules.py`) is a separate extension point from `Hook`: a
+deterministic check the loop runs over the model's proposed tool calls
+*before* dispatch. A rule blocks individual calls (the loop substitutes
+its feedback message as that call's `tool_result`) or halts the run —
+trading a probabilistic LLM mistake for a deterministic guarantee. See
+`rfc/loop-rules.md`.
+
+- Contract: `on_run_start()` (reset per-run state), `check(ctx,
+  tool_calls) -> RuleOutcome` (verdict; no LLM/I/O), `observe(ctx,
+  executed)` (post-dispatch state update from real results).
+- The loop aggregates all rules in `Agent._apply_rules`, appends one
+  `tool_result` per call (synthetic for blocked, real for dispatched,
+  in the model's original order), then halts if any rule asked to.
+- Core rules stay tool-agnostic (only `ToolCall`/`ToolResult`).
+  `RepeatedToolCallRule` ships on by default (governed by the
+  `repeat_tool_call_*` kwargs). Tool-aware rules (e.g. read-before-write)
+  belong in `ouro.capabilities` and are injected via the Agent `rules=`
+  arg / `AgentBuilder`.

--- a/ouro/core/README.md
+++ b/ouro/core/README.md
@@ -11,7 +11,8 @@ ouro.core
 │   ├── agent.py             # the Agent class
 │   ├── context.py           # MessageListContext (system + detached) + RunStatistic
 │   ├── message_list.py      # mutable wrapper backing MessageListContext.detached
-│   └── protocols.py         # Hook, ToolRegistry, ProgressSink, LoopContext
+│   ├── protocols.py         # Hook, ToolRegistry, ProgressSink, LoopContext
+│   └── rules.py             # Rule protocol + RepeatedToolCallRule (pre-dispatch guards)
 ├── llm/                     # LiteLLM client + message types
 │   ├── litellm_adapter.py   # LiteLLMAdapter
 │   ├── message_types.py     # LLMMessage, LLMResponse, ToolCall, ToolResult

--- a/ouro/core/README.md
+++ b/ouro/core/README.md
@@ -12,7 +12,7 @@ ouro.core
 │   ├── context.py           # MessageListContext (system + detached) + RunStatistic
 │   ├── message_list.py      # mutable wrapper backing MessageListContext.detached
 │   ├── protocols.py         # Hook, ToolRegistry, ProgressSink, LoopContext
-│   └── rules.py             # Rule protocol + RepeatedToolCallRule (pre-dispatch guards)
+│   └── rules.py             # Rule protocol + RepeatedToolCallRule (per-tool-call checks)
 ├── llm/                     # LiteLLM client + message types
 │   ├── litellm_adapter.py   # LiteLLMAdapter
 │   ├── message_types.py     # LLMMessage, LLMResponse, ToolCall, ToolResult

--- a/ouro/core/loop/__init__.py
+++ b/ouro/core/loop/__init__.py
@@ -10,8 +10,8 @@ Public surface:
   — protocols capabilities/interfaces implement to plug in.
 - `ContinueDecision`, `ContinueKind` — return types used by
   ``on_iteration_end`` (STOP / RETRY / CONTINUE voting).
-- `Rule`, `RuleOutcome`, `RuleViolation`, `RepeatedToolCallRule` —
-  deterministic pre-dispatch guards over proposed tool calls.
+- `Rule`, `RepeatedToolCallRule` — deterministic, per-tool-call checks that
+  block a call before dispatch or rewrite its result after.
 """
 
 from .agent import Agent
@@ -26,7 +26,7 @@ from .protocols import (
     ProgressSink,
     ToolRegistry,
 )
-from .rules import RepeatedToolCallRule, Rule, RuleOutcome, RuleViolation
+from .rules import RepeatedToolCallRule, Rule
 
 __all__ = [
     "Agent",
@@ -41,7 +41,5 @@ __all__ = [
     "ProgressSink",
     "ToolRegistry",
     "Rule",
-    "RuleOutcome",
-    "RuleViolation",
     "RepeatedToolCallRule",
 ]

--- a/ouro/core/loop/__init__.py
+++ b/ouro/core/loop/__init__.py
@@ -10,6 +10,8 @@ Public surface:
   — protocols capabilities/interfaces implement to plug in.
 - `ContinueDecision`, `ContinueKind` — return types used by
   ``on_iteration_end`` (STOP / RETRY / CONTINUE voting).
+- `Rule`, `RuleOutcome`, `RuleViolation`, `RepeatedToolCallRule` —
+  deterministic pre-dispatch guards over proposed tool calls.
 """
 
 from .agent import Agent
@@ -24,6 +26,7 @@ from .protocols import (
     ProgressSink,
     ToolRegistry,
 )
+from .rules import RepeatedToolCallRule, Rule, RuleOutcome, RuleViolation
 
 __all__ = [
     "Agent",
@@ -37,4 +40,8 @@ __all__ = [
     "NullProgressSink",
     "ProgressSink",
     "ToolRegistry",
+    "Rule",
+    "RuleOutcome",
+    "RuleViolation",
+    "RepeatedToolCallRule",
 ]

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -8,9 +8,8 @@ memory, BaseTool, verification, or terminal UI — those plug in via
 from __future__ import annotations
 
 import asyncio
-import json
 import os
-from typing import Any, Callable, Literal, NamedTuple, Sequence
+from typing import Any, Callable, Sequence
 
 from ouro.core.llm import LLMMessage, LLMResponse, StopReason, ToolCall, ToolResult
 from ouro.core.llm.reasoning import normalize_reasoning_effort
@@ -27,6 +26,7 @@ from .protocols import (
     ProgressSink,
     ToolRegistry,
 )
+from .rules import RepeatedToolCallRule, Rule
 
 logger = get_logger(__name__)
 
@@ -45,6 +45,7 @@ class Agent:
         usage_callback: Callable[[dict[str, int]], None] | None = None,
         repeat_tool_call_threshold: int = 3,
         repeat_tool_call_max: int = 5,
+        rules: Sequence[Rule] = (),
     ) -> None:
         self.llm = llm
         self.tools = tools
@@ -59,12 +60,22 @@ class Agent:
         # Setting threshold <= 0 disables the circuit breaker entirely.
         self.repeat_tool_call_threshold = repeat_tool_call_threshold
         self.repeat_tool_call_max = repeat_tool_call_max
+        # Deterministic pre-dispatch guards. The repeated-tool-call breaker is
+        # always present (governed by the kwargs above; threshold <= 0 makes it
+        # a no-op); any caller-supplied rules run after it. See `rules.py`.
+        self.rules: list[Rule] = [
+            RepeatedToolCallRule(repeat_tool_call_threshold, repeat_tool_call_max)
+        ]
+        self.rules.extend(rules)
 
     def set_reasoning_effort(self, value: str | None) -> None:
         self._reasoning_effort = normalize_reasoning_effort(value)
 
     def add_hook(self, hook: Hook) -> None:
         self.hooks.append(hook)
+
+    def add_rule(self, rule: Rule) -> None:
+        self.rules.append(rule)
 
     async def run(
         self,
@@ -81,14 +92,12 @@ class Agent:
         ctx = RunStatistic(task=task, progress=self.progress, usage_callback=self._usage_callback)
         messages = context.detached
         await self._fanout_async("on_run_start", ctx, messages)
+        # Reset per-run rule state (e.g. the repeated-tool-call counter).
+        for rule in self.rules:
+            rule.on_run_start()
 
         tool_schemas = self.tools.get_tool_schemas()
         final_answer: str = ""
-        # Per-run state for the repeated-tool-call circuit breaker. Tracks the
-        # last iteration's tool-call signature and how many iterations in a
-        # row have emitted the same signature. See `_tool_call_iter_signature`.
-        last_iter_sig: tuple[tuple[str, str], ...] | None = None
-        repeat_count: int = 0
         for ctx.iteration in range(1, self.max_iterations + 1):
             # Hooks may mutate ``context`` in place here (e.g.
             # ``CompactionHook`` compresses ``context.detached``).
@@ -153,32 +162,51 @@ class Agent:
                 # below sit in the correct chronological order.
                 messages.append(response.to_message())
 
-                guard = self._apply_repeated_tool_call_guard(
-                    tool_calls=tool_calls,
-                    messages=messages,
-                    last_iter_sig=last_iter_sig,
-                    repeat_count=repeat_count,
-                    iteration=ctx.iteration,
-                )
-                last_iter_sig = guard.last_iter_sig
-                repeat_count = guard.repeat_count
-                if guard.action == "halted":
-                    final_answer = guard.final_answer or ""
+                # Run deterministic rules over the proposed calls. Blocked
+                # calls get a synthetic tool_result (the rule's feedback) in
+                # place of dispatch; a halting rule ends the run.
+                blocked, halt, halt_message = self._apply_rules(ctx, tool_calls)
+                if halt:
+                    for tc in tool_calls:
+                        content = blocked.get(tc.id) or halt_message or "[ouro] Halted by rule."
+                        messages.append(
+                            LLMMessage(
+                                role="tool",
+                                content=content,
+                                tool_call_id=tc.id,
+                                name=tc.name,
+                            )
+                        )
+                    final_answer = halt_message or ""
                     self.progress.unfinished_answer(final_answer)
                     return final_answer
-                if guard.action == "intercepted":
-                    continue
 
-                tool_results = await self._dispatch_tools(ctx, tool_calls)
-                for tc, tr in zip(tool_calls, tool_results):
+                # Dispatch only the calls no rule blocked, then append every
+                # call's result in the model's original order (synthetic for
+                # blocked calls, real for dispatched ones) so each tool_call
+                # gets exactly one tool_result.
+                remaining = [tc for tc in tool_calls if tc.id not in blocked]
+                results_by_id: dict[str, str] = {}
+                executed: list[tuple[ToolCall, ToolResult]] = []
+                if remaining:
+                    tool_results = await self._dispatch_tools(ctx, remaining)
+                    for tc, tr in zip(remaining, tool_results):
+                        results_by_id[tc.id] = tr.content
+                        executed.append((tc, tr))
+
+                for tc in tool_calls:
+                    content = blocked[tc.id] if tc.id in blocked else results_by_id.get(tc.id, "")
                     messages.append(
                         LLMMessage(
                             role="tool",
-                            content=tr.content,
+                            content=content,
                             tool_call_id=tc.id,
                             name=tc.name,
                         )
                     )
+
+                for rule in self.rules:
+                    rule.observe(ctx, executed)
                 continue
 
             if response.stop_reason == StopReason.LENGTH:
@@ -217,89 +245,32 @@ class Agent:
         logger.warning("Agent.run reached max_iterations=%d without STOP", self.max_iterations)
         return final_answer
 
-    def _apply_repeated_tool_call_guard(
+    def _apply_rules(
         self,
-        *,
+        ctx: LoopContext,
         tool_calls: list[ToolCall],
-        messages: MessageList,
-        last_iter_sig: tuple[tuple[str, str], ...] | None,
-        repeat_count: int,
-        iteration: int,
-    ) -> _RepeatGuardOutcome:
-        """Track consecutive identical tool_call iterations and intercept loops.
+    ) -> tuple[dict[str, str], bool, str | None]:
+        """Evaluate every rule over the proposed calls and aggregate verdicts.
 
-        Compaction summaries can re-inject pathological tool-call patterns as
-        if they were task state, so when the model emits the same
-        ``(name, arguments)`` iteration N times in a row we either synthesize
-        a "stop repeating" tool_result (soft intercept) or terminate the run
-        (hard stop).  This method updates ``messages`` in place with the
-        synthesized tool_results when intercepting; the caller routes on
-        ``outcome.action``.
+        Returns ``(blocked, halt, halt_message)`` where ``blocked`` maps a
+        ``tool_call_id`` to the feedback to surface in place of dispatching it
+        (messages from multiple rules are joined). ``halt`` is true if any rule
+        asked to terminate the run; ``halt_message`` is the first such rule's
+        final answer. Rules do not mutate ``messages`` — the caller owns that.
         """
-        iter_sig = _tool_call_iter_signature(tool_calls)
-        if last_iter_sig is not None and iter_sig == last_iter_sig:
-            new_repeat_count = repeat_count + 1
-        else:
-            new_repeat_count = 1
-
-        if self.repeat_tool_call_threshold <= 0:
-            return _RepeatGuardOutcome("dispatch", iter_sig, new_repeat_count, None)
-
-        if new_repeat_count >= self.repeat_tool_call_max:
-            for tc in tool_calls:
-                messages.append(
-                    LLMMessage(
-                        role="tool",
-                        content=(
-                            f"[ouro] Same tool_call(s) repeated {new_repeat_count} "
-                            "times consecutively with no progress. Terminating "
-                            "to prevent runaway loop."
-                        ),
-                        tool_call_id=tc.id,
-                        name=tc.name,
-                    )
-                )
-            logger.warning(
-                "Agent.run: hard-stopping after %d consecutive identical "
-                "tool_call iterations on iteration %d (names=%s)",
-                new_repeat_count,
-                iteration,
-                [tc.name for tc in tool_calls],
-            )
-            final_answer = (
-                "[ouro] Halted: the model repeated the same tool call "
-                f"{new_repeat_count} times without progress "
-                f"({[tc.name for tc in tool_calls]}). Please rephrase your "
-                "request or restart the session."
-            )
-            return _RepeatGuardOutcome("halted", iter_sig, new_repeat_count, final_answer)
-
-        if new_repeat_count >= self.repeat_tool_call_threshold:
-            feedback = (
-                f"[ouro] This exact tool_call has now been issued {new_repeat_count} "
-                "times consecutively. The result has not changed. Stop repeating: "
-                "either choose a different action, ask the user for clarification, "
-                "or finish the task."
-            )
-            for tc in tool_calls:
-                messages.append(
-                    LLMMessage(
-                        role="tool",
-                        content=feedback,
-                        tool_call_id=tc.id,
-                        name=tc.name,
-                    )
-                )
-            logger.warning(
-                "Agent.run: intercepted %d-times-repeated tool_call(s) on "
-                "iteration %d (names=%s)",
-                new_repeat_count,
-                iteration,
-                [tc.name for tc in tool_calls],
-            )
-            return _RepeatGuardOutcome("intercepted", iter_sig, new_repeat_count, None)
-
-        return _RepeatGuardOutcome("dispatch", iter_sig, new_repeat_count, None)
+        violations: dict[str, list[str]] = {}
+        halt = False
+        halt_message: str | None = None
+        for rule in self.rules:
+            outcome = rule.check(ctx, tool_calls)
+            for v in outcome.violations:
+                violations.setdefault(v.tool_call_id, []).append(v.message)
+            if outcome.halt:
+                halt = True
+                if halt_message is None:
+                    halt_message = outcome.halt_message
+        blocked = {tid: "\n".join(msgs) for tid, msgs in violations.items()}
+        return blocked, halt, halt_message
 
     async def _dispatch_tools(
         self,
@@ -427,42 +398,6 @@ class Agent:
         if retries:
             return ContinueDecision.retry_with_feedback(*retries)
         return decision
-
-
-class _RepeatGuardOutcome(NamedTuple):
-    """Result of one iteration's repeated-tool-call check.
-
-    ``action`` routes the caller:
-    - ``"dispatch"``: not a repeat (or breaker disabled); run the tools normally.
-    - ``"intercepted"``: synthesized tool_results already appended; ``continue``.
-    - ``"halted"``: synthesized tool_results already appended; return ``final_answer``.
-    """
-
-    action: Literal["dispatch", "intercepted", "halted"]
-    last_iter_sig: tuple[tuple[str, str], ...]
-    repeat_count: int
-    final_answer: str | None
-
-
-def _tool_call_iter_signature(
-    tool_calls: list[ToolCall],
-) -> tuple[tuple[str, str], ...]:
-    """Build a deterministic fingerprint for one iteration's tool_calls.
-
-    Used by the repeated-tool-call circuit breaker to detect when the model
-    is emitting the exact same (name, arguments) batch iteration after
-    iteration. Arguments are serialized with ``sort_keys=True`` so key order
-    is normalized; non-JSON-safe values fall back to ``str(...)`` so the
-    helper never raises on exotic argument types.
-    """
-    sigs: list[tuple[str, str]] = []
-    for tc in tool_calls:
-        try:
-            args_repr = json.dumps(tc.arguments, sort_keys=True, default=str)
-        except (TypeError, ValueError):
-            args_repr = repr(tc.arguments)
-        sigs.append((tc.name, args_repr))
-    return tuple(sigs)
 
 
 def _log_outgoing_messages(iteration: int, messages: list[LLMMessage]) -> None:

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -44,7 +44,6 @@ class Agent:
         progress: ProgressSink | None = None,
         usage_callback: Callable[[dict[str, int]], None] | None = None,
         repeat_tool_call_threshold: int = 3,
-        repeat_tool_call_max: int = 5,
         rules: Sequence[Rule] = (),
     ) -> None:
         self.llm = llm
@@ -55,17 +54,14 @@ class Agent:
         self.progress: ProgressSink = progress or NullProgressSink()
         self._reasoning_effort: str | None = None
         self._usage_callback = usage_callback
-        # Soft intercept at `repeat_tool_call_threshold` consecutive identical
-        # tool-call iterations; hard terminate at `repeat_tool_call_max`.
-        # Setting threshold <= 0 disables the circuit breaker entirely.
+        # Warn the model after `repeat_tool_call_threshold` consecutive identical
+        # tool-call iterations; <= 0 disables the check. See RepeatedToolCallRule.
         self.repeat_tool_call_threshold = repeat_tool_call_threshold
-        self.repeat_tool_call_max = repeat_tool_call_max
         # Deterministic pre-dispatch guards. The repeated-tool-call breaker is
-        # always present (governed by the kwargs above; threshold <= 0 makes it
-        # a no-op); any caller-supplied rules run after it. See `rules.py`.
-        self.rules: list[Rule] = [
-            RepeatedToolCallRule(repeat_tool_call_threshold, repeat_tool_call_max)
-        ]
+        # always present (governed by the kwarg above); any caller-supplied
+        # rules run after it. Rules replace tool_results; they never stop the
+        # loop (max_iterations is the runaway backstop). See `rules.py`.
+        self.rules: list[Rule] = [RepeatedToolCallRule(repeat_tool_call_threshold)]
         self.rules.extend(rules)
 
     def set_reasoning_effort(self, value: str | None) -> None:
@@ -162,44 +158,25 @@ class Agent:
                 # below sit in the correct chronological order.
                 messages.append(response.to_message())
 
-                # Run deterministic rules over the proposed calls. Blocked
-                # calls get a synthetic tool_result (the rule's feedback) in
-                # place of dispatch; a halting rule ends the run.
-                blocked, halt, halt_message = self._apply_rules(ctx, tool_calls)
-                if halt:
-                    for tc in tool_calls:
-                        content = blocked.get(tc.id) or halt_message or "[ouro] Halted by rule."
-                        messages.append(
-                            LLMMessage(
-                                role="tool",
-                                content=content,
-                                tool_call_id=tc.id,
-                                name=tc.name,
-                            )
-                        )
-                    final_answer = halt_message or ""
-                    self.progress.unfinished_answer(final_answer)
-                    return final_answer
+                # Run deterministic rules over the proposed calls. A blocked
+                # call is not dispatched; the rule's feedback becomes its
+                # tool_result so the model self-corrects next turn.
+                blocked = self._apply_rules(ctx, tool_calls)
 
-                # Dispatch only the calls no rule blocked, then append every
-                # call's result in the model's original order (synthetic for
-                # blocked calls, real for dispatched ones) so each tool_call
-                # gets exactly one tool_result.
+                # Dispatch only the calls no rule blocked, then write one
+                # tool_result per call in the model's original order (synthetic
+                # feedback for blocked calls, real output for dispatched ones)
+                # so each tool_call gets exactly one tool_result.
                 remaining = [tc for tc in tool_calls if tc.id not in blocked]
-                results_by_id: dict[str, str] = {}
                 executed: list[tuple[ToolCall, ToolResult]] = []
                 if remaining:
-                    tool_results = await self._dispatch_tools(ctx, remaining)
-                    for tc, tr in zip(remaining, tool_results):
-                        results_by_id[tc.id] = tr.content
-                        executed.append((tc, tr))
-
+                    executed = list(zip(remaining, await self._dispatch_tools(ctx, remaining)))
+                contents = {**blocked, **{tc.id: tr.content for tc, tr in executed}}
                 for tc in tool_calls:
-                    content = blocked[tc.id] if tc.id in blocked else results_by_id.get(tc.id, "")
                     messages.append(
                         LLMMessage(
                             role="tool",
-                            content=content,
+                            content=contents[tc.id],
                             tool_call_id=tc.id,
                             name=tc.name,
                         )
@@ -249,28 +226,19 @@ class Agent:
         self,
         ctx: LoopContext,
         tool_calls: list[ToolCall],
-    ) -> tuple[dict[str, str], bool, str | None]:
+    ) -> dict[str, str]:
         """Evaluate every rule over the proposed calls and aggregate verdicts.
 
-        Returns ``(blocked, halt, halt_message)`` where ``blocked`` maps a
-        ``tool_call_id`` to the feedback to surface in place of dispatching it
-        (messages from multiple rules are joined). ``halt`` is true if any rule
-        asked to terminate the run; ``halt_message`` is the first such rule's
-        final answer. Rules do not mutate ``messages`` — the caller owns that.
+        Returns ``blocked``: a map from ``tool_call_id`` to the feedback to
+        surface in place of dispatching it (messages from multiple rules that
+        block the same call are joined). Calls not in the map dispatch normally.
+        Rules do not mutate ``messages`` — the caller owns that.
         """
         violations: dict[str, list[str]] = {}
-        halt = False
-        halt_message: str | None = None
         for rule in self.rules:
-            outcome = rule.check(ctx, tool_calls)
-            for v in outcome.violations:
+            for v in rule.check(ctx, tool_calls).violations:
                 violations.setdefault(v.tool_call_id, []).append(v.message)
-            if outcome.halt:
-                halt = True
-                if halt_message is None:
-                    halt_message = outcome.halt_message
-        blocked = {tid: "\n".join(msgs) for tid, msgs in violations.items()}
-        return blocked, halt, halt_message
+        return {tid: "\n".join(msgs) for tid, msgs in violations.items()}
 
     async def _dispatch_tools(
         self,

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -57,10 +57,11 @@ class Agent:
         # Warn the model after `repeat_tool_call_threshold` consecutive identical
         # tool-call iterations; <= 0 disables the check. See RepeatedToolCallRule.
         self.repeat_tool_call_threshold = repeat_tool_call_threshold
-        # Deterministic pre-dispatch guards. The repeated-tool-call breaker is
+        # Deterministic per-tool-call rules. The repeated-tool-call breaker is
         # always present (governed by the kwarg above); any caller-supplied
-        # rules run after it. Rules replace tool_results; they never stop the
-        # loop (max_iterations is the runaway backstop). See `rules.py`.
+        # rules run after it. A rule blocks a call before dispatch or rewrites
+        # its result after; it never stops the loop (max_iterations is the
+        # runaway backstop). See `rules.py`.
         self.rules: list[Rule] = [RepeatedToolCallRule(repeat_tool_call_threshold)]
         self.rules.extend(rules)
 
@@ -88,9 +89,6 @@ class Agent:
         ctx = RunStatistic(task=task, progress=self.progress, usage_callback=self._usage_callback)
         messages = context.detached
         await self._fanout_async("on_run_start", ctx, messages)
-        # Reset per-run rule state (e.g. the repeated-tool-call counter).
-        for rule in self.rules:
-            rule.on_run_start()
 
         tool_schemas = self.tools.get_tool_schemas()
         final_answer: str = ""
@@ -158,20 +156,19 @@ class Agent:
                 # below sit in the correct chronological order.
                 messages.append(response.to_message())
 
-                # Run deterministic rules over the proposed calls. A blocked
-                # call is not dispatched; the rule's feedback becomes its
-                # tool_result so the model self-corrects next turn.
-                blocked = self._apply_rules(ctx, tool_calls)
-
-                # Dispatch only the calls no rule blocked, then write one
-                # tool_result per call in the model's original order (synthetic
-                # feedback for blocked calls, real output for dispatched ones)
-                # so each tool_call gets exactly one tool_result.
+                # Per-tool-call rules. `before_toolcall` may block a call (its
+                # text becomes the result and the call is skipped); the rest
+                # dispatch, then `after_toolcall` may rewrite each real result.
+                blocked = self._rules_before(ctx, tool_calls)
                 remaining = [tc for tc in tool_calls if tc.id not in blocked]
-                executed: list[tuple[ToolCall, ToolResult]] = []
+
+                contents: dict[str, str] = dict(blocked)
                 if remaining:
-                    executed = list(zip(remaining, await self._dispatch_tools(ctx, remaining)))
-                contents = {**blocked, **{tc.id: tr.content for tc, tr in executed}}
+                    results = await self._dispatch_tools(ctx, remaining)
+                    for tc, tr in zip(remaining, results):
+                        contents[tc.id] = self._rules_after(ctx, tc, tr)
+
+                # One tool_result per call, in the model's original order.
                 for tc in tool_calls:
                     messages.append(
                         LLMMessage(
@@ -181,9 +178,6 @@ class Agent:
                             name=tc.name,
                         )
                     )
-
-                for rule in self.rules:
-                    rule.observe(ctx, executed)
                 continue
 
             if response.stop_reason == StopReason.LENGTH:
@@ -222,23 +216,44 @@ class Agent:
         logger.warning("Agent.run reached max_iterations=%d without STOP", self.max_iterations)
         return final_answer
 
-    def _apply_rules(
+    def _rules_before(
         self,
         ctx: LoopContext,
         tool_calls: list[ToolCall],
     ) -> dict[str, str]:
-        """Evaluate every rule over the proposed calls and aggregate verdicts.
+        """Run every rule's ``before_toolcall`` over each proposed call.
 
-        Returns ``blocked``: a map from ``tool_call_id`` to the feedback to
-        surface in place of dispatching it (messages from multiple rules that
-        block the same call are joined). Calls not in the map dispatch normally.
-        Rules do not mutate ``messages`` — the caller owns that.
+        Returns ``blocked``: a map from ``tool_call_id`` to the text to surface
+        in place of dispatching it (messages from multiple rules that block the
+        same call are joined). Calls absent from the map dispatch normally.
         """
-        violations: dict[str, list[str]] = {}
+        blocked: dict[str, list[str]] = {}
+        for tc in tool_calls:
+            for rule in self.rules:
+                fn = getattr(rule, "before_toolcall", None)
+                if fn is None:
+                    continue
+                msg = fn(ctx, tc)
+                if msg is not None:
+                    blocked.setdefault(tc.id, []).append(msg)
+        return {tid: "\n".join(msgs) for tid, msgs in blocked.items()}
+
+    def _rules_after(self, ctx: LoopContext, tool_call: ToolCall, result: ToolResult) -> str:
+        """Run every rule's ``after_toolcall`` over a dispatched call's result.
+
+        Each rule may rewrite the content (later rules see earlier rewrites) or
+        return ``None`` to leave it unchanged. Returns the final result text.
+        """
+        content = result.content
         for rule in self.rules:
-            for v in rule.check(ctx, tool_calls).violations:
-                violations.setdefault(v.tool_call_id, []).append(v.message)
-        return {tid: "\n".join(msgs) for tid, msgs in violations.items()}
+            fn = getattr(rule, "after_toolcall", None)
+            if fn is None:
+                continue
+            current = ToolResult(tool_call_id=tool_call.id, content=content, name=tool_call.name)
+            replacement = fn(ctx, tool_call, current)
+            if replacement is not None:
+                content = replacement
+        return content
 
     async def _dispatch_tools(
         self,

--- a/ouro/core/loop/rules.py
+++ b/ouro/core/loop/rules.py
@@ -1,0 +1,194 @@
+"""Loop rules: deterministic pre-dispatch guards.
+
+A *rule* is a deterministic, formal check the agent loop runs over the model's
+proposed tool calls *before* dispatching them. Where a hook does broad
+lifecycle work (compaction, verification), a rule does one narrow thing: inspect
+the proposed ``(name, arguments)`` calls and decide — without calling the LLM —
+whether each call may proceed. A rule trades a probabilistic LLM mistake for a
+deterministic guarantee, feeding any verdict back to the model as a synthetic
+``tool_result`` so it can self-correct on the next turn.
+
+The loop owns the integration (see ``Agent._apply_rules``); rules own only their
+verdict and any per-run state. ``ouro.core`` rules stay tool-agnostic — they see
+only ``ToolCall`` / ``ToolResult``. Tool-aware rules (e.g. "only modify files
+you've read") live in ``ouro.capabilities`` and are injected via the Agent
+constructor / ``AgentBuilder``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ouro.core.log import get_logger
+
+if TYPE_CHECKING:
+    from ouro.core.llm import ToolCall, ToolResult
+    from ouro.core.loop.protocols import LoopContext
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RuleViolation:
+    """One proposed tool call a rule decided to block.
+
+    ``message`` becomes the synthetic ``tool_result`` content fed back to the
+    model in place of dispatching the call, so it should read as actionable
+    feedback ("read the file before writing it", etc.).
+    """
+
+    tool_call_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RuleOutcome:
+    """A rule's verdict on one iteration's proposed tool calls.
+
+    - ``violations`` — calls to block (by id) with feedback. Siblings not named
+      here dispatch normally.
+    - ``halt`` — terminate the whole run after this iteration.
+    - ``halt_message`` — final answer returned to the caller when ``halt``.
+    """
+
+    violations: tuple[RuleViolation, ...] = ()
+    halt: bool = False
+    halt_message: str | None = None
+
+    @classmethod
+    def ok(cls) -> RuleOutcome:
+        """No objection — let every proposed call dispatch."""
+        return cls()
+
+
+@runtime_checkable
+class Rule(Protocol):
+    """A deterministic pre-dispatch check over proposed tool calls.
+
+    Lifecycle (driven by the loop):
+
+    - ``on_run_start`` — reset per-run state at the top of ``Agent.run``.
+    - ``check`` — before dispatch, return a ``RuleOutcome`` blocking calls
+      and/or halting. Must not call the LLM or perform I/O; it is meant to be
+      fast and deterministic.
+    - ``observe`` — after dispatch, see the executed ``(ToolCall, ToolResult)``
+      pairs so stateful rules can update (e.g. record which files were read).
+      Blocked calls are not in ``executed``.
+    """
+
+    name: str
+
+    def on_run_start(self) -> None: ...
+    def check(self, ctx: LoopContext, tool_calls: list[ToolCall]) -> RuleOutcome: ...
+    def observe(self, ctx: LoopContext, executed: list[tuple[ToolCall, ToolResult]]) -> None: ...
+
+
+def _tool_call_iter_signature(
+    tool_calls: list[ToolCall],
+) -> tuple[tuple[str, str], ...]:
+    """Build a deterministic fingerprint for one iteration's tool_calls.
+
+    Used by ``RepeatedToolCallRule`` to detect when the model is emitting the
+    exact same ``(name, arguments)`` batch iteration after iteration. Arguments
+    are serialized with ``sort_keys=True`` so key order is normalized;
+    non-JSON-safe values fall back to ``str(...)`` so the helper never raises on
+    exotic argument types.
+    """
+    sigs: list[tuple[str, str]] = []
+    for tc in tool_calls:
+        try:
+            args_repr = json.dumps(tc.arguments, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            args_repr = repr(tc.arguments)
+        sigs.append((tc.name, args_repr))
+    return tuple(sigs)
+
+
+@dataclass
+class RepeatedToolCallRule:
+    """Circuit-breaker for self-reinforcing tool-call loops.
+
+    Compaction summaries can re-inject pathological tool-call patterns as if
+    they were task state, so when the model emits the same ``(name, arguments)``
+    iteration ``threshold`` times in a row we block the calls with a "stop
+    repeating" feedback (soft intercept), and at ``max_repeats`` we halt the run
+    (hard stop). Setting ``threshold <= 0`` disables the breaker entirely.
+
+    This is the generic, tool-agnostic rule that ships on by default; it ports
+    the behavior previously baked into ``Agent._apply_repeated_tool_call_guard``.
+    """
+
+    threshold: int = 3
+    max_repeats: int = 5
+    name: str = field(default="repeated_tool_call", init=False)
+
+    def __post_init__(self) -> None:
+        self._last_iter_sig: tuple[tuple[str, str], ...] | None = None
+        self._repeat_count: int = 0
+
+    def on_run_start(self) -> None:
+        self._last_iter_sig = None
+        self._repeat_count = 0
+
+    def check(self, ctx: LoopContext, tool_calls: list[ToolCall]) -> RuleOutcome:
+        iter_sig = _tool_call_iter_signature(tool_calls)
+        if self._last_iter_sig is not None and iter_sig == self._last_iter_sig:
+            self._repeat_count += 1
+        else:
+            self._repeat_count = 1
+        self._last_iter_sig = iter_sig
+
+        if self.threshold <= 0:
+            return RuleOutcome.ok()
+
+        count = self._repeat_count
+        names = [tc.name for tc in tool_calls]
+
+        if count >= self.max_repeats:
+            feedback = (
+                f"[ouro] Same tool_call(s) repeated {count} times consecutively "
+                "with no progress. Terminating to prevent runaway loop."
+            )
+            logger.warning(
+                "RepeatedToolCallRule: hard-stopping after %d consecutive "
+                "identical tool_call iterations on iteration %d (names=%s)",
+                count,
+                ctx.iteration,
+                names,
+            )
+            halt_message = (
+                "[ouro] Halted: the model repeated the same tool call "
+                f"{count} times without progress ({names}). Please rephrase your "
+                "request or restart the session."
+            )
+            return RuleOutcome(
+                violations=tuple(RuleViolation(tc.id, feedback) for tc in tool_calls),
+                halt=True,
+                halt_message=halt_message,
+            )
+
+        if count >= self.threshold:
+            feedback = (
+                f"[ouro] This exact tool_call has now been issued {count} times "
+                "consecutively. The result has not changed. Stop repeating: "
+                "either choose a different action, ask the user for clarification, "
+                "or finish the task."
+            )
+            logger.warning(
+                "RepeatedToolCallRule: intercepted %d-times-repeated tool_call(s) "
+                "on iteration %d (names=%s)",
+                count,
+                ctx.iteration,
+                names,
+            )
+            return RuleOutcome(
+                violations=tuple(RuleViolation(tc.id, feedback) for tc in tool_calls)
+            )
+
+        return RuleOutcome.ok()
+
+    def observe(self, ctx: LoopContext, executed: list[tuple[ToolCall, ToolResult]]) -> None:
+        # Stateless w.r.t. results; signature tracking happens in ``check``.
+        return None

--- a/ouro/core/loop/rules.py
+++ b/ouro/core/loop/rules.py
@@ -1,18 +1,27 @@
-"""Loop rules: deterministic per-call tool-result substitution.
+"""Loop rules: deterministic, per-tool-call result control.
 
-A *rule* is a deterministic, formal check the agent loop runs over the model's
-proposed tool calls *before* dispatching them. Where a hook does broad
-lifecycle work (compaction, verification), a rule does one narrow thing: inspect
-the proposed ``(name, arguments)`` calls and, without calling the LLM, decide
-which calls to block. A blocked call is **not** dispatched — the loop
-substitutes the rule's feedback message as that call's ``tool_result``, so the
-model sees a deterministic error/hint and self-corrects on the next turn.
+A *rule* is a deterministic check the agent loop runs around each individual
+tool call. Where a hook does broad lifecycle work (compaction, verification), a
+rule does one narrow thing per call: decide, without calling the LLM, whether
+to block the call or rewrite its result. A rule trades a probabilistic LLM
+mistake for a deterministic guarantee, feeding its verdict back as the call's
+``tool_result`` so the model self-corrects.
 
-A rule never stops the loop. It only replaces results; runaway protection is
-the loop's own concern (``max_iterations``). This keeps the rule contract
-small: every rule, from the generic repeat breaker to a tool-aware
-read-before-write check, answers the same question — "which of these calls
-should I replace, and with what message?"
+Two optional hooks — a rule implements whichever it needs:
+
+- ``before_toolcall(ctx, tool_call) -> str | None`` runs *before* dispatch.
+  Return a string to **block** the call: it is skipped (never executed) and the
+  returned text becomes its ``tool_result``. Return ``None`` to let it run. This
+  is the only way to stop a side-effecting call (write/edit/delete/run) from
+  actually happening.
+- ``after_toolcall(ctx, tool_call, tool_result) -> str | None`` runs *after* a
+  dispatched call returns. Return a string to **replace** its result text;
+  return ``None`` to leave it unchanged. Use it to rewrite output and/or to
+  record state from real results (e.g. which files were read).
+
+Both are per-tool-call and deterministic (no LLM/I/O). A rule never stops the
+loop; it only blocks or rewrites individual results. Runaway protection is the
+loop's own concern (``max_iterations``).
 
 ``ouro.core`` rules stay tool-agnostic — they see only ``ToolCall`` /
 ``ToolResult``. Tool-aware rules (e.g. "only modify files you've read") live in
@@ -28,138 +37,96 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from ouro.core.log import get_logger
 
 if TYPE_CHECKING:
-    from ouro.core.llm import ToolCall, ToolResult
+    from ouro.core.llm import ToolCall
     from ouro.core.loop.protocols import LoopContext
 
 logger = get_logger(__name__)
 
 
-@dataclass(frozen=True)
-class RuleViolation:
-    """One proposed tool call a rule decided to block.
-
-    ``message`` becomes the synthetic ``tool_result`` content fed back to the
-    model in place of dispatching the call, so it should read as actionable
-    feedback ("read the file before writing it", etc.).
-    """
-
-    tool_call_id: str
-    message: str
-
-
-@dataclass(frozen=True)
-class RuleOutcome:
-    """A rule's verdict on one iteration's proposed tool calls.
-
-    ``violations`` names the calls to block (by id) with feedback; the loop
-    substitutes that feedback as their ``tool_result`` instead of dispatching
-    them. Calls not named here dispatch normally.
-    """
-
-    violations: tuple[RuleViolation, ...] = ()
-
-    @classmethod
-    def ok(cls) -> RuleOutcome:
-        """No objection — let every proposed call dispatch."""
-        return cls()
-
-
 @runtime_checkable
 class Rule(Protocol):
-    """A deterministic pre-dispatch check over proposed tool calls.
+    """A deterministic, per-tool-call check.
 
-    Lifecycle (driven by the loop):
+    A rule carries a ``name`` and defines **either or both** of these optional
+    hooks (the loop duck-types via ``getattr``, so a rule implements only what
+    it needs):
 
-    - ``on_run_start`` — reset per-run state at the top of ``Agent.run``.
-    - ``check`` — before dispatch, return a ``RuleOutcome`` naming the calls to
-      block. Must not call the LLM or perform I/O; it is meant to be fast and
-      deterministic. A rule blocks calls; it never stops the loop.
-    - ``observe`` — after dispatch, see the executed ``(ToolCall, ToolResult)``
-      pairs so stateful rules can update (e.g. record which files were read).
-      Blocked calls are not in ``executed``.
+    - ``before_toolcall(ctx, tool_call) -> str | None`` — before dispatch;
+      return text to block the call (it is skipped and the text becomes its
+      ``tool_result``), or ``None`` to let it run.
+    - ``after_toolcall(ctx, tool_call, tool_result) -> str | None`` — after a
+      dispatched call; return text to replace its result, or ``None`` to leave
+      it (also where stateful rules record from real results).
+
+    The signatures live in the docstring rather than the Protocol body so that
+    a rule implementing just one hook still structurally satisfies ``Rule``.
     """
 
     name: str
 
-    def on_run_start(self) -> None: ...
-    def check(self, ctx: LoopContext, tool_calls: list[ToolCall]) -> RuleOutcome: ...
-    def observe(self, ctx: LoopContext, executed: list[tuple[ToolCall, ToolResult]]) -> None: ...
 
+def _tool_call_signature(tool_call: ToolCall) -> tuple[str, str]:
+    """Build a deterministic ``(name, arguments)`` fingerprint for one call.
 
-def _tool_call_iter_signature(
-    tool_calls: list[ToolCall],
-) -> tuple[tuple[str, str], ...]:
-    """Build a deterministic fingerprint for one iteration's tool_calls.
-
-    Used by ``RepeatedToolCallRule`` to detect when the model is emitting the
-    exact same ``(name, arguments)`` batch iteration after iteration. Arguments
-    are serialized with ``sort_keys=True`` so key order is normalized;
-    non-JSON-safe values fall back to ``str(...)`` so the helper never raises on
-    exotic argument types.
+    Arguments are serialized with ``sort_keys=True`` so key order is normalized;
+    non-JSON-safe values fall back to ``str(...)`` so this never raises on exotic
+    argument types.
     """
-    sigs: list[tuple[str, str]] = []
-    for tc in tool_calls:
-        try:
-            args_repr = json.dumps(tc.arguments, sort_keys=True, default=str)
-        except (TypeError, ValueError):
-            args_repr = repr(tc.arguments)
-        sigs.append((tc.name, args_repr))
-    return tuple(sigs)
+    try:
+        args_repr = json.dumps(tool_call.arguments, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        args_repr = repr(tool_call.arguments)
+    return (tool_call.name, args_repr)
 
 
 @dataclass
 class RepeatedToolCallRule:
-    """Warn the model when it repeats an identical tool-call batch.
+    """Warn the model when it repeats an identical tool call across turns.
 
     Compaction summaries can re-inject pathological tool-call patterns as if
-    they were task state, so when the model emits the same ``(name, arguments)``
-    batch ``threshold`` times in a row we block the calls and substitute a "stop
-    repeating" feedback as their results. The model sees the warning and is
-    expected to change course on the next turn; the rule never halts the run
-    (``Agent.max_iterations`` remains the ultimate backstop). Setting
-    ``threshold <= 0`` disables the check entirely.
+    they were task state, so when the same ``(name, arguments)`` call recurs on
+    consecutive iterations ``threshold`` times we block it and feed back a "stop
+    repeating" message as its result. The model is expected to change course;
+    the rule never halts the run (``Agent.max_iterations`` is the backstop).
 
-    This is the generic, tool-agnostic rule that ships on by default.
+    State is per-call and self-resetting: a new run restarts ``ctx.iteration``
+    at 1, which clears stale counts, so the rule needs no lifecycle reset.
+    ``threshold <= 0`` disables the check.
     """
 
     threshold: int = 3
     name: str = field(default="repeated_tool_call", init=False)
 
     def __post_init__(self) -> None:
-        self._last_iter_sig: tuple[tuple[str, str], ...] | None = None
-        self._repeat_count: int = 0
+        # signature -> (last iteration it was seen on, consecutive-turn count)
+        self._counts: dict[tuple[str, str], tuple[int, int]] = {}
 
-    def on_run_start(self) -> None:
-        self._last_iter_sig = None
-        self._repeat_count = 0
+    def before_toolcall(self, ctx: LoopContext, tool_call: ToolCall) -> str | None:
+        if self.threshold <= 0:
+            return None
+        iteration = ctx.iteration
+        if iteration <= 1:
+            # A new run restarts the iteration counter at 1; drop stale state.
+            self._counts.clear()
 
-    def check(self, ctx: LoopContext, tool_calls: list[ToolCall]) -> RuleOutcome:
-        iter_sig = _tool_call_iter_signature(tool_calls)
-        if self._last_iter_sig is not None and iter_sig == self._last_iter_sig:
-            self._repeat_count += 1
-        else:
-            self._repeat_count = 1
-        self._last_iter_sig = iter_sig
+        sig = _tool_call_signature(tool_call)
+        last_iter, count = self._counts.get(sig, (0, 0))
+        # Consecutive if it recurred on this turn or the immediately prior one.
+        count = count + 1 if last_iter and last_iter >= iteration - 1 else 1
+        self._counts[sig] = (iteration, count)
 
-        if self.threshold <= 0 or self._repeat_count < self.threshold:
-            return RuleOutcome.ok()
+        if count < self.threshold:
+            return None
 
-        count = self._repeat_count
-        feedback = (
-            f"[ouro] This exact tool_call has now been issued {count} times "
-            "consecutively. The result has not changed. Stop repeating: either "
-            "choose a different action, ask the user for clarification, or "
-            "finish the task."
-        )
         logger.warning(
-            "RepeatedToolCallRule: intercepted %d-times-repeated tool_call(s) "
-            "on iteration %d (names=%s)",
+            "RepeatedToolCallRule: tool_call %r issued %d times across "
+            "consecutive iterations (iteration %d)",
+            tool_call.name,
             count,
-            ctx.iteration,
-            [tc.name for tc in tool_calls],
+            iteration,
         )
-        return RuleOutcome(tuple(RuleViolation(tc.id, feedback) for tc in tool_calls))
-
-    def observe(self, ctx: LoopContext, executed: list[tuple[ToolCall, ToolResult]]) -> None:
-        # Stateless w.r.t. results; signature tracking happens in ``check``.
-        return None
+        return (
+            f"[ouro] This exact tool_call has now been issued {count} times across "
+            "consecutive turns with no change in result. Stop repeating: choose a "
+            "different action, ask the user for clarification, or finish the task."
+        )

--- a/ouro/core/loop/rules.py
+++ b/ouro/core/loop/rules.py
@@ -1,18 +1,22 @@
-"""Loop rules: deterministic pre-dispatch guards.
+"""Loop rules: deterministic per-call tool-result substitution.
 
 A *rule* is a deterministic, formal check the agent loop runs over the model's
 proposed tool calls *before* dispatching them. Where a hook does broad
 lifecycle work (compaction, verification), a rule does one narrow thing: inspect
-the proposed ``(name, arguments)`` calls and decide — without calling the LLM —
-whether each call may proceed. A rule trades a probabilistic LLM mistake for a
-deterministic guarantee, feeding any verdict back to the model as a synthetic
-``tool_result`` so it can self-correct on the next turn.
+the proposed ``(name, arguments)`` calls and, without calling the LLM, decide
+which calls to block. A blocked call is **not** dispatched — the loop
+substitutes the rule's feedback message as that call's ``tool_result``, so the
+model sees a deterministic error/hint and self-corrects on the next turn.
 
-The loop owns the integration (see ``Agent._apply_rules``); rules own only their
-verdict and any per-run state. ``ouro.core`` rules stay tool-agnostic — they see
-only ``ToolCall`` / ``ToolResult``. Tool-aware rules (e.g. "only modify files
-you've read") live in ``ouro.capabilities`` and are injected via the Agent
-constructor / ``AgentBuilder``.
+A rule never stops the loop. It only replaces results; runaway protection is
+the loop's own concern (``max_iterations``). This keeps the rule contract
+small: every rule, from the generic repeat breaker to a tool-aware
+read-before-write check, answers the same question — "which of these calls
+should I replace, and with what message?"
+
+``ouro.core`` rules stay tool-agnostic — they see only ``ToolCall`` /
+``ToolResult``. Tool-aware rules (e.g. "only modify files you've read") live in
+``ouro.capabilities`` and are injected via the Agent constructor / ``AgentBuilder``.
 """
 
 from __future__ import annotations
@@ -47,15 +51,12 @@ class RuleViolation:
 class RuleOutcome:
     """A rule's verdict on one iteration's proposed tool calls.
 
-    - ``violations`` — calls to block (by id) with feedback. Siblings not named
-      here dispatch normally.
-    - ``halt`` — terminate the whole run after this iteration.
-    - ``halt_message`` — final answer returned to the caller when ``halt``.
+    ``violations`` names the calls to block (by id) with feedback; the loop
+    substitutes that feedback as their ``tool_result`` instead of dispatching
+    them. Calls not named here dispatch normally.
     """
 
     violations: tuple[RuleViolation, ...] = ()
-    halt: bool = False
-    halt_message: str | None = None
 
     @classmethod
     def ok(cls) -> RuleOutcome:
@@ -70,9 +71,9 @@ class Rule(Protocol):
     Lifecycle (driven by the loop):
 
     - ``on_run_start`` — reset per-run state at the top of ``Agent.run``.
-    - ``check`` — before dispatch, return a ``RuleOutcome`` blocking calls
-      and/or halting. Must not call the LLM or perform I/O; it is meant to be
-      fast and deterministic.
+    - ``check`` — before dispatch, return a ``RuleOutcome`` naming the calls to
+      block. Must not call the LLM or perform I/O; it is meant to be fast and
+      deterministic. A rule blocks calls; it never stops the loop.
     - ``observe`` — after dispatch, see the executed ``(ToolCall, ToolResult)``
       pairs so stateful rules can update (e.g. record which files were read).
       Blocked calls are not in ``executed``.
@@ -108,20 +109,20 @@ def _tool_call_iter_signature(
 
 @dataclass
 class RepeatedToolCallRule:
-    """Circuit-breaker for self-reinforcing tool-call loops.
+    """Warn the model when it repeats an identical tool-call batch.
 
     Compaction summaries can re-inject pathological tool-call patterns as if
     they were task state, so when the model emits the same ``(name, arguments)``
-    iteration ``threshold`` times in a row we block the calls with a "stop
-    repeating" feedback (soft intercept), and at ``max_repeats`` we halt the run
-    (hard stop). Setting ``threshold <= 0`` disables the breaker entirely.
+    batch ``threshold`` times in a row we block the calls and substitute a "stop
+    repeating" feedback as their results. The model sees the warning and is
+    expected to change course on the next turn; the rule never halts the run
+    (``Agent.max_iterations`` remains the ultimate backstop). Setting
+    ``threshold <= 0`` disables the check entirely.
 
-    This is the generic, tool-agnostic rule that ships on by default; it ports
-    the behavior previously baked into ``Agent._apply_repeated_tool_call_guard``.
+    This is the generic, tool-agnostic rule that ships on by default.
     """
 
     threshold: int = 3
-    max_repeats: int = 5
     name: str = field(default="repeated_tool_call", init=False)
 
     def __post_init__(self) -> None:
@@ -140,54 +141,24 @@ class RepeatedToolCallRule:
             self._repeat_count = 1
         self._last_iter_sig = iter_sig
 
-        if self.threshold <= 0:
+        if self.threshold <= 0 or self._repeat_count < self.threshold:
             return RuleOutcome.ok()
 
         count = self._repeat_count
-        names = [tc.name for tc in tool_calls]
-
-        if count >= self.max_repeats:
-            feedback = (
-                f"[ouro] Same tool_call(s) repeated {count} times consecutively "
-                "with no progress. Terminating to prevent runaway loop."
-            )
-            logger.warning(
-                "RepeatedToolCallRule: hard-stopping after %d consecutive "
-                "identical tool_call iterations on iteration %d (names=%s)",
-                count,
-                ctx.iteration,
-                names,
-            )
-            halt_message = (
-                "[ouro] Halted: the model repeated the same tool call "
-                f"{count} times without progress ({names}). Please rephrase your "
-                "request or restart the session."
-            )
-            return RuleOutcome(
-                violations=tuple(RuleViolation(tc.id, feedback) for tc in tool_calls),
-                halt=True,
-                halt_message=halt_message,
-            )
-
-        if count >= self.threshold:
-            feedback = (
-                f"[ouro] This exact tool_call has now been issued {count} times "
-                "consecutively. The result has not changed. Stop repeating: "
-                "either choose a different action, ask the user for clarification, "
-                "or finish the task."
-            )
-            logger.warning(
-                "RepeatedToolCallRule: intercepted %d-times-repeated tool_call(s) "
-                "on iteration %d (names=%s)",
-                count,
-                ctx.iteration,
-                names,
-            )
-            return RuleOutcome(
-                violations=tuple(RuleViolation(tc.id, feedback) for tc in tool_calls)
-            )
-
-        return RuleOutcome.ok()
+        feedback = (
+            f"[ouro] This exact tool_call has now been issued {count} times "
+            "consecutively. The result has not changed. Stop repeating: either "
+            "choose a different action, ask the user for clarification, or "
+            "finish the task."
+        )
+        logger.warning(
+            "RepeatedToolCallRule: intercepted %d-times-repeated tool_call(s) "
+            "on iteration %d (names=%s)",
+            count,
+            ctx.iteration,
+            [tc.name for tc in tool_calls],
+        )
+        return RuleOutcome(tuple(RuleViolation(tc.id, feedback) for tc in tool_calls))
 
     def observe(self, ctx: LoopContext, executed: list[tuple[ToolCall, ToolResult]]) -> None:
         # Stateless w.r.t. results; signature tracking happens in ``check``.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -36,3 +36,4 @@ Tip: keep this list up to date when adding an RFC.
 - [loop-owned-message-list.md](loop-owned-message-list.md) — Loop Owned Message List
 - [reasoning-controls.md](reasoning-controls.md) — Reasoning Controls
 - [token-counting-accuracy.md](token-counting-accuracy.md) — Token Counting Accuracy
+- [loop-rules.md](loop-rules.md) — Loop Rules (Deterministic Pre-Dispatch Guards)

--- a/rfc/loop-rules.md
+++ b/rfc/loop-rules.md
@@ -8,10 +8,11 @@
 
 Generalize the hard-coded repeated-tool-call guard in the core agent loop into
 a pluggable **Rule** abstraction: a small set of deterministic, formal checks
-that run over the model's proposed tool calls *before* dispatch, and can block
-individual calls (feeding an error back to the model as a synthetic
-`tool_result`) or halt the run. Rules trade a probabilistic LLM mistake for a
-deterministic guarantee.
+that run over the model's proposed tool calls *before* dispatch and block
+individual calls — substituting the rule's feedback as that call's synthetic
+`tool_result` so the model self-corrects. A rule never stops the loop; it only
+replaces results. Rules trade a probabilistic LLM mistake for a deterministic
+guarantee.
 
 ## Problem
 
@@ -42,8 +43,9 @@ scale and conflates distinct concerns inside one loop branch.
   siblings dispatch.
 - Per-run rule state with a reset hook, and a post-dispatch `observe` hook so
   stateful rules (e.g. "files I've read") can update from real results.
-- Migrate the existing repeated-tool-call guard onto this abstraction with **no
-  behavioral change** and no change to existing public kwargs.
+- Migrate the existing repeated-tool-call guard onto this abstraction. Rules
+  only replace `tool_result`s — they never stop the run, so the old hard-stop
+  is dropped (see Proposed Behavior); soft warnings are unchanged.
 - Keep `ouro.core` tool-agnostic: the generic repeated-call rule lives in core;
   tool-aware rules (read-before-write) live in `ouro.capabilities`.
 
@@ -58,25 +60,33 @@ scale and conflates distinct concerns inside one loop branch.
 
 ## Proposed Behavior (User-Facing)
 
-No user-visible behavior change in this PR. The repeated-tool-call circuit
-breaker behaves identically (same thresholds, same feedback text, same hard
-stop). The `repeat_tool_call_threshold` / `repeat_tool_call_max` constructor
-kwargs are preserved and now construct a default `RepeatedToolCallRule`.
+One intentional behavior change: the repeated-tool-call breaker's **hard stop is
+removed**. A rule's only power is to replace tool_results, so when the model
+repeats an identical batch past `repeat_tool_call_threshold` it keeps getting a
+"stop repeating" warning every turn (soft intercept, unchanged) but the run is
+no longer terminated at a second threshold. Rationale: the warning is expected
+to redirect the model; `Agent.max_iterations` remains the runaway backstop, and
+stopping the loop is the loop's concern, not a rule's. The
+`repeat_tool_call_max` constructor kwarg is therefore removed;
+`repeat_tool_call_threshold` is preserved (`<= 0` still disables the check).
 
 - CLI / UX changes: none.
-- Config changes: none.
-- Output / logging changes: log messages stay equivalent (rule name included).
+- Config changes: `repeat_tool_call_max` kwarg removed (no external callers).
+- Output / logging changes: soft-intercept warning unchanged; no more hard-stop
+  warning or "[ouro] Halted…" final answer.
 
 ## Invariants (Must Not Regress)
 
 - Every `tool_call` still receives exactly one `tool_result` message (API
   requirement) — blocked calls get a synthetic result, dispatched calls a real
   one.
-- Repeated-call soft intercept at `threshold` and hard stop at `max` keep their
-  exact semantics, including the disabled-by-`<= 0` case.
+- Repeated-call soft intercept at `threshold` keeps its semantics, including the
+  disabled-by-`<= 0` case.
 - Assistant tool-call message is still persisted before any tool_result.
 - Parallel/sequential dispatch batching is unchanged for non-blocked calls.
 - Loop remains free of tool-name knowledge (`read_file`/`write_file` etc.).
+- A rule cannot terminate the run; only the loop (STOP / LENGTH /
+  `max_iterations`) ends it.
 
 ## Design Sketch (Minimal)
 
@@ -90,9 +100,7 @@ class RuleViolation:
 
 @dataclass(frozen=True)
 class RuleOutcome:
-    violations: tuple[RuleViolation, ...] = ()
-    halt: bool = False
-    halt_message: str | None = None
+    violations: tuple[RuleViolation, ...] = ()   # calls to block; no halt power
 
 @runtime_checkable
 class Rule(Protocol):
@@ -104,9 +112,10 @@ class Rule(Protocol):
                 executed: list[tuple[ToolCall, ToolResult]]) -> None: ...  # post-dispatch
 ```
 
-`RepeatedToolCallRule(threshold, max)` (core, generic) ports the current guard:
-holds `last_iter_sig` / `repeat_count`; `check` returns all calls as violations
-at `threshold` (continue) and additionally `halt=True` at `max`.
+`RepeatedToolCallRule(threshold)` (core, generic) ports the soft-intercept half
+of the old guard: holds `last_iter_sig` / `repeat_count`; `check` returns all
+calls as violations once the count reaches `threshold` (the model is warned and
+the calls are not dispatched). It has no hard stop.
 
 Loop integration (replaces the inline guard in the `TOOL_CALLS` branch):
 
@@ -114,17 +123,15 @@ Loop integration (replaces the inline guard in the `TOOL_CALLS` branch):
    fanout).
 2. After persisting the assistant tool-call message, run every rule's `check`
    and aggregate: union violations by `tool_call_id` (concatenate messages from
-   multiple rules), `halt` if any rule halts.
-3. For each blocked `tool_call_id`, append a synthetic `tool_result` with the
-   aggregated message. If `halt`: append synthetic results for *all* calls and
-   return `halt_message`.
-4. Dispatch only the non-blocked calls; append their real results.
-5. `observe` all rules with the executed `(ToolCall, ToolResult)` pairs.
-6. If no calls remained to dispatch (all blocked, no halt) → `continue`.
+   multiple rules that block the same call) into a `blocked: dict[id, str]`.
+3. Dispatch only the non-blocked calls. Build `contents` = blocked feedback
+   merged with dispatched results, then append one `tool_result` per call in the
+   model's original order. If every call was blocked, dispatch nothing and just
+   `continue` to the next turn.
+4. `observe` all rules with the executed `(ToolCall, ToolResult)` pairs.
 
-`Agent.__init__` gains `rules: Sequence[Rule] = ()`. For backward compatibility,
-when no rules are passed it defaults to
-`[RepeatedToolCallRule(threshold, max)]` built from the existing kwargs.
+`Agent.__init__` gains `rules: Sequence[Rule] = ()`; the `RepeatedToolCallRule`
+(from `repeat_tool_call_threshold`) is always prepended, then caller rules.
 
 Tool-aware rules (follow-up): `ReadBeforeWriteRule` in
 `ouro/capabilities/rules/`, knowing the `read_file` / `write_file` / `edit`
@@ -149,12 +156,15 @@ writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
 - Unit tests (new `test/test_loop_rules.py`):
   - A toy `Rule` blocks one call in a 2-call batch → blocked call gets the
     synthetic message, sibling dispatches, loop continues.
-  - A rule halting → run returns `halt_message`, all calls get tool_results.
+  - A fully-blocked iteration still emits one tool_result per call and the run
+    continues (no halt) until the model itself stops.
   - `on_run_start` resets state across two `run()` calls.
-  - `observe` receives executed `(ToolCall, ToolResult)` pairs.
+  - `observe` receives only the dispatched `(ToolCall, ToolResult)` pairs.
+  - Multiple rules blocking the same call → feedback joined deterministically.
 - Migrated coverage: `test/test_repeat_tool_call_circuit_breaker.py` updated to
   drive `RepeatedToolCallRule` (signature normalization, intercept at threshold,
-  hard stop at max, reset on changed args, disabled at `<= 0`) — same assertions.
+  reset on changed args, disabled at `<= 0`, and sustained repeats keep being
+  intercepted without halting).
 - Targeted: `./scripts/dev.sh test -q test/test_loop_rules.py
   test/test_repeat_tool_call_circuit_breaker.py test/test_parallel_tools.py
   test/test_ralph_loop.py`.
@@ -163,16 +173,20 @@ writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
 
 ## Rollout / Migration
 
-- Backward compatibility: `repeat_tool_call_threshold` / `repeat_tool_call_max`
-  kwargs preserved; default behavior identical when no `rules=` passed.
+- Backward compatibility: `repeat_tool_call_threshold` kwarg preserved
+  (`<= 0` still disables). `repeat_tool_call_max` is removed — it had no
+  external callers (only `Agent` itself and its tests).
+- Behavior change: the repeated-call hard stop is gone (see Proposed Behavior).
 - Migration steps: none for callers. Internally, `_apply_repeated_tool_call_guard`
   and `_RepeatGuardOutcome` are removed; `_tool_call_iter_signature` moves into
-  `rules.py` (still importable for tests).
+  `rules.py`.
 
 ## Risks & Mitigations
 
-- **Behavioral drift in the migrated guard.** Mitigation: reuse the existing
-  circuit-breaker test assertions verbatim against the new rule.
+- **Losing the hard stop weakens runaway protection.** Mitigation: the soft
+  warning still fires every repeat past `threshold`; capable models redirect on
+  the warning, and `max_iterations` bounds the worst case. Accepted trade-off
+  for a clean rule contract (rules replace results, never stop the loop).
 - **Ordering / aggregation bugs when multiple rules block the same call.**
   Mitigation: deterministic aggregation (union by id, stable message order) with
   a dedicated unit test.
@@ -184,5 +198,5 @@ writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
 - Should rule violations be surfaced to the `ProgressSink` (e.g. a
   `progress.info` line) so the user sees "blocked write_file: read it first"?
   Leaning yes in the follow-up, no extra surface in this PR.
-- Do we eventually want a config flag to toggle rules? Deferred to when there is
-  more than one rule shipping by default.
+- If a future check genuinely needs to *stop* the loop (not just warn), that
+  belongs to the loop or a `Hook` vote, not the `Rule` contract — revisit then.

--- a/rfc/loop-rules.md
+++ b/rfc/loop-rules.md
@@ -1,0 +1,188 @@
+# RFC: Loop Rules (Deterministic Pre-Dispatch Guards)
+
+- Status: Draft
+- Authors: Yixin Luo
+- Date: 2026-05-23
+
+## Summary
+
+Generalize the hard-coded repeated-tool-call guard in the core agent loop into
+a pluggable **Rule** abstraction: a small set of deterministic, formal checks
+that run over the model's proposed tool calls *before* dispatch, and can block
+individual calls (feeding an error back to the model as a synthetic
+`tool_result`) or halt the run. Rules trade a probabilistic LLM mistake for a
+deterministic guarantee.
+
+## Problem
+
+The loop currently has exactly one guard — `_apply_repeated_tool_call_guard`
+in `ouro/core/loop/agent.py` — baked directly into the `TOOL_CALLS` branch. It
+works (detects identical tool-call iterations, intercepts with feedback, hard
+stops on runaway), but its shape is bespoke: a private method returning a
+one-off `_RepeatGuardOutcome` NamedTuple, with `last_iter_sig` / `repeat_count`
+threaded through the loop as local variables.
+
+We want more checks of the same *kind*. Concrete near-term example: **only
+allow the agent to modify a file it has previously read**. If the model issues
+`write_file` / `edit` on a path it never `read_file`'d, return a deterministic
+error ("read the file first") instead of silently overwriting. This is exactly
+the repeated-call pattern — inspect proposed tool calls, decide deterministically,
+feed the verdict back as a `tool_result` so the model self-corrects — but it
+needs per-call granularity and per-run state that the current bespoke guard
+can't host.
+
+Adding each new check as another private method + more threaded locals does not
+scale and conflates distinct concerns inside one loop branch.
+
+## Goals
+
+- A first-class `Rule` abstraction in `ouro.core.loop`: deterministic checks
+  evaluated before tool dispatch.
+- Per-tool-call granularity: a rule can block one call in a batch while letting
+  siblings dispatch.
+- Per-run rule state with a reset hook, and a post-dispatch `observe` hook so
+  stateful rules (e.g. "files I've read") can update from real results.
+- Migrate the existing repeated-tool-call guard onto this abstraction with **no
+  behavioral change** and no change to existing public kwargs.
+- Keep `ouro.core` tool-agnostic: the generic repeated-call rule lives in core;
+  tool-aware rules (read-before-write) live in `ouro.capabilities`.
+
+## Non-goals
+
+- Implementing the read-before-write rule itself (follow-up PR; this RFC defines
+  the seam and validates it mentally against that use case).
+- A user-facing config surface for enabling/disabling individual rules (rules
+  are wired in code via the Agent constructor / `AgentBuilder` for now).
+- Any change to the `Hook` lifecycle (`on_run_start` / `on_iteration_start` /
+  `on_iteration_end`). Rules are a separate concept from hooks.
+
+## Proposed Behavior (User-Facing)
+
+No user-visible behavior change in this PR. The repeated-tool-call circuit
+breaker behaves identically (same thresholds, same feedback text, same hard
+stop). The `repeat_tool_call_threshold` / `repeat_tool_call_max` constructor
+kwargs are preserved and now construct a default `RepeatedToolCallRule`.
+
+- CLI / UX changes: none.
+- Config changes: none.
+- Output / logging changes: log messages stay equivalent (rule name included).
+
+## Invariants (Must Not Regress)
+
+- Every `tool_call` still receives exactly one `tool_result` message (API
+  requirement) — blocked calls get a synthetic result, dispatched calls a real
+  one.
+- Repeated-call soft intercept at `threshold` and hard stop at `max` keep their
+  exact semantics, including the disabled-by-`<= 0` case.
+- Assistant tool-call message is still persisted before any tool_result.
+- Parallel/sequential dispatch batching is unchanged for non-blocked calls.
+- Loop remains free of tool-name knowledge (`read_file`/`write_file` etc.).
+
+## Design Sketch (Minimal)
+
+New module `ouro/core/loop/rules.py`:
+
+```python
+@dataclass(frozen=True)
+class RuleViolation:
+    tool_call_id: str
+    message: str            # becomes the synthetic tool_result content
+
+@dataclass(frozen=True)
+class RuleOutcome:
+    violations: tuple[RuleViolation, ...] = ()
+    halt: bool = False
+    halt_message: str | None = None
+
+@runtime_checkable
+class Rule(Protocol):
+    name: str
+    def on_run_start(self) -> None: ...                       # reset per-run state
+    def check(self, ctx: LoopContext,
+              tool_calls: list[ToolCall]) -> RuleOutcome: ...  # pre-dispatch verdict
+    def observe(self, ctx: LoopContext,
+                executed: list[tuple[ToolCall, ToolResult]]) -> None: ...  # post-dispatch
+```
+
+`RepeatedToolCallRule(threshold, max)` (core, generic) ports the current guard:
+holds `last_iter_sig` / `repeat_count`; `check` returns all calls as violations
+at `threshold` (continue) and additionally `halt=True` at `max`.
+
+Loop integration (replaces the inline guard in the `TOOL_CALLS` branch):
+
+1. `on_run_start`: call `rule.on_run_start()` for each rule (alongside hook
+   fanout).
+2. After persisting the assistant tool-call message, run every rule's `check`
+   and aggregate: union violations by `tool_call_id` (concatenate messages from
+   multiple rules), `halt` if any rule halts.
+3. For each blocked `tool_call_id`, append a synthetic `tool_result` with the
+   aggregated message. If `halt`: append synthetic results for *all* calls and
+   return `halt_message`.
+4. Dispatch only the non-blocked calls; append their real results.
+5. `observe` all rules with the executed `(ToolCall, ToolResult)` pairs.
+6. If no calls remained to dispatch (all blocked, no halt) → `continue`.
+
+`Agent.__init__` gains `rules: Sequence[Rule] = ()`. For backward compatibility,
+when no rules are passed it defaults to
+`[RepeatedToolCallRule(threshold, max)]` built from the existing kwargs.
+
+Tool-aware rules (follow-up): `ReadBeforeWriteRule` in
+`ouro/capabilities/rules/`, knowing the `read_file` / `write_file` / `edit`
+tool names and their `file_path` arg; tracks read paths in `observe`, blocks
+writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
+`interfaces → capabilities → core` import direction.
+
+## Alternatives Considered
+
+- **New `Hook` lifecycle method (`before_dispatch`)** instead of a separate
+  `Rule` concept. Rejected: hooks are broad lifecycle/LLM-side effects
+  (compaction, verification) that vote on continuation; rules are narrow
+  deterministic per-call gates. Keeping them distinct keeps each contract small
+  and the intent legible ("rule = formal check").
+- **Leave the guard inline, add rules alongside.** Rejected: two parallel
+  mechanisms doing the same thing in the same loop branch.
+- **Whole-iteration verdict only (no per-call granularity).** Rejected: the
+  read-before-write use case must block one call while dispatching siblings.
+
+## Test Plan
+
+- Unit tests (new `test/test_loop_rules.py`):
+  - A toy `Rule` blocks one call in a 2-call batch → blocked call gets the
+    synthetic message, sibling dispatches, loop continues.
+  - A rule halting → run returns `halt_message`, all calls get tool_results.
+  - `on_run_start` resets state across two `run()` calls.
+  - `observe` receives executed `(ToolCall, ToolResult)` pairs.
+- Migrated coverage: `test/test_repeat_tool_call_circuit_breaker.py` updated to
+  drive `RepeatedToolCallRule` (signature normalization, intercept at threshold,
+  hard stop at max, reset on changed args, disabled at `<= 0`) — same assertions.
+- Targeted: `./scripts/dev.sh test -q test/test_loop_rules.py
+  test/test_repeat_tool_call_circuit_breaker.py test/test_parallel_tools.py
+  test/test_ralph_loop.py`.
+- `./scripts/dev.sh importlint` (boundary unchanged: rules stay in core).
+- Smoke: `python main.py --task "say hi then stop" --verify`.
+
+## Rollout / Migration
+
+- Backward compatibility: `repeat_tool_call_threshold` / `repeat_tool_call_max`
+  kwargs preserved; default behavior identical when no `rules=` passed.
+- Migration steps: none for callers. Internally, `_apply_repeated_tool_call_guard`
+  and `_RepeatGuardOutcome` are removed; `_tool_call_iter_signature` moves into
+  `rules.py` (still importable for tests).
+
+## Risks & Mitigations
+
+- **Behavioral drift in the migrated guard.** Mitigation: reuse the existing
+  circuit-breaker test assertions verbatim against the new rule.
+- **Ordering / aggregation bugs when multiple rules block the same call.**
+  Mitigation: deterministic aggregation (union by id, stable message order) with
+  a dedicated unit test.
+- **Layer leak (tool names creeping into core).** Mitigation: core rules use only
+  `ToolCall`/`ToolResult`; tool-aware rules live in capabilities; importlint guards.
+
+## Open Questions
+
+- Should rule violations be surfaced to the `ProgressSink` (e.g. a
+  `progress.info` line) so the user sees "blocked write_file: read it first"?
+  Leaning yes in the follow-up, no extra surface in this PR.
+- Do we eventually want a config flag to toggle rules? Deferred to when there is
+  more than one rule shipping by default.

--- a/rfc/loop-rules.md
+++ b/rfc/loop-rules.md
@@ -7,12 +7,12 @@
 ## Summary
 
 Generalize the hard-coded repeated-tool-call guard in the core agent loop into
-a pluggable **Rule** abstraction: a small set of deterministic, formal checks
-that run over the model's proposed tool calls *before* dispatch and block
-individual calls — substituting the rule's feedback as that call's synthetic
-`tool_result` so the model self-corrects. A rule never stops the loop; it only
-replaces results. Rules trade a probabilistic LLM mistake for a deterministic
-guarantee.
+a pluggable **Rule** abstraction: deterministic, per-tool-call checks the loop
+runs around each call. A rule can **block** a call before it runs (its text
+becomes the call's `tool_result`, and the call is skipped) or **rewrite** a
+dispatched call's result afterward. A rule never stops the loop; it only blocks
+or rewrites individual results. Rules trade a probabilistic LLM mistake for a
+deterministic guarantee.
 
 ## Problem
 
@@ -25,27 +25,26 @@ threaded through the loop as local variables.
 
 We want more checks of the same *kind*. Concrete near-term example: **only
 allow the agent to modify a file it has previously read**. If the model issues
-`write_file` / `edit` on a path it never `read_file`'d, return a deterministic
-error ("read the file first") instead of silently overwriting. This is exactly
-the repeated-call pattern — inspect proposed tool calls, decide deterministically,
-feed the verdict back as a `tool_result` so the model self-corrects — but it
-needs per-call granularity and per-run state that the current bespoke guard
-can't host.
+`write_file` / `edit` on a path it never `read_file`'d, block the call with a
+deterministic error ("read the file first") instead of silently overwriting —
+crucially, *before* the write runs. That rule needs to block one call before
+dispatch (`before_toolcall`) and to learn which files were actually read from
+real results (`after_toolcall`) — neither of which the bespoke guard can host.
 
 Adding each new check as another private method + more threaded locals does not
 scale and conflates distinct concerns inside one loop branch.
 
 ## Goals
 
-- A first-class `Rule` abstraction in `ouro.core.loop`: deterministic checks
-  evaluated before tool dispatch.
-- Per-tool-call granularity: a rule can block one call in a batch while letting
-  siblings dispatch.
-- Per-run rule state with a reset hook, and a post-dispatch `observe` hook so
-  stateful rules (e.g. "files I've read") can update from real results.
+- A first-class `Rule` abstraction in `ouro.core.loop`: deterministic,
+  per-tool-call checks around dispatch.
+- Block-before-dispatch (`before_toolcall`) so a side-effecting call (write /
+  edit / delete) can be stopped before it runs — not merely reported after.
+- Result rewrite / state capture after dispatch (`after_toolcall`).
+- Per-call granularity: act on one call in a batch while siblings dispatch.
 - Migrate the existing repeated-tool-call guard onto this abstraction. Rules
-  only replace `tool_result`s — they never stop the run, so the old hard-stop
-  is dropped (see Proposed Behavior); soft warnings are unchanged.
+  only block or rewrite `tool_result`s — they never stop the run, so the old
+  hard-stop is dropped (see Proposed Behavior); soft warnings are unchanged.
 - Keep `ouro.core` tool-agnostic: the generic repeated-call rule lives in core;
   tool-aware rules (read-before-write) live in `ouro.capabilities`.
 
@@ -61,19 +60,20 @@ scale and conflates distinct concerns inside one loop branch.
 ## Proposed Behavior (User-Facing)
 
 One intentional behavior change: the repeated-tool-call breaker's **hard stop is
-removed**. A rule's only power is to replace tool_results, so when the model
-repeats an identical batch past `repeat_tool_call_threshold` it keeps getting a
-"stop repeating" warning every turn (soft intercept, unchanged) but the run is
-no longer terminated at a second threshold. Rationale: the warning is expected
-to redirect the model; `Agent.max_iterations` remains the runaway backstop, and
-stopping the loop is the loop's concern, not a rule's. The
-`repeat_tool_call_max` constructor kwarg is therefore removed;
-`repeat_tool_call_threshold` is preserved (`<= 0` still disables the check).
+removed**. A rule's only power is to block or rewrite a call's result, so when
+the model repeats an identical call on consecutive turns past
+`repeat_tool_call_threshold` the call keeps getting blocked with a "stop
+repeating" warning every turn (soft intercept) but the run is no longer
+terminated at a second threshold. Rationale: the warning is expected to redirect
+the model; `Agent.max_iterations` remains the runaway backstop, and stopping the
+loop is the loop's concern, not a rule's. The `repeat_tool_call_max` constructor
+kwarg is therefore removed; `repeat_tool_call_threshold` is preserved (`<= 0`
+still disables the check).
 
 - CLI / UX changes: none.
 - Config changes: `repeat_tool_call_max` kwarg removed (no external callers).
-- Output / logging changes: soft-intercept warning unchanged; no more hard-stop
-  warning or "[ouro] Halted…" final answer.
+- Output / logging changes: soft-intercept warning unchanged in spirit (now
+  per-call); no more hard-stop warning or "[ouro] Halted…" final answer.
 
 ## Invariants (Must Not Regress)
 
@@ -90,54 +90,52 @@ stopping the loop is the loop's concern, not a rule's. The
 
 ## Design Sketch (Minimal)
 
-New module `ouro/core/loop/rules.py`:
+New module `ouro/core/loop/rules.py`. A rule is two **optional**, per-tool-call
+hooks; it implements whichever it needs (the loop duck-types via `getattr`):
 
 ```python
-@dataclass(frozen=True)
-class RuleViolation:
-    tool_call_id: str
-    message: str            # becomes the synthetic tool_result content
-
-@dataclass(frozen=True)
-class RuleOutcome:
-    violations: tuple[RuleViolation, ...] = ()   # calls to block; no halt power
-
 @runtime_checkable
 class Rule(Protocol):
     name: str
-    def on_run_start(self) -> None: ...                       # reset per-run state
-    def check(self, ctx: LoopContext,
-              tool_calls: list[ToolCall]) -> RuleOutcome: ...  # pre-dispatch verdict
-    def observe(self, ctx: LoopContext,
-                executed: list[tuple[ToolCall, ToolResult]]) -> None: ...  # post-dispatch
+    # Before dispatch: return text to BLOCK the call (it is skipped and the
+    # text becomes its tool_result), or None to let it run.
+    def before_toolcall(self, ctx: LoopContext, tool_call: ToolCall) -> str | None: ...
+    # After a dispatched call returns: return text to REPLACE its result, or
+    # None to leave it. Also the place to record state from real results.
+    def after_toolcall(self, ctx: LoopContext, tool_call: ToolCall,
+                       tool_result: ToolResult) -> str | None: ...
 ```
 
-`RepeatedToolCallRule(threshold)` (core, generic) ports the soft-intercept half
-of the old guard: holds `last_iter_sig` / `repeat_count`; `check` returns all
-calls as violations once the count reaches `threshold` (the model is warned and
-the calls are not dispatched). It has no hard stop.
+No `RuleOutcome` / `RuleViolation` types and no `on_run_start`: rules return a
+plain `str | None`, and per-run state self-resets where needed (see below).
+
+`RepeatedToolCallRule(threshold)` (core, generic) implements only
+`before_toolcall`: it tracks a per-`(name, arguments)` consecutive-iteration
+count and, once a call recurs `threshold` times, blocks it with a "stop
+repeating" message. State self-resets each run because `ctx.iteration` restarts
+at 1 (stale counts are dropped) — no lifecycle reset method required. No hard
+stop.
 
 Loop integration (replaces the inline guard in the `TOOL_CALLS` branch):
 
-1. `on_run_start`: call `rule.on_run_start()` for each rule (alongside hook
-   fanout).
-2. After persisting the assistant tool-call message, run every rule's `check`
-   and aggregate: union violations by `tool_call_id` (concatenate messages from
-   multiple rules that block the same call) into a `blocked: dict[id, str]`.
-3. Dispatch only the non-blocked calls. Build `contents` = blocked feedback
-   merged with dispatched results, then append one `tool_result` per call in the
-   model's original order. If every call was blocked, dispatch nothing and just
-   `continue` to the next turn.
-4. `observe` all rules with the executed `(ToolCall, ToolResult)` pairs.
+1. After persisting the assistant tool-call message, run every rule's
+   `before_toolcall` for each call; collect a `blocked: dict[id, str]` (messages
+   from multiple rules blocking the same call are joined).
+2. Dispatch only the non-blocked calls. For each dispatched call, run every
+   rule's `after_toolcall` to (optionally) rewrite its result.
+3. Append one `tool_result` per call in the model's original order — blocked
+   text for blocked calls, (possibly rewritten) output for dispatched ones. If
+   every call was blocked, dispatch nothing and `continue`.
 
 `Agent.__init__` gains `rules: Sequence[Rule] = ()`; the `RepeatedToolCallRule`
 (from `repeat_tool_call_threshold`) is always prepended, then caller rules.
 
 Tool-aware rules (follow-up): `ReadBeforeWriteRule` in
 `ouro/capabilities/rules/`, knowing the `read_file` / `write_file` / `edit`
-tool names and their `file_path` arg; tracks read paths in `observe`, blocks
-writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
-`interfaces → capabilities → core` import direction.
+tool names and their `file_path` arg; records read paths in `after_toolcall`,
+blocks writes to unread paths in `before_toolcall`. Injected by `AgentBuilder`.
+This respects the `interfaces → capabilities → core` import direction, and is
+the motivating proof that `before_toolcall` must run *before* dispatch.
 
 ## Alternatives Considered
 
@@ -148,23 +146,29 @@ writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
   and the intent legible ("rule = formal check").
 - **Leave the guard inline, add rules alongside.** Rejected: two parallel
   mechanisms doing the same thing in the same loop branch.
-- **Whole-iteration verdict only (no per-call granularity).** Rejected: the
-  read-before-write use case must block one call while dispatching siblings.
+- **A single post-dispatch `observe`/`after_toolcall` (no before-hook).**
+  Rejected: it runs after the call executed, so it cannot stop a side-effecting
+  call (write/edit/delete) from happening — it can only rewrite what the model
+  is told. Blocking such calls is the whole point of read-before-write, so a
+  pre-dispatch `before_toolcall` is required.
+- **`RuleOutcome`/`RuleViolation` value types + batch `check`.** Dropped in favor
+  of per-call methods returning `str | None`: simpler, and the per-call shape
+  matches how rules actually reason (about one call at a time).
 
 ## Test Plan
 
 - Unit tests (new `test/test_loop_rules.py`):
-  - A toy `Rule` blocks one call in a 2-call batch → blocked call gets the
-    synthetic message, sibling dispatches, loop continues.
+  - `before_toolcall` blocks one call in a 2-call batch → blocked call gets the
+    rule's text, sibling dispatches, loop continues.
+  - `after_toolcall` rewrites a dispatched call's result (tool still runs).
   - A fully-blocked iteration still emits one tool_result per call and the run
     continues (no halt) until the model itself stops.
-  - `on_run_start` resets state across two `run()` calls.
-  - `observe` receives only the dispatched `(ToolCall, ToolResult)` pairs.
-  - Multiple rules blocking the same call → feedback joined deterministically.
-- Migrated coverage: `test/test_repeat_tool_call_circuit_breaker.py` updated to
-  drive `RepeatedToolCallRule` (signature normalization, intercept at threshold,
-  reset on changed args, disabled at `<= 0`, and sustained repeats keep being
-  intercepted without halting).
+  - `after_toolcall` sees only dispatched calls, not blocked ones.
+  - Multiple rules blocking the same call → text joined deterministically.
+- Migrated coverage: `test/test_repeat_tool_call_circuit_breaker.py` drives
+  `RepeatedToolCallRule` (per-call signature normalization, intercept at
+  threshold, reset on changed args, disabled at `<= 0`, sustained repeats keep
+  being intercepted without halting).
 - Targeted: `./scripts/dev.sh test -q test/test_loop_rules.py
   test/test_repeat_tool_call_circuit_breaker.py test/test_parallel_tools.py
   test/test_ralph_loop.py`.
@@ -178,8 +182,8 @@ writes to unread paths in `check`. Injected by `AgentBuilder`. This respects the
   external callers (only `Agent` itself and its tests).
 - Behavior change: the repeated-call hard stop is gone (see Proposed Behavior).
 - Migration steps: none for callers. Internally, `_apply_repeated_tool_call_guard`
-  and `_RepeatGuardOutcome` are removed; `_tool_call_iter_signature` moves into
-  `rules.py`.
+  and `_RepeatGuardOutcome` are removed; the per-call `_tool_call_signature`
+  helper lives in `rules.py`.
 
 ## Risks & Mitigations
 

--- a/test/test_loop_rules.py
+++ b/test/test_loop_rules.py
@@ -1,0 +1,243 @@
+"""Tests for the pluggable loop Rule abstraction (ouro.core.loop.rules).
+
+Covers the generic seam — per-call blocking, halting, per-run reset, and the
+post-dispatch ``observe`` hook — independent of the repeated-tool-call rule
+(which keeps its dedicated regression suite in
+``test_repeat_tool_call_circuit_breaker.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouro.capabilities.tools.base import BaseTool
+from ouro.capabilities.tools.executor import ToolExecutor
+from ouro.core.llm import LLMResponse, StopReason, ToolCall, ToolResult
+from ouro.core.loop import Agent, NullProgressSink
+from ouro.core.loop.rules import RuleOutcome, RuleViolation
+
+
+class _NoopTool(BaseTool):
+    readonly = True
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self.invocations: int = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "stub"
+
+    @property
+    def parameters(self):
+        return {}
+
+    async def execute(self, **kwargs) -> str:
+        self.invocations += 1
+        return f"{self._name}-result"
+
+
+class _ScriptedLLM:
+    model = "stub-model"
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def call_async(self, **kwargs) -> LLMResponse:
+        self.calls += 1
+        if self._responses:
+            return self._responses.pop(0)
+        return LLMResponse(content="done", stop_reason=StopReason.STOP)
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]:
+        return list(response.tool_calls or [])
+
+
+def _tool_calls_response(*calls: tuple[str, str, dict]) -> LLMResponse:
+    return LLMResponse(
+        content=None,
+        stop_reason=StopReason.TOOL_CALLS,
+        tool_calls=[ToolCall(id=cid, name=name, arguments=args) for cid, name, args in calls],
+    )
+
+
+class _BlockToolRule:
+    """Blocks any call to a named tool with fixed feedback; never halts."""
+
+    name = "block-tool"
+
+    def __init__(self, tool_name: str, message: str) -> None:
+        self._tool_name = tool_name
+        self._message = message
+        self.run_starts = 0
+        self.observed: list[tuple[str, str]] = []
+
+    def on_run_start(self) -> None:
+        self.run_starts += 1
+
+    def check(self, ctx, tool_calls: list[ToolCall]) -> RuleOutcome:
+        violations = tuple(
+            RuleViolation(tc.id, self._message) for tc in tool_calls if tc.name == self._tool_name
+        )
+        return RuleOutcome(violations=violations)
+
+    def observe(self, ctx, executed: list[tuple[ToolCall, ToolResult]]) -> None:
+        self.observed.extend((tc.name, tr.content) for tc, tr in executed)
+
+
+@pytest.mark.asyncio
+async def test_rule_blocks_one_call_and_dispatches_sibling():
+    """A per-call violation blocks just that call; the sibling still runs."""
+    read_tool = _NoopTool("read_file")
+    write_tool = _NoopTool("write_file")
+    llm = _ScriptedLLM(
+        [
+            _tool_calls_response(
+                ("c1", "write_file", {"file_path": "/x"}),
+                ("c2", "read_file", {"file_path": "/y"}),
+            ),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    rule = _BlockToolRule("write_file", "[test] read it before writing")
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([read_tool, write_tool]),
+        progress=NullProgressSink(),
+        rules=[rule],
+    )
+
+    answer = await agent.run("test")
+
+    assert answer == "ok"
+    assert write_tool.invocations == 0  # blocked
+    assert read_tool.invocations == 1  # dispatched
+    # observe only sees the dispatched call, not the blocked one.
+    assert rule.observed == [("read_file", "read_file-result")]
+
+
+@pytest.mark.asyncio
+async def test_blocked_call_feedback_reaches_history_in_order():
+    """Blocked call gets a synthetic tool_result; ordering follows tool_calls."""
+    read_tool = _NoopTool("read_file")
+    write_tool = _NoopTool("write_file")
+    llm = _ScriptedLLM(
+        [
+            _tool_calls_response(
+                ("c1", "write_file", {"file_path": "/x"}),
+                ("c2", "read_file", {"file_path": "/y"}),
+            ),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([read_tool, write_tool]),
+        progress=NullProgressSink(),
+        rules=[_BlockToolRule("write_file", "[test] blocked")],
+    )
+    ctx = None  # use default transient context
+
+    from ouro.core.loop import MessageListContext
+
+    ctx = MessageListContext()
+    await agent.run("test", context=ctx)
+
+    tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
+    assert [m.tool_call_id for m in tool_msgs] == ["c1", "c2"]
+    assert tool_msgs[0].content == "[test] blocked"
+    assert tool_msgs[1].content == "read_file-result"
+
+
+class _HaltRule:
+    name = "halt"
+
+    def on_run_start(self) -> None:
+        pass
+
+    def check(self, ctx, tool_calls: list[ToolCall]) -> RuleOutcome:
+        return RuleOutcome(
+            violations=tuple(RuleViolation(tc.id, "[test] stop") for tc in tool_calls),
+            halt=True,
+            halt_message="[test] halted by rule",
+        )
+
+    def observe(self, ctx, executed) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_halting_rule_returns_halt_message_and_emits_results():
+    read_tool = _NoopTool("read_file")
+    llm = _ScriptedLLM([_tool_calls_response(("c1", "read_file", {"file_path": "/x"}))])
+    from ouro.core.loop import MessageListContext
+
+    ctx = MessageListContext()
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([read_tool]),
+        progress=NullProgressSink(),
+        rules=[_HaltRule()],
+    )
+
+    answer = await agent.run("test", context=ctx)
+
+    assert answer == "[test] halted by rule"
+    assert read_tool.invocations == 0  # halted before dispatch
+    # The single tool_call still gets a tool_result (API requirement).
+    tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
+    assert [m.tool_call_id for m in tool_msgs] == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_on_run_start_resets_between_runs():
+    """Rule lifecycle reset fires once per Agent.run()."""
+    tool = _NoopTool("read_file")
+    rule = _BlockToolRule("write_file", "[test] x")
+
+    def _fresh_llm():
+        return _ScriptedLLM([LLMResponse(content="ok", stop_reason=StopReason.STOP)])
+
+    agent = Agent(llm=_fresh_llm(), tools=ToolExecutor([tool]), rules=[rule])
+    await agent.run("first")
+    agent.llm = _fresh_llm()
+    await agent.run("second")
+
+    assert rule.run_starts == 2
+
+
+@pytest.mark.asyncio
+async def test_multiple_rules_blocking_same_call_join_feedback():
+    write_tool = _NoopTool("write_file")
+    from ouro.core.loop import MessageListContext
+
+    ctx = MessageListContext()
+    llm = _ScriptedLLM(
+        [
+            _tool_calls_response(("c1", "write_file", {"file_path": "/x"})),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([write_tool]),
+        progress=NullProgressSink(),
+        rules=[
+            _BlockToolRule("write_file", "[rule-a] first"),
+            _BlockToolRule("write_file", "[rule-b] second"),
+        ],
+    )
+
+    await agent.run("test", context=ctx)
+
+    tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
+    assert tool_msgs[0].content == "[rule-a] first\n[rule-b] second"
+    assert write_tool.invocations == 0

--- a/test/test_loop_rules.py
+++ b/test/test_loop_rules.py
@@ -1,9 +1,9 @@
-"""Tests for the pluggable loop Rule abstraction (ouro.core.loop.rules).
+"""Tests for the per-tool-call Rule abstraction (ouro.core.loop.rules).
 
-Covers the generic seam — per-call blocking, halting, per-run reset, and the
-post-dispatch ``observe`` hook — independent of the repeated-tool-call rule
-(which keeps its dedicated regression suite in
-``test_repeat_tool_call_circuit_breaker.py``).
+Covers the generic seam — ``before_toolcall`` blocking a call before dispatch,
+``after_toolcall`` rewriting a dispatched call's result, both being optional,
+and per-call granularity — independent of the repeated-tool-call rule (which
+keeps its dedicated suite in ``test_repeat_tool_call_circuit_breaker.py``).
 """
 
 from __future__ import annotations
@@ -13,8 +13,7 @@ import pytest
 from ouro.capabilities.tools.base import BaseTool
 from ouro.capabilities.tools.executor import ToolExecutor
 from ouro.core.llm import LLMResponse, StopReason, ToolCall, ToolResult
-from ouro.core.loop import Agent, NullProgressSink
-from ouro.core.loop.rules import RuleOutcome, RuleViolation
+from ouro.core.loop import Agent, MessageListContext, NullProgressSink
 
 
 class _NoopTool(BaseTool):
@@ -70,32 +69,26 @@ def _tool_calls_response(*calls: tuple[str, str, dict]) -> LLMResponse:
 
 
 class _BlockToolRule:
-    """Blocks any call to a named tool with fixed feedback; never halts."""
+    """before-only rule: blocks any call to a named tool, records the rest."""
 
     name = "block-tool"
 
     def __init__(self, tool_name: str, message: str) -> None:
         self._tool_name = tool_name
         self._message = message
-        self.run_starts = 0
-        self.observed: list[tuple[str, str]] = []
+        self.seen_after: list[tuple[str, str]] = []
 
-    def on_run_start(self) -> None:
-        self.run_starts += 1
+    def before_toolcall(self, ctx, tool_call: ToolCall) -> str | None:
+        return self._message if tool_call.name == self._tool_name else None
 
-    def check(self, ctx, tool_calls: list[ToolCall]) -> RuleOutcome:
-        violations = tuple(
-            RuleViolation(tc.id, self._message) for tc in tool_calls if tc.name == self._tool_name
-        )
-        return RuleOutcome(violations=violations)
-
-    def observe(self, ctx, executed: list[tuple[ToolCall, ToolResult]]) -> None:
-        self.observed.extend((tc.name, tr.content) for tc, tr in executed)
+    def after_toolcall(self, ctx, tool_call: ToolCall, tool_result: ToolResult) -> str | None:
+        # Record dispatched results (blocked calls never reach here); leave them.
+        self.seen_after.append((tool_call.name, tool_result.content))
+        return None
 
 
 @pytest.mark.asyncio
-async def test_rule_blocks_one_call_and_dispatches_sibling():
-    """A per-call violation blocks just that call; the sibling still runs."""
+async def test_before_blocks_one_call_and_dispatches_sibling():
     read_tool = _NoopTool("read_file")
     write_tool = _NoopTool("write_file")
     llm = _ScriptedLLM(
@@ -118,17 +111,17 @@ async def test_rule_blocks_one_call_and_dispatches_sibling():
     answer = await agent.run("test")
 
     assert answer == "ok"
-    assert write_tool.invocations == 0  # blocked
-    assert read_tool.invocations == 1  # dispatched
-    # observe only sees the dispatched call, not the blocked one.
-    assert rule.observed == [("read_file", "read_file-result")]
+    assert write_tool.invocations == 0  # blocked before dispatch
+    assert read_tool.invocations == 1  # sibling dispatched
+    # after_toolcall only sees the dispatched call, not the blocked one.
+    assert rule.seen_after == [("read_file", "read_file-result")]
 
 
 @pytest.mark.asyncio
 async def test_blocked_call_feedback_reaches_history_in_order():
-    """Blocked call gets a synthetic tool_result; ordering follows tool_calls."""
     read_tool = _NoopTool("read_file")
     write_tool = _NoopTool("write_file")
+    ctx = MessageListContext()
     llm = _ScriptedLLM(
         [
             _tool_calls_response(
@@ -144,11 +137,7 @@ async def test_blocked_call_feedback_reaches_history_in_order():
         progress=NullProgressSink(),
         rules=[_BlockToolRule("write_file", "[test] blocked")],
     )
-    ctx = None  # use default transient context
 
-    from ouro.core.loop import MessageListContext
-
-    ctx = MessageListContext()
     await agent.run("test", context=ctx)
 
     tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
@@ -157,27 +146,54 @@ async def test_blocked_call_feedback_reaches_history_in_order():
     assert tool_msgs[1].content == "read_file-result"
 
 
-class _BlockAllRule:
-    """Blocks every proposed call — proves a fully-blocked iteration still
-    yields one tool_result per call and the loop continues (never halts)."""
+class _RewriteRule:
+    """after-only rule: rewrites a named tool's result text."""
 
+    name = "rewrite"
+
+    def __init__(self, tool_name: str, replacement: str) -> None:
+        self._tool_name = tool_name
+        self._replacement = replacement
+
+    def after_toolcall(self, ctx, tool_call: ToolCall, tool_result: ToolResult) -> str | None:
+        return self._replacement if tool_call.name == self._tool_name else None
+
+
+@pytest.mark.asyncio
+async def test_after_rewrites_dispatched_result():
+    """after_toolcall replaces a real result; the tool still runs."""
+    read_tool = _NoopTool("read_file")
+    ctx = MessageListContext()
+    llm = _ScriptedLLM(
+        [
+            _tool_calls_response(("c1", "read_file", {"file_path": "/x"})),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([read_tool]),
+        progress=NullProgressSink(),
+        rules=[_RewriteRule("read_file", "[test] rewritten")],
+    )
+
+    await agent.run("test", context=ctx)
+
+    assert read_tool.invocations == 1  # rewrite happens after real dispatch
+    tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
+    assert tool_msgs[0].content == "[test] rewritten"
+
+
+class _BlockAllRule:
     name = "block-all"
 
-    def on_run_start(self) -> None:
-        pass
-
-    def check(self, ctx, tool_calls: list[ToolCall]) -> RuleOutcome:
-        return RuleOutcome(tuple(RuleViolation(tc.id, "[test] blocked") for tc in tool_calls))
-
-    def observe(self, ctx, executed) -> None:
-        pass
+    def before_toolcall(self, ctx, tool_call: ToolCall) -> str | None:
+        return "[test] blocked"
 
 
 @pytest.mark.asyncio
 async def test_fully_blocked_iteration_continues_without_dispatch():
     read_tool = _NoopTool("read_file")
-    from ouro.core.loop import MessageListContext
-
     ctx = MessageListContext()
     llm = _ScriptedLLM(
         [
@@ -194,8 +210,8 @@ async def test_fully_blocked_iteration_continues_without_dispatch():
 
     answer = await agent.run("test", context=ctx)
 
-    # The rule blocks the only call, but the run continues to the next turn
-    # (no halt) and ends when the model itself stops.
+    # The only call is blocked, but the run continues (no halt) and ends when
+    # the model itself stops.
     assert answer == "ok"
     assert read_tool.invocations == 0
     tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
@@ -204,27 +220,8 @@ async def test_fully_blocked_iteration_continues_without_dispatch():
 
 
 @pytest.mark.asyncio
-async def test_on_run_start_resets_between_runs():
-    """Rule lifecycle reset fires once per Agent.run()."""
-    tool = _NoopTool("read_file")
-    rule = _BlockToolRule("write_file", "[test] x")
-
-    def _fresh_llm():
-        return _ScriptedLLM([LLMResponse(content="ok", stop_reason=StopReason.STOP)])
-
-    agent = Agent(llm=_fresh_llm(), tools=ToolExecutor([tool]), rules=[rule])
-    await agent.run("first")
-    agent.llm = _fresh_llm()
-    await agent.run("second")
-
-    assert rule.run_starts == 2
-
-
-@pytest.mark.asyncio
 async def test_multiple_rules_blocking_same_call_join_feedback():
     write_tool = _NoopTool("write_file")
-    from ouro.core.loop import MessageListContext
-
     ctx = MessageListContext()
     llm = _ScriptedLLM(
         [

--- a/test/test_loop_rules.py
+++ b/test/test_loop_rules.py
@@ -157,44 +157,50 @@ async def test_blocked_call_feedback_reaches_history_in_order():
     assert tool_msgs[1].content == "read_file-result"
 
 
-class _HaltRule:
-    name = "halt"
+class _BlockAllRule:
+    """Blocks every proposed call — proves a fully-blocked iteration still
+    yields one tool_result per call and the loop continues (never halts)."""
+
+    name = "block-all"
 
     def on_run_start(self) -> None:
         pass
 
     def check(self, ctx, tool_calls: list[ToolCall]) -> RuleOutcome:
-        return RuleOutcome(
-            violations=tuple(RuleViolation(tc.id, "[test] stop") for tc in tool_calls),
-            halt=True,
-            halt_message="[test] halted by rule",
-        )
+        return RuleOutcome(tuple(RuleViolation(tc.id, "[test] blocked") for tc in tool_calls))
 
     def observe(self, ctx, executed) -> None:
         pass
 
 
 @pytest.mark.asyncio
-async def test_halting_rule_returns_halt_message_and_emits_results():
+async def test_fully_blocked_iteration_continues_without_dispatch():
     read_tool = _NoopTool("read_file")
-    llm = _ScriptedLLM([_tool_calls_response(("c1", "read_file", {"file_path": "/x"}))])
     from ouro.core.loop import MessageListContext
 
     ctx = MessageListContext()
+    llm = _ScriptedLLM(
+        [
+            _tool_calls_response(("c1", "read_file", {"file_path": "/x"})),
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
     agent = Agent(
         llm=llm,
         tools=ToolExecutor([read_tool]),
         progress=NullProgressSink(),
-        rules=[_HaltRule()],
+        rules=[_BlockAllRule()],
     )
 
     answer = await agent.run("test", context=ctx)
 
-    assert answer == "[test] halted by rule"
-    assert read_tool.invocations == 0  # halted before dispatch
-    # The single tool_call still gets a tool_result (API requirement).
+    # The rule blocks the only call, but the run continues to the next turn
+    # (no halt) and ends when the model itself stops.
+    assert answer == "ok"
+    assert read_tool.invocations == 0
     tool_msgs = [m for m in ctx.detached.snapshot() if m.role == "tool"]
     assert [m.tool_call_id for m in tool_msgs] == ["c1"]
+    assert tool_msgs[0].content == "[test] blocked"
 
 
 @pytest.mark.asyncio

--- a/test/test_repeat_tool_call_circuit_breaker.py
+++ b/test/test_repeat_tool_call_circuit_breaker.py
@@ -128,11 +128,15 @@ async def test_third_identical_call_is_intercepted_with_synthetic_feedback():
 
 
 @pytest.mark.asyncio
-async def test_fifth_identical_call_hard_stops_run():
-    """At max=5, the run terminates with an explanatory final answer."""
+async def test_sustained_repeats_keep_being_intercepted_without_halting():
+    """The breaker warns every repeat past threshold but never stops the loop."""
     args = {"file_path": "/m.py", "offset": 0, "limit": 100}
     tool = _NoopTool("read_file")
-    llm = _ScriptedLLM([_tool_call_response(f"c{i}", "read_file", args) for i in range(1, 7)])
+    # 5 identical repeats, then the model finally relents and stops.
+    llm = _ScriptedLLM(
+        [_tool_call_response(f"c{i}", "read_file", args) for i in range(1, 6)]
+        + [LLMResponse(content="ok", stop_reason=StopReason.STOP)]
+    )
     agent = Agent(
         llm=llm,
         tools=ToolExecutor([tool]),
@@ -140,12 +144,12 @@ async def test_fifth_identical_call_hard_stops_run():
         progress=NullProgressSink(),
     )
     answer = await agent.run("test")
-    assert "Halted" in answer
-    assert "read_file" in answer
-    # 1st & 2nd dispatched; 3rd & 4th intercepted; 5th hard-stops.
+    # Run is not halted by the rule — it ends when the model itself stops.
+    assert answer == "ok"
+    # 1st & 2nd dispatched; 3rd..5th intercepted (replaced, not dispatched).
     assert tool.invocations == 2
-    # LLM was called 5 times before the breaker fired.
-    assert llm.calls == 5
+    # Every repeat still triggered an LLM turn; the rule never short-circuits.
+    assert llm.calls == 6
 
 
 @pytest.mark.asyncio

--- a/test/test_repeat_tool_call_circuit_breaker.py
+++ b/test/test_repeat_tool_call_circuit_breaker.py
@@ -13,7 +13,7 @@ from ouro.capabilities.tools.base import BaseTool
 from ouro.capabilities.tools.executor import ToolExecutor
 from ouro.core.llm import LLMResponse, StopReason, ToolCall
 from ouro.core.loop import Agent, NullProgressSink
-from ouro.core.loop.agent import _tool_call_iter_signature
+from ouro.core.loop.rules import _tool_call_iter_signature
 
 
 class _NoopTool(BaseTool):

--- a/test/test_repeat_tool_call_circuit_breaker.py
+++ b/test/test_repeat_tool_call_circuit_breaker.py
@@ -13,7 +13,7 @@ from ouro.capabilities.tools.base import BaseTool
 from ouro.capabilities.tools.executor import ToolExecutor
 from ouro.core.llm import LLMResponse, StopReason, ToolCall
 from ouro.core.loop import Agent, NullProgressSink
-from ouro.core.loop.rules import _tool_call_iter_signature
+from ouro.core.loop.rules import _tool_call_signature
 
 
 class _NoopTool(BaseTool):
@@ -71,20 +71,20 @@ def _tool_call_response(call_id: str, name: str, args: dict) -> LLMResponse:
 
 
 # ---------------------------------------------------------------------------
-# _tool_call_iter_signature
+# _tool_call_signature (per-call fingerprint)
 # ---------------------------------------------------------------------------
 
 
 def test_signature_normalizes_argument_key_order():
     a = ToolCall(id="1", name="read_file", arguments={"file_path": "/x", "offset": 0})
     b = ToolCall(id="2", name="read_file", arguments={"offset": 0, "file_path": "/x"})
-    assert _tool_call_iter_signature([a]) == _tool_call_iter_signature([b])
+    assert _tool_call_signature(a) == _tool_call_signature(b)
 
 
 def test_signature_differs_when_arguments_differ():
     a = ToolCall(id="1", name="read_file", arguments={"file_path": "/x"})
     b = ToolCall(id="2", name="read_file", arguments={"file_path": "/y"})
-    assert _tool_call_iter_signature([a]) != _tool_call_iter_signature([b])
+    assert _tool_call_signature(a) != _tool_call_signature(b)
 
 
 def test_signature_handles_non_json_safe_arguments():
@@ -94,7 +94,7 @@ def test_signature_handles_non_json_safe_arguments():
             return "<weird>"
 
     tc = ToolCall(id="1", name="x", arguments={"v": Weird()})
-    assert _tool_call_iter_signature([tc])  # smoke test: doesn't raise
+    assert _tool_call_signature(tc)  # smoke test: doesn't raise
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generalize the hard-coded repeated-tool-call guard in the core agent loop into a first-class **Rule** abstraction: deterministic, **per-tool-call** checks the loop runs around each call. A rule defines either or both of two optional hooks:

- `before_toolcall(ctx, tool_call) -> str | None` — runs before dispatch; return text to **block** the call (it is skipped and the text becomes its `tool_result`), or `None` to let it run. The only way to stop a side-effecting call (write/edit/delete) before it happens.
- `after_toolcall(ctx, tool_call, tool_result) -> str | None` — runs after a dispatched call; return text to **replace** its result, or `None` to leave it. Also where stateful rules record from real results.

A rule never stops the loop; it only blocks or rewrites individual results. Trades a probabilistic LLM mistake for a deterministic guarantee.

RFC: `rfc/loop-rules.md`. Scope: RFC + core abstraction + migrate the existing guard. The first tool-aware rule (read-before-write) is a deliberate follow-up.

## Scope

- Goals:
  - First-class `Rule` extension point in `ouro.core.loop` (distinct from `Hook`).
  - Block-before-dispatch so side-effecting calls can be stopped before they run.
  - Result rewrite / state capture after dispatch.
  - Per-call granularity (act on one call in a batch while siblings dispatch).
  - Migrate the repeated-tool-call guard onto it.
- Non-goals:
  - Implementing read-before-write (follow-up; lives in `capabilities`).
  - User-facing config to toggle rules; any change to the `Hook` lifecycle.

## Intentional behavior change

The repeated-tool-call breaker's **hard stop is removed**. A rule can only block/rewrite results, so repeating an identical call on consecutive turns past `repeat_tool_call_threshold` keeps the call blocked with a "stop repeating" warning every turn (soft intercept) but no longer terminates the run. Rationale: the warning is expected to redirect the model; `max_iterations` is the runaway backstop; stopping the loop is the loop's concern, not a rule's. `repeat_tool_call_max` is removed (no external callers); `repeat_tool_call_threshold` is preserved (`<= 0` disables).

## Invariants (Must Not Regress)

- [x] Every `tool_call` gets exactly one `tool_result` (blocked text or real/rewritten output), in the model's original order.
- [x] Repeated-call soft intercept at `threshold` keeps its semantics, including disabled-by-`<= 0`.
- [x] Assistant tool-call message persisted before any tool_result.
- [x] Parallel/sequential dispatch batching unchanged for non-blocked calls.
- [x] Loop stays free of tool-name knowledge (importlint: 3 kept, 0 broken).
- [x] A rule cannot terminate the run; only the loop (STOP / LENGTH / `max_iterations`) ends it.

## Acceptance Criteria

- [x] `Rule` protocol (requires `name`; both hooks optional) + `RepeatedToolCallRule` in `ouro/core/loop/rules.py`.
- [x] `before_toolcall` blocks before dispatch; `after_toolcall` rewrites after.
- [x] `Agent(rules=...)` arg + `add_rule()`.
- [x] Per-call: block one call while siblings dispatch; `after_toolcall` sees only dispatched calls.

## Test Plan

- [x] `test/test_loop_rules.py` (before-block + sibling dispatch, after-rewrite, fully-blocked iteration continues without halt, after sees only dispatched, multi-rule feedback join).
- [x] `test/test_repeat_tool_call_circuit_breaker.py` (per-call signature normalization, intercept at threshold, reset on changed args, disabled at `<= 0`, sustained repeats keep intercepting without halting).
- [x] `./scripts/dev.sh check` — invariants OK, importlint 3 kept / 0 broken, typecheck clean, 619 passed / 1 skipped.

## Smoke Run (Real CLI)

- [ ] Skipped: loop is exercised end-to-end by the scripted-LLM tests above; the only behavior change (no hard stop) is directly asserted. A live-LLM smoke adds little and incurs cost.

## Adversarial Review (Answer Briefly)

- **What could break?** tool_result ordering vs tool_calls; the soft-intercept threshold/text/disabled path; the per-call repeat counter; multi-rule aggregation; the removed hard stop. All covered by tests.
- **Worst-case size?** Rules run per call on one iteration; no new unbounded growth. With the hard stop gone, a model that ignores the warning repeats until `max_iterations` — bounded, and the documented trade-off.
- **Secrets/logging?** No secrets. `RepeatedToolCallRule` logs tool *names* + counts only.
- **Async/blocking I/O?** None added. `before_toolcall`/`after_toolcall` are sync, deterministic, no I/O; dispatch path unchanged.
- **Error on failure?** Blocked calls return actionable feedback ("stop repeating…" / future rule messages).

## Docs / Compatibility

- [x] Updated `rfc/loop-rules.md` (+ index), `ouro/core/CLAUDE.md`, `ouro/core/README.md`.
- [x] `repeat_tool_call_threshold` preserved; `repeat_tool_call_max` removed (internal only).
- [x] No secrets / generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
