### PR TITLE
feat(rules): ReadBeforeWriteRule — block blind overwrites of unread files

### DIFF
--- a/ouro/capabilities/CLAUDE.md
+++ b/ouro/capabilities/CLAUDE.md
@@ -20,6 +20,11 @@ the injected `ProgressSink` Protocol from `ouro.core.loop`.
 - `skills/` — registry, parser, render, installer, bundled system data.
 - `verification/` — `Verifier` Protocol + `LLMVerifier` +
   `VerificationHook` (Ralph-style outer loop).
+- `rules/` — tool-aware loop rules implementing the core `Rule`
+  per-tool-call contract (e.g. `ReadBeforeWriteRule`). Unlike the generic
+  rules in `ouro.core.loop.rules`, these know specific tool names, so they
+  live here. Wired by `AgentBuilder` (`ReadBeforeWriteRule` is on by
+  default; `.without_read_before_write()` / `.with_rule(...)` to change).
 - `todo/`, `context/`, `prompts/` — small leaf utilities.
 - `builder.py` — `AgentBuilder` (fluent construction) +
   `ComposedAgent` (core.Agent + convenience proxies).

--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -31,12 +31,14 @@ from ouro.core.loop import (
     MessageListContext,
     NullProgressSink,
     ProgressSink,
+    Rule,
 )
 
 from .compaction.hook import CompactionHook
 from .context.env import format_context_prompt
 from .memory.manager import MemoryManager
 from .prompts import DEFAULT_SYSTEM_PROMPT
+from .rules import ReadBeforeWriteRule
 from .skills.registry import SkillsRegistry
 from .skills.render import render_skills_section
 from .todo.state import TodoList
@@ -91,6 +93,10 @@ class AgentBuilder:
     verification_max_iterations: int = 0  # 0 disables verification
     progress: ProgressSink = field(default_factory=NullProgressSink)
     extra_hooks: list[Hook] = field(default_factory=list)
+    # Deterministic per-tool-call rules. ReadBeforeWriteRule is on by default;
+    # `extra_rules` run after it. See `ouro.capabilities.rules`.
+    read_before_write: bool = True
+    extra_rules: list[Rule] = field(default_factory=list)
 
     # ---- LLM ----------------------------------------------------------------
 
@@ -168,6 +174,16 @@ class AgentBuilder:
         self.extra_hooks.append(hook)
         return self
 
+    # ---- Rules --------------------------------------------------------------
+
+    def with_rule(self, rule: Rule) -> AgentBuilder:
+        self.extra_rules.append(rule)
+        return self
+
+    def without_read_before_write(self) -> AgentBuilder:
+        self.read_before_write = False
+        return self
+
     # ---- Build --------------------------------------------------------------
 
     def build(self) -> ComposedAgent:
@@ -211,6 +227,13 @@ class AgentBuilder:
         # Caller-provided extras run after first-party hooks.
         hooks.extend(self.extra_hooks)
 
+        # Deterministic per-tool-call rules (the repeat breaker is added by the
+        # core Agent itself). ReadBeforeWriteRule is on by default.
+        rules: list[Rule] = []
+        if self.read_before_write:
+            rules.append(ReadBeforeWriteRule())
+        rules.extend(self.extra_rules)
+
         core = Agent(
             llm=self.llm,
             tools=tool_executor,
@@ -218,6 +241,7 @@ class AgentBuilder:
             max_iterations=self.max_iterations,
             progress=self.progress,
             usage_callback=(memory.token_tracker.record_usage if memory is not None else None),
+            rules=rules,
         )
 
         return ComposedAgent(

--- a/ouro/capabilities/rules/__init__.py
+++ b/ouro/capabilities/rules/__init__.py
@@ -1,0 +1,10 @@
+"""Tool-aware loop rules (capabilities layer).
+
+These implement the core ``ouro.core.loop.Rule`` per-tool-call contract but, unlike
+the generic rules in ``ouro.core.loop.rules``, they know about specific tool names
+and argument shapes — so they live here, above the core boundary.
+"""
+
+from .read_before_write import ReadBeforeWriteRule
+
+__all__ = ["ReadBeforeWriteRule"]

--- a/ouro/capabilities/rules/read_before_write.py
+++ b/ouro/capabilities/rules/read_before_write.py
@@ -1,0 +1,104 @@
+"""ReadBeforeWriteRule — block blind overwrites of files the agent hasn't read.
+
+A tool-aware loop rule (implements the core ``Rule`` contract). It guards
+against the model issuing ``write_file`` / ``smart_edit`` on an *existing* file
+it never looked at this session — a common way to clobber content the model is
+only guessing about.
+
+- ``after_toolcall`` records the ``file_path`` of every read (``read_file``) and
+  every successful write/edit (writing a file means the agent now knows its
+  contents), keyed by absolute path.
+- ``before_toolcall`` blocks a write/edit when the target file **exists on disk**
+  but is not in the recorded set, returning a message telling the model to read
+  it first. Creating a brand-new file (path does not exist) is allowed, as is
+  re-editing a file already read or written this session.
+
+State is per-run: it self-resets when the loop hands the rule a new
+``RunStatistic`` context (a fresh object each ``Agent.run``), so reads from one
+session never authorize writes in the next.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from ouro.core.log import get_logger
+
+if TYPE_CHECKING:
+    from ouro.core.llm import ToolCall, ToolResult
+    from ouro.core.loop.protocols import LoopContext
+
+logger = get_logger(__name__)
+
+# Tools that mutate the file at their ``file_path`` argument.
+_DEFAULT_WRITE_TOOLS = frozenset({"write_file", "smart_edit"})
+# Tools that read a specific file at their ``file_path`` argument.
+_DEFAULT_READ_TOOLS = frozenset({"read_file"})
+
+
+class ReadBeforeWriteRule:
+    """Require a file to be read before it is overwritten/edited (see module doc)."""
+
+    name = "read_before_write"
+
+    def __init__(
+        self,
+        *,
+        write_tools: frozenset[str] = _DEFAULT_WRITE_TOOLS,
+        read_tools: frozenset[str] = _DEFAULT_READ_TOOLS,
+    ) -> None:
+        self._write_tools = write_tools
+        self._read_tools = read_tools
+        # Absolute paths the agent has read or written *this run*.
+        self._seen: set[str] = set()
+        # Identity of the run context last observed; a new one means a new run.
+        self._last_ctx: object | None = None
+
+    def _reset_on_new_run(self, ctx: LoopContext) -> None:
+        # ``RunStatistic`` is constructed fresh per ``Agent.run``; a different
+        # object identity is the reliable signal that a new run has started.
+        if ctx is not self._last_ctx:
+            self._seen.clear()
+            self._last_ctx = ctx
+
+    @staticmethod
+    def _abs_path(tool_call: ToolCall) -> str | None:
+        raw = tool_call.arguments.get("file_path")
+        if not isinstance(raw, str) or not raw:
+            return None
+        return os.path.abspath(raw)
+
+    def before_toolcall(self, ctx: LoopContext, tool_call: ToolCall) -> str | None:
+        self._reset_on_new_run(ctx)
+        if tool_call.name not in self._write_tools:
+            return None
+        path = self._abs_path(tool_call)
+        if path is None or path in self._seen:
+            return None
+        # Creating a new file is fine; only guard overwrites of existing content.
+        if not os.path.exists(path):
+            return None
+        logger.warning(
+            "ReadBeforeWriteRule: blocked %s on unread existing file %r",
+            tool_call.name,
+            tool_call.arguments.get("file_path"),
+        )
+        return (
+            f"[ouro] Refusing to run {tool_call.name} on "
+            f"{tool_call.arguments.get('file_path')!r}: it exists but you have not "
+            "read it this session, so an edit would be based on guessed contents. "
+            "Call read_file on it first, then retry your change."
+        )
+
+    def after_toolcall(
+        self, ctx: LoopContext, tool_call: ToolCall, tool_result: ToolResult
+    ) -> str | None:
+        # A read makes a file known; a dispatched write/edit means we now know
+        # its post-write contents. Either way, record it. Never rewrites results.
+        self._reset_on_new_run(ctx)
+        if tool_call.name in self._read_tools or tool_call.name in self._write_tools:
+            path = self._abs_path(tool_call)
+            if path is not None:
+                self._seen.add(path)
+        return None

--- a/ouro/core/CLAUDE.md
+++ b/ouro/core/CLAUDE.md
@@ -20,9 +20,9 @@ Never imports `ouro.capabilities` or `ouro.interfaces`.
 - `loop/protocols.py` — structural Protocols capabilities implement:
   `Hook`, `ToolRegistry`, `ProgressSink`, `LoopContext`. Plus the
   `ContinueDecision` return type used by `on_iteration_end`.
-- `loop/rules.py` — `Rule` protocol + `RuleOutcome` / `RuleViolation`
-  and the generic `RepeatedToolCallRule`. Rules are deterministic
-  pre-dispatch guards; see "Rules" below.
+- `loop/rules.py` — `Rule` protocol (optional `before_toolcall` /
+  `after_toolcall`) + the generic `RepeatedToolCallRule`. Rules are
+  deterministic per-tool-call checks; see "Rules" below.
 - `llm/` — `LLMMessage`, `LLMResponse`, `ToolCall`, `ToolResult`,
   `LiteLLMAdapter`, `ModelManager`, content/compat/reasoning helpers,
   OAuth (chatgpt, copilot).

--- a/ouro/core/loop/rules.py
+++ b/ouro/core/loop/rules.py
@@ -19,9 +19,10 @@ Two optional hooks — a rule implements whichever it needs:
   return ``None`` to leave it unchanged. Use it to rewrite output and/or to
   record state from real results (e.g. which files were read).
 
-Both are per-tool-call and deterministic (no LLM/I/O). A rule never stops the
-loop; it only blocks or rewrites individual results. Runaway protection is the
-loop's own concern (``max_iterations``).
+Both are per-tool-call and should be cheap and side-effect-free: no LLM calls
+and no heavy or blocking I/O (a quick local check such as ``os.path.exists`` is
+fine). A rule never stops the loop; it only blocks or rewrites individual
+results. Runaway protection is the loop's own concern (``max_iterations``).
 
 ``ouro.core`` rules stay tool-agnostic — they see only ``ToolCall`` /
 ``ToolResult``. Tool-aware rules (e.g. "only modify files you've read") live in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ packages = [
     "ouro.capabilities.memory.recall",
     "ouro.capabilities.memory.store",
     "ouro.capabilities.prompts",
+    "ouro.capabilities.rules",
     "ouro.capabilities.skills",
     "ouro.capabilities.todo",
     "ouro.capabilities.tools",

--- a/rfc/loop-rules.md
+++ b/rfc/loop-rules.md
@@ -130,12 +130,14 @@ Loop integration (replaces the inline guard in the `TOOL_CALLS` branch):
 `Agent.__init__` gains `rules: Sequence[Rule] = ()`; the `RepeatedToolCallRule`
 (from `repeat_tool_call_threshold`) is always prepended, then caller rules.
 
-Tool-aware rules (follow-up): `ReadBeforeWriteRule` in
-`ouro/capabilities/rules/`, knowing the `read_file` / `write_file` / `edit`
-tool names and their `file_path` arg; records read paths in `after_toolcall`,
-blocks writes to unread paths in `before_toolcall`. Injected by `AgentBuilder`.
-This respects the `interfaces → capabilities → core` import direction, and is
-the motivating proof that `before_toolcall` must run *before* dispatch.
+Tool-aware rules: `ReadBeforeWriteRule` in `ouro/capabilities/rules/`
+(**implemented** as the follow-up to the core abstraction) knows the
+`read_file` / `write_file` / `smart_edit` tool names and their `file_path` arg;
+it records read/written paths in `after_toolcall` and, in `before_toolcall`,
+blocks `write_file`/`smart_edit` on a file that **exists** but wasn't read this
+run (creating a new file is allowed). On by default via `AgentBuilder`. This
+respects the `interfaces → capabilities → core` import direction, and is the
+motivating proof that `before_toolcall` must run *before* dispatch.
 
 ## Alternatives Considered
 

--- a/test/test_read_before_write_rule.py
+++ b/test/test_read_before_write_rule.py
@@ -1,0 +1,216 @@
+"""Tests for ReadBeforeWriteRule (ouro.capabilities.rules.read_before_write).
+
+Unit tests drive the rule's two hooks directly (the rule only uses ctx by
+identity, so a plain sentinel object stands in for the loop's RunStatistic).
+An integration test runs it through the real Agent loop, and builder tests
+confirm it ships on by default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouro.capabilities.builder import AgentBuilder
+from ouro.capabilities.rules import ReadBeforeWriteRule
+from ouro.capabilities.tools.base import BaseTool
+from ouro.capabilities.tools.executor import ToolExecutor
+from ouro.core.llm import LLMResponse, StopReason, ToolCall, ToolResult
+from ouro.core.loop import Agent, NullProgressSink
+
+
+def _tc(name: str, file_path: str, cid: str = "c1") -> ToolCall:
+    return ToolCall(id=cid, name=name, arguments={"file_path": file_path})
+
+
+def _tr(name: str, cid: str = "c1", content: str = "ok") -> ToolResult:
+    return ToolResult(tool_call_id=cid, content=content, name=name)
+
+
+# ---------------------------------------------------------------------------
+# before_toolcall (block decision)
+# ---------------------------------------------------------------------------
+
+
+def test_blocks_write_to_existing_unread_file(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    msg = rule.before_toolcall(object(), _tc("write_file", str(f)))
+    assert msg is not None
+    assert "read_file" in msg
+
+
+def test_blocks_smart_edit_to_existing_unread_file(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    assert rule.before_toolcall(object(), _tc("smart_edit", str(f))) is not None
+
+
+def test_allows_write_to_nonexistent_file(tmp_path):
+    f = tmp_path / "new.py"  # does not exist → creating a new file
+    rule = ReadBeforeWriteRule()
+    assert rule.before_toolcall(object(), _tc("write_file", str(f))) is None
+
+
+def test_allows_non_write_tools(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    assert rule.before_toolcall(object(), _tc("read_file", str(f))) is None
+    other = ToolCall(id="c", name="shell", arguments={"command": "rm -rf /"})
+    assert rule.before_toolcall(object(), other) is None
+
+
+def test_after_toolcall_never_rewrites_result(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    assert rule.after_toolcall(object(), _tc("read_file", str(f)), _tr("read_file")) is None
+
+
+# ---------------------------------------------------------------------------
+# read/write recording via after_toolcall
+# ---------------------------------------------------------------------------
+
+
+def test_allows_write_after_read(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    ctx = object()
+    rule.after_toolcall(ctx, _tc("read_file", str(f)), _tr("read_file"))
+    assert rule.before_toolcall(ctx, _tc("write_file", str(f))) is None
+
+
+def test_allows_edit_after_prior_write(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    ctx = object()
+    # Writing a file means the agent now knows its contents → later edit is fine.
+    rule.after_toolcall(ctx, _tc("write_file", str(f)), _tr("write_file"))
+    assert rule.before_toolcall(ctx, _tc("smart_edit", str(f))) is None
+
+
+def test_path_is_normalized(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    ctx = object()
+    # Read via a non-normalized path; write via the clean path — same file.
+    rule.after_toolcall(ctx, _tc("read_file", str(tmp_path / "." / "a.py")), _tr("read_file"))
+    assert rule.before_toolcall(ctx, _tc("write_file", str(f))) is None
+
+
+def test_seen_resets_across_runs(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("x")
+    rule = ReadBeforeWriteRule()
+    run1 = object()
+    rule.after_toolcall(run1, _tc("read_file", str(f)), _tr("read_file"))
+    assert rule.before_toolcall(run1, _tc("write_file", str(f))) is None
+    # A fresh run context clears the seen set; the stale read no longer counts.
+    run2 = object()
+    assert rule.before_toolcall(run2, _tc("write_file", str(f))) is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration through the Agent loop
+# ---------------------------------------------------------------------------
+
+
+class _StubTool(BaseTool):
+    def __init__(self, name: str, readonly: bool = False) -> None:
+        self._name = name
+        self.readonly = readonly
+        self.invocations = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "stub"
+
+    @property
+    def parameters(self):
+        return {}
+
+    async def execute(self, **kwargs) -> str:
+        self.invocations += 1
+        return f"{self._name}-ok"
+
+
+class _ScriptedLLM:
+    model = "stub-model"
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = list(responses)
+
+    async def call_async(self, **kwargs) -> LLMResponse:
+        if self._responses:
+            return self._responses.pop(0)
+        return LLMResponse(content="done", stop_reason=StopReason.STOP)
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]:
+        return list(response.tool_calls or [])
+
+
+def _call(cid: str, name: str, file_path: str) -> LLMResponse:
+    return LLMResponse(
+        content=None,
+        stop_reason=StopReason.TOOL_CALLS,
+        tool_calls=[ToolCall(id=cid, name=name, arguments={"file_path": file_path})],
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_blocks_then_allows_after_read(tmp_path):
+    f = tmp_path / "a.py"
+    f.write_text("orig")
+    read_tool = _StubTool("read_file", readonly=True)
+    write_tool = _StubTool("write_file")
+    llm = _ScriptedLLM(
+        [
+            _call("c1", "write_file", str(f)),  # blocked: existing + unread
+            _call("c2", "read_file", str(f)),  # dispatched, records the path
+            _call("c3", "write_file", str(f)),  # now allowed
+            LLMResponse(content="ok", stop_reason=StopReason.STOP),
+        ]
+    )
+    agent = Agent(
+        llm=llm,
+        tools=ToolExecutor([read_tool, write_tool]),
+        progress=NullProgressSink(),
+        rules=[ReadBeforeWriteRule()],
+    )
+
+    answer = await agent.run("test")
+
+    assert answer == "ok"
+    assert read_tool.invocations == 1
+    assert write_tool.invocations == 1  # first write blocked, second ran
+
+
+# ---------------------------------------------------------------------------
+# AgentBuilder wiring
+# ---------------------------------------------------------------------------
+
+
+def _rule_names(agent) -> list[str]:
+    return [getattr(r, "name", None) for r in agent._core.rules]
+
+
+def test_builder_adds_read_before_write_by_default():
+    agent = AgentBuilder(llm=object()).without_memory().build()
+    assert "read_before_write" in _rule_names(agent)
+
+
+def test_builder_can_disable_read_before_write():
+    agent = AgentBuilder(llm=object()).without_memory().without_read_before_write().build()
+    assert "read_before_write" not in _rule_names(agent)


### PR DESCRIPTION
## Summary

The first tool-aware loop **Rule**, built on the core per-tool-call `Rule` contract from #190. `ReadBeforeWriteRule` guards against the model issuing `write_file` / `smart_edit` on an **existing** file it never read this session — a common way to clobber content it is only guessing about.

- `before_toolcall` — block `write_file`/`smart_edit` when the target file **exists on disk** but wasn't read/written this run (returns a "read it first, then retry" message). Creating a brand-new file (path absent) is allowed; re-editing a file already read/written this run is allowed.
- `after_toolcall` — record `read_file` paths (and successful writes) as "seen", keyed by absolute path; never rewrites results.
- Per-run state self-resets by `RunStatistic` identity (a fresh `ctx` object per `Agent.run`), so reads from one session never authorize writes in the next — no `on_run_start` needed.

RFC: `rfc/loop-rules.md` (this is the implemented follow-up to the abstraction).

## Scope

- Goals:
  - Implement `ReadBeforeWriteRule` in a new `ouro/capabilities/rules/` subpackage.
  - Wire it into `AgentBuilder`, **on by default**, with an opt-out and a generic `with_rule()`.
  - Pass `rules=` from `AgentBuilder` to the core `Agent` (it didn't before).
- Non-goals:
  - Changing the core `Rule` mechanism (only a docstring tweak + a stale-doc fix).
  - Guarding shell/multi_task or other indirect file mutators (only `write_file`/`smart_edit`).

## Behavior

- New default behavior: agents built via `AgentBuilder` now block edits/overwrites of an existing-but-unread file. Disable with `.without_read_before_write()`.
- Decisions (confirmed): block when the file **exists** (allow new-file creation); guard `write_file` **and** `smart_edit`; **on by default**.

## Invariants (Must Not Regress)

- [x] Non-write tools and writes to read/written/new paths are never blocked.
- [x] Every `tool_call` still gets exactly one `tool_result`; blocked write isn't dispatched.
- [x] Rule is per-tool-call and side-effect-free beyond a cheap `os.path.exists`.
- [x] Layer boundary holds: rule lives in capabilities, imports only core types (importlint 3 kept / 0 broken).
- [x] `AgentBuilder` callers unaffected unless they rely on writing unread existing files.

## Acceptance Criteria

- [x] Block `write_file`/`smart_edit` on existing unread file; allow after `read_file`; allow new-file creation; allow re-edit after a prior write.
- [x] Per-run reset (stale reads don't carry across runs).
- [x] `AgentBuilder` adds it by default; `.without_read_before_write()` removes it; `.with_rule()` appends extras.

## Test Plan

- [x] `test/test_read_before_write_rule.py`: unit block/allow matrix, path normalization, per-run reset; Agent-loop integration (blocked → read → allowed); builder default-on / opt-out.
- [x] `./scripts/dev.sh check` — invariants OK (incl. new subpackage in `pyproject` packages), importlint 3 kept / 0 broken, typecheck clean, 620 passed / 1 skipped.

## Smoke Run (Real CLI)

- [ ] Skipped: the rule is exercised end-to-end through the real `Agent` loop in the integration test (block-then-allow), and the block decision is pure local logic. A live-LLM smoke adds little and incurs cost.

## Adversarial Review (Answer Briefly)

- **What could break?** A workflow that legitimately overwrites an existing file without reading it now gets blocked once (must read first) — intended; opt-out available. Path-normalization mismatches (read `./a.py` vs write `a.py`) — handled via `os.path.abspath` + a test.
- **Worst-case size?** O(files touched per run) set of absolute path strings; trivial.
- **Secrets/logging?** No secrets. Logs the blocked tool name + path at WARNING.
- **Async/blocking I/O?** One `os.path.exists` per write call in a sync method — negligible, no blocking. Core rules docstring updated to sanction a cheap local check.
- **Error on failure?** Block message is actionable: names the file and says to `read_file` it first, then retry.

## Docs / Compatibility

- [x] `ouro/capabilities/CLAUDE.md` (new `rules/` subpackage), `rfc/loop-rules.md` (marked implemented), `ouro/core/CLAUDE.md` (fixed stale `RuleOutcome`/`RuleViolation` bullet from #190).
- [x] `pyproject.toml` `[tool.setuptools] packages` includes `ouro.capabilities.rules`.
- [x] No secrets / generated artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
