### PR TITLE
feat(context): deterministic AGENTS.md auto-loading

### DIFF
--- a/docs/agents-md-guide.md
+++ b/docs/agents-md-guide.md
@@ -2,22 +2,21 @@
 
 ## Overview
 
-ouro supports project-specific instructions via AGENTS.md files. The agent will automatically look for and read these files when relevant (e.g., before modifying code, exploring a codebase, or starting complex tasks).
+ouro supports project-specific instructions via AGENTS.md files. They are auto-loaded into the system prompt at the start of every run, so the instructions apply deterministically regardless of the task.
 
 ## How It Works
 
-- **Location**: Place AGENTS.md in your project directory (or subdirectories)
-- **Discovery**: Agent uses nearest AGENTS.md (subdirectory wins over parent)
-- **Reading**: Agent reads AGENTS.md when needed (not automatically at startup)
+- **Location**: Place AGENTS.md in your project directory (or any parent directory)
+- **Discovery**: ouro walks from the working directory up to the filesystem root and collects every AGENTS.md found
+- **Loading**: All discovered files are merged and injected at startup, parent-first so the nearest AGENTS.md wins (subdirectory overrides parent)
 - **Format**: Plain markdown, no special syntax required
 
-## When Agent Reads AGENTS.md
+## What Gets Loaded
 
-The agent will look for AGENTS.md in these situations:
-- Before modifying code or making significant changes
-- Before exploring an unfamiliar codebase
-- When you mention project-specific workflows or conventions
-- At the start of complex multi-step tasks
+On every run, ouro discovers and merges AGENTS.md files from the working
+directory upward. No tool calls or LLM judgement are involved — if an
+AGENTS.md exists on the path from the CWD to `/`, its instructions are present
+in context. If none exist, nothing is injected.
 
 ## Example AGENTS.md
 
@@ -148,12 +147,11 @@ AGENTS.md is compatible with:
 - **Cursor**: Supports AGENTS.md alongside other rule systems
 - **Jules** (Google): Reads AGENTS.md automatically
 
-### ouro Difference
-Unlike other tools that auto-load AGENTS.md at startup:
-- **On-demand reading**: Agent decides when to read based on context
-- **Token-efficient**: Only loads when relevant (saves tokens on simple tasks)
-- **Flexible**: Agent adapts based on task complexity
-- **Tool-based**: Uses existing tools (no special loader needed)
+### ouro Behavior
+Like Codex CLI and Jules, ouro auto-loads AGENTS.md at startup:
+- **Deterministic**: Loaded every run, no reliance on LLM judgement
+- **Hierarchical**: Walks CWD → `/`, nearest file wins on conflict
+- **Project tier only**: No `@import` directives, size caps, or user-global tier
 
 ### Migration from Other Tools
 If you're coming from another tool, your existing AGENTS.md should work as-is. ouro will read and follow the same instructions.
@@ -233,15 +231,15 @@ cd backend
 
 ## Troubleshooting
 
-### Agent Not Reading AGENTS.md
+### AGENTS.md Not Loaded
 - Ensure file is named exactly `AGENTS.md` (case-sensitive)
-- Verify file is in project directory or parent directories
-- Try mentioning "check project instructions" in your request
+- Verify it sits in the working directory or one of its parents (the walk only goes upward, not into sibling subdirectories)
+- Empty / whitespace-only files are skipped
 
-### Agent Reading Wrong AGENTS.md
-- The agent chooses the nearest AGENTS.md to the working directory
+### Wrong AGENTS.md Taking Precedence
+- The nearest AGENTS.md to the working directory wins on conflict
 - If working in a subdirectory, ensure you want the subdirectory version
-- Use `cd` to change directories if needed
+- Use `cd` to change the working directory if needed
 
 ### Instructions Not Being Followed
 - Use emphasis: "IMPORTANT", "YOU MUST", "NEVER"

--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -34,6 +34,7 @@ from ouro.core.loop import (
 )
 
 from .compaction.hook import CompactionHook
+from .context.agents_md import load_agents_md
 from .context.env import format_context_prompt
 from .memory.manager import MemoryManager
 from .prompts import DEFAULT_SYSTEM_PROMPT
@@ -527,6 +528,12 @@ class ComposedAgent:
             system_content = system_content + "\n" + ctx
         except Exception:
             pass
+        try:
+            project_instructions = await load_agents_md()
+            if project_instructions:
+                system_content = system_content + "\n" + project_instructions
+        except Exception:
+            logger.warning("Failed to load AGENTS.md project instructions", exc_info=True)
         if self.memory.long_term:
             try:
                 async with self._progress.spinner("Loading memory...", title="Working"):

--- a/ouro/capabilities/context/agents_md.py
+++ b/ouro/capabilities/context/agents_md.py
@@ -1,0 +1,91 @@
+"""Deterministic discovery + loading of AGENTS.md project instructions.
+
+ouro auto-loads ``AGENTS.md`` files at agent startup, walking from the current
+working directory up to the filesystem root and merging every ``AGENTS.md``
+found. Files closer to the CWD are appended last so they take precedence
+(nearest wins), mirroring how Claude Code assembles project memory.
+
+Scope is intentionally minimal (see ``rfc/agents-md-autoload.md``): project-tier
+upward walk only. No ``@import`` directives, no size caps, no user/global tier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+from ouro.core.log import get_logger
+
+logger = get_logger(__name__)
+
+AGENTS_FILENAME = "AGENTS.md"
+
+
+def _discover_agents_md(start_dir: str | None = None) -> list[Path]:
+    """Collect ``AGENTS.md`` files from ``start_dir`` up to the filesystem root.
+
+    Args:
+        start_dir: Directory to start the upward walk from. Defaults to CWD.
+
+    Returns:
+        Paths ordered parent-first (root → ``start_dir``), so the nearest file
+        is last and wins on merge.
+    """
+    start = Path(start_dir or os.getcwd()).resolve()
+    found: list[Path] = []
+    for directory in (start, *start.parents):
+        candidate = directory / AGENTS_FILENAME
+        if candidate.is_file():
+            found.append(candidate)
+    found.reverse()  # parent-first, nearest last
+    return found
+
+
+def _read_and_merge(paths: list[Path]) -> str:
+    """Read each path and join non-empty contents with a per-file header."""
+    sections: list[str] = []
+    for path in paths:
+        try:
+            content = path.read_text(encoding="utf-8", errors="ignore").strip()
+        except OSError:
+            logger.warning("Failed to read %s, skipping", path, exc_info=True)
+            continue
+        if not content:
+            continue
+        sections.append(f"# {path}\n{content}")
+    return "\n\n".join(sections)
+
+
+def _format(merged: str) -> str:
+    """Wrap merged AGENTS.md content in a ``<project_instructions>`` block."""
+    if not merged:
+        return ""
+    return (
+        "<project_instructions>\n"
+        "The following project instructions were auto-loaded from AGENTS.md "
+        "files found from the working directory up to the filesystem root "
+        "(nearest last; nearest takes precedence). Treat them as project "
+        "context and follow them unless a higher-priority instruction "
+        "overrides.\n\n"
+        f"{merged}\n"
+        "</project_instructions>\n"
+    )
+
+
+async def load_agents_md(start_dir: str | None = None) -> str:
+    """Discover, merge, and format AGENTS.md project instructions.
+
+    Args:
+        start_dir: Directory to start the upward walk from. Defaults to CWD.
+
+    Returns:
+        A formatted ``<project_instructions>`` block, or ``""`` when no
+        non-empty ``AGENTS.md`` is found. File I/O runs in a worker thread to
+        keep the caller's event loop responsive.
+    """
+
+    def _work() -> str:
+        return _format(_read_and_merge(_discover_agents_md(start_dir)))
+
+    return await asyncio.to_thread(_work)

--- a/ouro/capabilities/prompts/system_prompt.py
+++ b/ouro/capabilities/prompts/system_prompt.py
@@ -33,11 +33,4 @@ When you have enough information, provide your final answer directly without usi
 - Use manage_todo_list to track progress for complex tasks
 </tool_usage_guidelines>
 
-<agents_md>
-Project instructions may be defined in AGENTS.md files in the project directory structure.
-Before modifying code, check for AGENTS.md: glob_files(pattern="AGENTS.md")
-If found, read it with read_file and follow the project-specific instructions.
-AGENTS.md is optional. If not found, proceed normally.
-</agents_md>
-
 """

--- a/rfc/agents-md-autoload.md
+++ b/rfc/agents-md-autoload.md
@@ -1,0 +1,104 @@
+# RFC: Deterministic AGENTS.md auto-loading
+
+- Status: Proposed
+- Authors: Yixin Luo
+- Date: 2026-05-24
+
+## Summary
+
+Replace ouro's on-demand AGENTS.md strategy (the LLM decides whether to
+`glob_files` + `read_file`) with deterministic auto-loading at agent startup:
+walk from the working directory up to the filesystem root, merge every
+`AGENTS.md` found (nearest wins), and inject the result into the system prompt
+as a `<project_instructions>` block. Borrows the core idea from Claude Code's
+CLAUDE.md handling, scoped down to a minimal project tier.
+
+## Problem
+
+Today the agent is only *told* to look for AGENTS.md
+(`ouro/capabilities/prompts/system_prompt.py` `<agents_md>` block). Whether the
+project instructions are ever loaded depends on the model's judgement, so the
+same project can behave differently run to run, and simple tasks silently skip
+the rules entirely. Claude Code instead loads its instruction files
+deterministically, which is what users actually expect from a project rules
+file.
+
+## Goals
+
+- Project AGENTS.md instructions are loaded every run, with no reliance on LLM
+  judgement.
+- Upward walk from CWD to `/`, collecting every `AGENTS.md`; the nearest file
+  takes precedence (appended last).
+- Merged content is injected into the system prompt next to `<environment>`.
+
+## Non-goals
+
+- No `@import` directives.
+- No size caps / truncation.
+- No user-global (`~/.ouro/AGENTS.md`) or machine-wide tier.
+- No new disable env var or exclude globs.
+- No change to how the file is injected (system prompt, not a first user
+  message).
+
+## Proposed Behavior (User-Facing)
+
+- On every agent build, ouro discovers `AGENTS.md` from the CWD upward and
+  injects them. No tool calls, no spinner gating on it.
+- Subdirectory AGENTS.md still wins over parent (nearest last in the merge).
+- If no `AGENTS.md` exists, nothing is injected (no error, no empty block).
+- The old "check for AGENTS.md with glob_files" guidance is removed from the
+  system prompt (redundant + risks double-reading).
+
+## Invariants (Must Not Regress)
+
+- System prompt assembly order stays stable: base → `<environment>` →
+  `<project_instructions>` → `<long_term_memory>` → skills → soul.
+- A run with no AGENTS.md produces no `<project_instructions>` block.
+- File-read / discovery failures never crash agent startup (logged, skipped).
+- No blocking I/O on the loop hot path (discovery runs once at startup via
+  `asyncio.to_thread`).
+
+## Design Sketch (Minimal)
+
+New leaf module `ouro/capabilities/context/agents_md.py`:
+
+- `_discover_agents_md(start_dir)` → list[Path], parent-first / nearest-last.
+- `_read_and_merge(paths)` → merged text with a `# <path>` header per file.
+- `load_agents_md(start_dir=None)` → formatted `<project_instructions>` block
+  (or `""`), file I/O wrapped in `asyncio.to_thread`.
+
+`ComposedAgent._add_system_prompt()` calls `load_agents_md()` right after
+`format_context_prompt()` and appends the block when non-empty. The
+`<agents_md>` block is deleted from `DEFAULT_SYSTEM_PROMPT`.
+
+## Alternatives Considered
+
+- Keep on-demand (status quo): non-deterministic; the reported problem.
+- First-user-message `<system-reminder>` injection (full Claude Code parity):
+  better cache locality but a larger structural change to ouro's message flow;
+  deferred.
+
+## Test Plan
+
+- Unit tests (`test/test_agents_md.py`): no file → `""`; single file; upward
+  walk merge order (nearest last); empty/whitespace file skipped; default CWD.
+- Targeted: `./scripts/dev.sh test -q test/test_agents_md.py`.
+- Smoke: `python main.py --task "what project instructions apply here?"` from a
+  dir containing an AGENTS.md.
+
+## Rollout / Migration
+
+- Backward compatible: existing AGENTS.md files keep working; they are now
+  always loaded instead of sometimes. `docs/agents-md-guide.md` updated to drop
+  the "on-demand only" framing.
+
+## Risks & Mitigations
+
+- Large/many AGENTS.md inflate the prompt: accepted for MVP (no caps); revisit
+  if it bites.
+- Symlinked AGENTS.md (this repo's own setup) resolve normally via `is_file()`
+  / `read_text`; covered implicitly.
+
+## Open Questions
+
+- Whether to add a user-global tier and a disable switch later (out of scope).

--- a/test/test_agents_md.py
+++ b/test/test_agents_md.py
@@ -1,0 +1,57 @@
+"""Tests for deterministic AGENTS.md auto-loading.
+
+Offline, no API keys. Each test scopes the upward walk to a tmp directory via
+the ``start_dir`` argument so results don't depend on the developer's machine.
+"""
+
+from ouro.capabilities.context.agents_md import _discover_agents_md, load_agents_md
+
+
+async def test_no_agents_md_returns_empty(tmp_path):
+    assert await load_agents_md(str(tmp_path)) == ""
+
+
+async def test_single_agents_md(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("Run the tests before committing.")
+    block = await load_agents_md(str(tmp_path))
+    assert "<project_instructions>" in block
+    assert "</project_instructions>" in block
+    assert "Run the tests before committing." in block
+
+
+async def test_upward_walk_merge_order_nearest_last(tmp_path):
+    child = tmp_path / "sub" / "deep"
+    child.mkdir(parents=True)
+    (tmp_path / "AGENTS.md").write_text("PARENT RULE")
+    (child / "AGENTS.md").write_text("CHILD RULE")
+
+    block = await load_agents_md(str(child))
+
+    # Both present, and the nearest (child) appears after the parent so it
+    # takes precedence in the merged prompt.
+    assert "PARENT RULE" in block
+    assert "CHILD RULE" in block
+    assert block.index("PARENT RULE") < block.index("CHILD RULE")
+
+
+async def test_empty_file_skipped(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("   \n\t  \n")
+    assert await load_agents_md(str(tmp_path)) == ""
+
+
+async def test_uses_cwd_by_default(tmp_path, monkeypatch):
+    (tmp_path / "AGENTS.md").write_text("CWD RULE")
+    monkeypatch.chdir(tmp_path)
+    block = await load_agents_md()
+    assert "CWD RULE" in block
+
+
+def test_discover_orders_parent_first(tmp_path):
+    child = tmp_path / "sub"
+    child.mkdir()
+    (tmp_path / "AGENTS.md").write_text("parent")
+    (child / "AGENTS.md").write_text("child")
+
+    found = _discover_agents_md(str(child))
+
+    assert [p.parent for p in found] == [tmp_path.resolve(), child.resolve()]


### PR DESCRIPTION
## Summary

Replaces ouro's **on-demand** AGENTS.md strategy (the LLM decides whether to `glob_files` + `read_file`) with **deterministic auto-loading at agent startup**. ouro now walks from the working directory up to the filesystem root, merges every `AGENTS.md` found (parent-first, nearest wins), and injects the result into the system prompt as a `<project_instructions>` block — next to `<environment>`.

Borrows the core idea from Claude Code's CLAUDE.md handling, scoped to a minimal project tier. Design recorded in `rfc/agents-md-autoload.md`.

## Scope

- Goals: project AGENTS.md loaded every run (no LLM judgement); upward walk CWD → `/`; nearest wins; injected into system prompt.
- Non-goals: `@import` directives, size caps/truncation, user-global (`~/.ouro/AGENTS.md`) or machine-wide tier, disable env var / exclude globs, first-user-message injection.

## Invariants (Must Not Regress)

- [x] System prompt order stays stable: base → `<environment>` → `<project_instructions>` → `<long_term_memory>` → skills → soul.
- [x] No AGENTS.md → no `<project_instructions>` block (no error, no empty block).
- [x] Discovery/read failures never crash startup (logged, skipped).
- [x] No blocking I/O on the loop hot path (discovery runs once at startup via `asyncio.to_thread`).
- [x] Layer boundaries intact (capabilities → core only).

## Acceptance Criteria

- [x] `load_agents_md()` discovers AGENTS.md from CWD upward and merges nearest-last.
- [x] On-demand `<agents_md>` guidance removed from `DEFAULT_SYSTEM_PROMPT`.
- [x] Symlinked AGENTS.md (this repo's own setup) resolves normally.

## Test Plan

- [x] Targeted: `./scripts/dev.sh test -q test/test_agents_md.py` (6 passed) — empty/missing, single file, upward-walk merge order, whitespace skip, default-CWD, discovery ordering.
- [x] `./scripts/dev.sh check` — import contracts kept (3/3), typecheck clean, 614 passed / 1 skipped.

## Smoke Run (Real CLI)

- [x] Deterministic smoke: `load_agents_md()` from repo root discovers `AGENTS.md`, follows its symlink to `CLAUDE.md`, and produces a valid `<project_instructions>` block. (Used instead of a live-LLM run to avoid API cost.)

## Adversarial Review

- **What could break?** The 5 invariants above (prompt order, empty-case, failure handling, hot-path I/O, layer boundaries).
- **Worst-case size?** Many/large AGENTS.md inflate the prompt — accepted for MVP (no caps); revisit if it bites.
- **Secrets/logging?** Only logs file paths + a warning on read failure; no file contents logged.
- **Async/blocking I/O?** File reads wrapped in `asyncio.to_thread`; runs once at startup, not in the loop.
- **Failure UX?** Read failure → warning log + skip that file; agent proceeds normally.

## Docs / Compatibility

- [x] `docs/agents-md-guide.md` updated to describe deterministic auto-load (dropped "on-demand only" framing).
- [x] No secrets / generated artifacts committed.
- Backward compatible: existing AGENTS.md files keep working; now always loaded instead of sometimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)