### PR TITLE
feat(tools): commit/PR attribution via shell tool description

### DIFF
--- a/ouro/capabilities/prompts/attribution.py
+++ b/ouro/capabilities/prompts/attribution.py
@@ -12,7 +12,7 @@ The attribution can be disabled (``ATTRIBUTION_ENABLED=false`` in
 has no template prompting it to add the trailers.
 """
 
-COMMIT_TRAILER = "Co-Authored-By: ouro <noreply@ouro-ai-labs.github.io>"
+COMMIT_TRAILER = "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
 PR_FOOTER = "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
 
 

--- a/ouro/capabilities/prompts/attribution.py
+++ b/ouro/capabilities/prompts/attribution.py
@@ -1,0 +1,64 @@
+"""Commit / PR attribution trailers for the shell tool description.
+
+ouro identifies itself as the commit co-author and PR generator so the code
+it ships stays traceable. Mirroring Claude Code's BashTool approach, the
+trailers are interpolated into the shell tool's *description* rather than
+applied via a git hook or post-processing step: the model copies the
+``<example>`` blocks when it builds ``git commit`` / ``gh pr create``
+commands, so the trailers land on every commit and PR it authors.
+
+The attribution can be disabled (``ATTRIBUTION_ENABLED=false`` in
+``~/.ouro/config``); when off, the whole section collapses out and the model
+has no template prompting it to add the trailers.
+"""
+
+COMMIT_TRAILER = "Co-Authored-By: ouro <noreply@ouro-ai-labs.github.io>"
+PR_FOOTER = "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
+
+
+def get_commit_and_pr_instructions(enabled: bool = True) -> str:
+    """Return the git-commit / PR attribution section for a tool description.
+
+    Args:
+        enabled: When False, return an empty string so the trailers (and the
+            entire section) disappear cleanly.
+
+    Returns:
+        The instruction block, or ``""`` when attribution is disabled.
+    """
+    if not enabled:
+        return ""
+
+    return f"""# Committing changes with git
+
+When you create a git commit, end the commit message with:
+
+{COMMIT_TRAILER}
+
+<example>
+git commit -m "$(cat <<'EOF'
+Commit message here.
+
+{COMMIT_TRAILER}
+EOF
+)"
+</example>
+
+# Creating pull requests
+
+When you create a pull request (e.g. with the gh CLI), end the PR body with:
+
+{PR_FOOTER}
+
+<example>
+gh pr create --title "the pr title" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+## Test plan
+[Checklist of TODOs for testing the pull request...]
+
+{PR_FOOTER}
+EOF
+)"
+</example>"""

--- a/ouro/capabilities/tools/builtins/shell.py
+++ b/ouro/capabilities/tools/builtins/shell.py
@@ -3,6 +3,7 @@
 import asyncio
 from typing import Any, Dict
 
+from ...prompts.attribution import get_commit_and_pr_instructions
 from ..base import BaseTool
 
 
@@ -12,16 +13,26 @@ class ShellTool(BaseTool):
     DEFAULT_TIMEOUT = 120.0  # Default timeout in seconds
     MAX_TIMEOUT = 600.0  # Maximum allowed timeout
 
+    def __init__(self, attribution_enabled: bool = True) -> None:
+        """Args:
+        attribution_enabled: When True, the description carries the
+            commit/PR attribution template so commits and PRs the model
+            authors end with ouro's trailers. See ``prompts.attribution``.
+        """
+        self._attribution_enabled = attribution_enabled
+
     @property
     def name(self) -> str:
         return "shell"
 
     @property
     def description(self) -> str:
-        return (
+        base = (
             "Execute shell commands. Returns stdout/stderr. "
             "Commands that exceed the timeout are killed and an error is returned."
         )
+        instructions = get_commit_and_pr_instructions(self._attribution_enabled)
+        return f"{base}\n\n{instructions}" if instructions else base
 
     @property
     def parameters(self) -> Dict[str, Any]:

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -20,6 +20,10 @@ MAX_ITERATIONS=1000
 
 # Ralph Loop (outer verification loop — re-checks task completion)
 # RALPH_LOOP_MAX_ITERATIONS=3
+
+# Commit / PR attribution: append "Co-Authored-By: ouro" to commits and
+# "Generated with ouro" to PR bodies the agent authors. Set to false to disable.
+# ATTRIBUTION_ENABLED=true
 """
 
 
@@ -77,6 +81,9 @@ class Config:
 
     # Agent Configuration
     MAX_ITERATIONS = int(_cfg.get("MAX_ITERATIONS", "1000"))
+
+    # Commit / PR attribution (append ouro trailers to commits/PRs)
+    ATTRIBUTION_ENABLED = _cfg.get("ATTRIBUTION_ENABLED", "true").lower() == "true"
 
     # Ralph Loop (outer verification loop)
     RALPH_LOOP_MAX_ITERATIONS = int(_cfg.get("RALPH_LOOP_MAX_ITERATIONS", "3"))

--- a/ouro/interfaces/cli/factory.py
+++ b/ouro/interfaces/cli/factory.py
@@ -86,7 +86,7 @@ def create_agent(
         GlobTool(),
         GrepTool(),
         SmartEditTool(),
-        ShellTool(),
+        ShellTool(attribution_enabled=Config.ATTRIBUTION_ENABLED),
         ConversationSearchTool(memory_dir=memory_dir),
     ]
 

--- a/test/test_attribution.py
+++ b/test/test_attribution.py
@@ -25,8 +25,7 @@ class TestAttributionInstructions:
 
     def test_trailer_constants(self):
         assert (
-            COMMIT_TRAILER
-            == "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
+            COMMIT_TRAILER == "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
         )
         assert PR_FOOTER == "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
 

--- a/test/test_attribution.py
+++ b/test/test_attribution.py
@@ -24,7 +24,10 @@ class TestAttributionInstructions:
         assert get_commit_and_pr_instructions(enabled=False) == ""
 
     def test_trailer_constants(self):
-        assert COMMIT_TRAILER == "Co-Authored-By: ouro <noreply@ouro-ai-labs.github.io>"
+        assert (
+            COMMIT_TRAILER
+            == "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
+        )
         assert PR_FOOTER == "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
 
 

--- a/test/test_attribution.py
+++ b/test/test_attribution.py
@@ -1,0 +1,49 @@
+"""Tests for commit/PR attribution in the shell tool description."""
+
+from ouro.capabilities.prompts.attribution import (
+    COMMIT_TRAILER,
+    PR_FOOTER,
+    get_commit_and_pr_instructions,
+)
+from ouro.capabilities.tools.builtins.shell import ShellTool
+
+
+class TestAttributionInstructions:
+    """The standalone instruction builder."""
+
+    def test_enabled_contains_both_trailers_and_examples(self):
+        text = get_commit_and_pr_instructions(enabled=True)
+        assert COMMIT_TRAILER in text
+        assert PR_FOOTER in text
+        # The <example> blocks are what the model copies when building commands.
+        assert text.count("<example>") == 2
+        assert "git commit" in text
+        assert "gh pr create" in text
+
+    def test_disabled_collapses_to_empty(self):
+        assert get_commit_and_pr_instructions(enabled=False) == ""
+
+    def test_trailer_constants(self):
+        assert COMMIT_TRAILER == "Co-Authored-By: ouro <noreply@ouro-ai-labs.github.io>"
+        assert PR_FOOTER == "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
+
+
+class TestShellToolDescription:
+    """ShellTool.description wires the instructions in/out by the flag."""
+
+    def test_default_includes_attribution(self):
+        # Default-on so the SDK path (not just the CLI factory) is attributed.
+        desc = ShellTool().description
+        assert COMMIT_TRAILER in desc
+        assert PR_FOOTER in desc
+
+    def test_enabled_includes_attribution(self):
+        desc = ShellTool(attribution_enabled=True).description
+        assert "Execute shell commands" in desc
+        assert COMMIT_TRAILER in desc
+
+    def test_disabled_omits_attribution(self):
+        desc = ShellTool(attribution_enabled=False).description
+        assert "Execute shell commands" in desc
+        assert "Co-Authored-By" not in desc
+        assert "Generated with ouro" not in desc


### PR DESCRIPTION
## Summary

ouro now identifies itself as the commit co-author and PR generator so the code it ships stays traceable. Faithful port of Claude Code's BashTool pattern (documented in `COMMIT_ATTRIBUTION.md`): the trailers are interpolated into the **shell tool's description**, and the model copies the `<example>` blocks when it builds `git commit` / `gh pr create` commands. **No git hook, no commit template, no post-processing.**

Trailers (ouro-branded — stable regardless of which provider/model is active):
- Commit: `Co-Authored-By: ouro <noreply@ouro-ai-labs.github.io>`
- PR body: `🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)`

## Scope

- Goals: append ouro attribution to commits/PRs the agent authors; provide a clean opt-out.
- Non-goals: enforce trailers deterministically (this is prompt-driven, like Claude Code); name the underlying model; add a dedicated git tool.

## Invariants (Must Not Regress)

- [ ] `ShellTool.execute` behavior (timeout clamp, stderr handling, size limits) unchanged.
- [ ] `ShellTool()` with no args still constructs (default `attribution_enabled=True`).
- [ ] Three-layer import boundaries hold (ShellTool reads no global config; flag injected at construction).
- [ ] `shell` tool name and `parameters` schema unchanged.
- [ ] CLI factory toolset unchanged except the shell-tool flag.

## Acceptance Criteria

- [x] When enabled, `ShellTool.description` carries both trailers + two `<example>` blocks.
- [x] When `ATTRIBUTION_ENABLED=false`, the section collapses out entirely (no `Co-Authored-By` / `Generated with ouro`).
- [x] `Config.ATTRIBUTION_ENABLED` defaults to `true` and is wired through the CLI factory.

## Test Plan

- [x] Targeted: `./scripts/dev.sh test -q test/test_attribution.py test/test_shell.py` (14 passed)
- [x] `./scripts/dev.sh check` — 626 passed, 1 skipped; precommit + strict typecheck + importlint (3/3) clean
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` (via check)

## Smoke Run (Real CLI)

- [x] Printed real `ShellTool(...).to_anthropic_schema()['description']`: trailers present when on, bare description when off. (Full `python main.py --task` needs models configured; tool-schema smoke covers the model-facing surface this change touches.)

## Adversarial Review (Answer Briefly)

- **What could break?** See invariants — execute() untouched; default-on keeps `ShellTool()` callers working.
- **Worst-case size?** Fixed ~900-char static block; no user input interpolated.
- **Secrets/logging risks?** None — static strings, no secrets, no new logging.
- **Async/blocking I/O on hot paths?** None — `description` is a pure string property.
- **Error message on failure?** N/A — no new failure mode.

## Docs / Compatibility

- [ ] No docs strictly required; the new `ATTRIBUTION_ENABLED` flag is documented inline in `~/.ouro/config` template. Can add a line to `docs/configuration.md` if desired.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)