### PR TITLE
docs(readme): add attribution section for git commits and PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ source .venv/bin/activate
 
 End-users should prefer `uv tool install ouro-ai` (see [Quick Start](#quick-start)); the source checkout is only needed when contributing.
 
+## Attribution
+
+When ouro creates git commits or pull requests, it appends an attribution trailer by default (shipped in PR #194):
+
+- Git commits include `Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>`
+- Pull request bodies include `🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)`
+
+Set `ATTRIBUTION_ENABLED=false` in `~/.ouro/config` to disable.
 ## License
 
 MIT License


### PR DESCRIPTION
## Summary

Add a short section to the root README documenting ouro's attribution behavior for git commits and PRs.

## Scope

- Goals: Document the default attribution trailers added by ouro.
- Non-goals: Change any code or configuration defaults.

## Invariants (Must Not Regress)

- [ ] README structure and existing sections remain unchanged.
- [ ] No new dependencies or build steps introduced.

## Acceptance Criteria

- [ ] README includes a concise Attribution subsection.
- [ ] Mentions `Co-Authored-By: ouro` for commits.
- [ ] Mentions `Generated with ouro` for PRs.
- [ ] Notes the `ATTRIBUTION_ENABLED` config toggle in `~/.ouro/config`.

## Test Plan

- [ ] Visual review of the rendered README.

## Smoke Run (Real CLI)

- [ ] N/A — documentation-only change.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? None; docs-only.
- Worst-case input/output size? N/A.
- Any secrets/logging risks? No secrets added.
- Any async/blocking I/O added on hot paths? None.
- What error message does the user see on failure? N/A.

## Docs / Compatibility

- [x] Updated README.md.
- [x] No secrets committed.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
