### PR TITLE
feat(rules): lazy subdirectory AGENTS.md loading

### DIFF
--- a/docs/agents-md-guide.md
+++ b/docs/agents-md-guide.md
@@ -47,18 +47,25 @@ in context. If none exist, nothing is injected.
 You can have multiple AGENTS.md files in different directories:
 
 ```
-project/
-├── AGENTS.md          # General project rules
+project/            # working directory
+├── AGENTS.md          # General project rules — eager-loaded at startup
 └── backend/
-    ├── AGENTS.md      # Backend-specific rules (wins when in backend/)
+    ├── AGENTS.md      # Backend rules — loaded when a file under backend/ is read
     └── api/
-        └── AGENTS.md  # API-specific rules (wins when in api/)
+        └── AGENTS.md  # API rules — loaded when a file under api/ is read
 ```
 
-The agent uses the **nearest** AGENTS.md relative to the working directory. This allows you to:
-- Define general rules at the project root
-- Override with specific rules for subdirectories
-- Keep different conventions for different parts of a monorepo
+There are two complementary mechanisms:
+
+- **Eager (startup)**: AGENTS.md in the working directory and *above* it are loaded once at the start of every run (see "What Gets Loaded").
+- **Lazy (subdirectory)**: AGENTS.md in *subdirectories* of the working directory are loaded on demand — when the agent reads a file under that subdirectory, every AGENTS.md on the path from the working directory down to that file is appended to the read result. Sibling subtrees are never scanned, and each subdirectory's AGENTS.md is injected at most once per run.
+
+This lets you:
+- Define general rules at the project root (always present)
+- Add subdirectory rules that surface only while working in that subtree
+- Keep different conventions for different parts of a monorepo without bloating context
+
+Lazy loading is on by default. The SDK can disable it with `AgentBuilder.without_nested_agents_md()`.
 
 ## Best Practices
 
@@ -148,9 +155,9 @@ AGENTS.md is compatible with:
 - **Jules** (Google): Reads AGENTS.md automatically
 
 ### ouro Behavior
-Like Codex CLI and Jules, ouro auto-loads AGENTS.md at startup:
+Like Codex CLI and Jules, ouro auto-loads AGENTS.md deterministically:
 - **Deterministic**: Loaded every run, no reliance on LLM judgement
-- **Hierarchical**: Walks CWD → `/`, nearest file wins on conflict
+- **Hierarchical**: Eager walk CWD → `/` at startup, plus lazy loading of subdirectory AGENTS.md when a file under them is read; nearest file wins on conflict
 - **Project tier only**: No `@import` directives, size caps, or user-global tier
 
 ### Migration from Other Tools
@@ -233,7 +240,7 @@ cd backend
 
 ### AGENTS.md Not Loaded
 - Ensure file is named exactly `AGENTS.md` (case-sensitive)
-- Verify it sits in the working directory or one of its parents (the walk only goes upward, not into sibling subdirectories)
+- A working-directory or parent AGENTS.md is loaded eagerly at startup; a subdirectory AGENTS.md loads only once the agent **reads a file under that subdirectory** (sibling subtrees are never scanned)
 - Empty / whitespace-only files are skipped
 
 ### Wrong AGENTS.md Taking Precedence

--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -39,7 +39,7 @@ from .context.agents_md import load_agents_md
 from .context.env import format_context_prompt
 from .memory.manager import MemoryManager
 from .prompts import DEFAULT_SYSTEM_PROMPT
-from .rules import ReadBeforeWriteRule
+from .rules import NestedAgentsMdRule, ReadBeforeWriteRule
 from .skills.registry import SkillsRegistry
 from .skills.render import render_skills_section
 from .todo.state import TodoList
@@ -94,9 +94,11 @@ class AgentBuilder:
     verification_max_iterations: int = 0  # 0 disables verification
     progress: ProgressSink = field(default_factory=NullProgressSink)
     extra_hooks: list[Hook] = field(default_factory=list)
-    # Deterministic per-tool-call rules. ReadBeforeWriteRule is on by default;
-    # `extra_rules` run after it. See `ouro.capabilities.rules`.
+    # Deterministic per-tool-call rules. ReadBeforeWriteRule and
+    # NestedAgentsMdRule are on by default; `extra_rules` run after them.
+    # See `ouro.capabilities.rules`.
     read_before_write: bool = True
+    nested_agents_md: bool = True
     extra_rules: list[Rule] = field(default_factory=list)
 
     # ---- LLM ----------------------------------------------------------------
@@ -185,6 +187,10 @@ class AgentBuilder:
         self.read_before_write = False
         return self
 
+    def without_nested_agents_md(self) -> AgentBuilder:
+        self.nested_agents_md = False
+        return self
+
     # ---- Build --------------------------------------------------------------
 
     def build(self) -> ComposedAgent:
@@ -229,10 +235,13 @@ class AgentBuilder:
         hooks.extend(self.extra_hooks)
 
         # Deterministic per-tool-call rules (the repeat breaker is added by the
-        # core Agent itself). ReadBeforeWriteRule is on by default.
+        # core Agent itself). ReadBeforeWriteRule and NestedAgentsMdRule are on
+        # by default.
         rules: list[Rule] = []
         if self.read_before_write:
             rules.append(ReadBeforeWriteRule())
+        if self.nested_agents_md:
+            rules.append(NestedAgentsMdRule())
         rules.extend(self.extra_rules)
 
         core = Agent(

--- a/ouro/capabilities/context/agents_md.py
+++ b/ouro/capabilities/context/agents_md.py
@@ -7,6 +7,11 @@ found. Files closer to the CWD are appended last so they take precedence
 
 Scope is intentionally minimal (see ``rfc/agents-md-autoload.md``): project-tier
 upward walk only. No ``@import`` directives, no size caps, no user/global tier.
+
+Subdirectory ``AGENTS.md`` files *below* the working directory are not part of
+this eager load — they are surfaced lazily by ``NestedAgentsMdRule`` when the
+agent reads a file under them (see ``load_nested_instructions`` and
+``rfc/nested-agents-md.md``).
 """
 
 from __future__ import annotations
@@ -89,3 +94,77 @@ async def load_agents_md(start_dir: str | None = None) -> str:
         return _format(_read_and_merge(_discover_agents_md(start_dir)))
 
     return await asyncio.to_thread(_work)
+
+
+# --- Nested (subdirectory) loading ------------------------------------------
+#
+# The eager load above covers the working directory and everything above it.
+# AGENTS.md files in *subdirectories* of the CWD are surfaced on demand when a
+# file under them is read, via ``NestedAgentsMdRule``. These helpers are
+# synchronous because the rule runs them on the per-tool-call path.
+
+
+def _nested_agents_md_paths(cwd: str, file_path: str) -> list[Path]:
+    """Existing ``AGENTS.md`` along the path from ``cwd`` down to ``file_path``.
+
+    Scans only the directories strictly between ``cwd`` (exclusive) and the
+    directory containing ``file_path`` (inclusive) — the single path down to the
+    file, never sibling subtrees. Returns paths ordered parent-first (nearest
+    last). Returns ``[]`` when ``file_path`` sits at the ``cwd`` level or outside
+    ``cwd``; those directories are already covered by the eager startup load.
+    """
+    cwd_abs = os.path.abspath(cwd)
+    target_dir = os.path.dirname(os.path.abspath(file_path))
+    try:
+        within = os.path.commonpath([cwd_abs, target_dir]) == cwd_abs
+    except ValueError:
+        return []  # different drives / mixed roots (Windows)
+    if not within or target_dir == cwd_abs:
+        return []
+
+    found: list[Path] = []
+    directory = target_dir
+    while directory != cwd_abs:
+        candidate = Path(directory) / AGENTS_FILENAME
+        if candidate.is_file():
+            found.append(candidate)
+        parent = os.path.dirname(directory)
+        if parent == directory:
+            break  # reached filesystem root without hitting cwd (defensive)
+        directory = parent
+    found.reverse()  # parent-first, nearest last
+    return found
+
+
+def _format_nested(merged: str) -> str:
+    """Wrap merged subdirectory AGENTS.md in a ``<project_instructions>`` block."""
+    if not merged:
+        return ""
+    return (
+        "<project_instructions>\n"
+        "Additional project instructions were auto-loaded from AGENTS.md files "
+        "in subdirectories on the path to the file you just accessed (nearest "
+        "last; nearest takes precedence). Follow them while working under those "
+        "subdirectories unless a higher-priority instruction overrides.\n\n"
+        f"{merged}\n"
+        "</project_instructions>\n"
+    )
+
+
+def load_nested_instructions(cwd: str, file_path: str, already_injected: set[str]) -> str:
+    """Read subdirectory AGENTS.md newly relevant to ``file_path`` and format them.
+
+    Walks the directories between ``cwd`` and ``file_path``'s directory, skips
+    AGENTS.md already recorded in ``already_injected`` (by string path), reads
+    the rest, records them in ``already_injected``, and returns a formatted
+    ``<project_instructions>`` block (or ``""`` when nothing new applies).
+
+    ``already_injected`` is mutated in place; paths are recorded even when their
+    content is empty/unreadable so they are not re-read on a later trigger.
+    """
+    paths = _nested_agents_md_paths(cwd, file_path)
+    fresh = [p for p in paths if str(p) not in already_injected]
+    if not fresh:
+        return ""
+    already_injected.update(str(p) for p in fresh)
+    return _format_nested(_read_and_merge(fresh))

--- a/ouro/capabilities/rules/__init__.py
+++ b/ouro/capabilities/rules/__init__.py
@@ -5,6 +5,7 @@ the generic rules in ``ouro.core.loop.rules``, they know about specific tool nam
 and argument shapes — so they live here, above the core boundary.
 """
 
+from .nested_agents_md import NestedAgentsMdRule
 from .read_before_write import ReadBeforeWriteRule
 
-__all__ = ["ReadBeforeWriteRule"]
+__all__ = ["NestedAgentsMdRule", "ReadBeforeWriteRule"]

--- a/ouro/capabilities/rules/nested_agents_md.py
+++ b/ouro/capabilities/rules/nested_agents_md.py
@@ -1,0 +1,78 @@
+"""NestedAgentsMdRule — surface subdirectory AGENTS.md when a file under it is read.
+
+A tool-aware loop rule (implements the core ``Rule`` contract), the lazy
+counterpart to the eager startup load in ``ouro.capabilities.context.agents_md``.
+The eager load covers the working directory and everything above it; AGENTS.md
+files in *subdirectories* of the CWD are surfaced only when the agent actually
+reads a file under them.
+
+- ``after_toolcall`` watches ``read_file`` calls. When the read target sits in a
+  subdirectory of the CWD, it loads every ``AGENTS.md`` along the path from the
+  CWD down to that file's directory (parent-first, nearest last; sibling
+  subtrees are never scanned) and **appends** them to the read result as a
+  ``<project_instructions>`` block, so the subdirectory's rules land right next
+  to the file the model just looked at.
+
+Dedup is per-run: an injected-set records which AGENTS.md were already surfaced
+and self-resets when the loop hands the rule a new ``RunStatistic`` (a fresh
+object each ``Agent.run``), mirroring ``ReadBeforeWriteRule``. So a subdirectory's
+AGENTS.md is injected at most once per run.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from ouro.capabilities.context.agents_md import load_nested_instructions
+from ouro.core.log import get_logger
+
+if TYPE_CHECKING:
+    from ouro.core.llm import ToolCall, ToolResult
+    from ouro.core.loop.protocols import LoopContext
+
+logger = get_logger(__name__)
+
+# Tools that read a specific file at their ``file_path`` argument.
+_DEFAULT_READ_TOOLS = frozenset({"read_file"})
+
+
+class NestedAgentsMdRule:
+    """Inject subdirectory AGENTS.md when a file under them is read (see module doc)."""
+
+    name = "nested_agents_md"
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        read_tools: frozenset[str] = _DEFAULT_READ_TOOLS,
+    ) -> None:
+        self._cwd = os.path.abspath(cwd or os.getcwd())
+        self._read_tools = read_tools
+        # Paths of AGENTS.md already surfaced *this run*.
+        self._injected: set[str] = set()
+        # Identity of the run context last observed; a new one means a new run.
+        self._last_ctx: object | None = None
+
+    def _reset_on_new_run(self, ctx: LoopContext) -> None:
+        # ``RunStatistic`` is constructed fresh per ``Agent.run``; a different
+        # object identity is the reliable signal that a new run has started.
+        if ctx is not self._last_ctx:
+            self._injected.clear()
+            self._last_ctx = ctx
+
+    def after_toolcall(
+        self, ctx: LoopContext, tool_call: ToolCall, tool_result: ToolResult
+    ) -> str | None:
+        self._reset_on_new_run(ctx)
+        if tool_call.name not in self._read_tools:
+            return None
+        raw = tool_call.arguments.get("file_path")
+        if not isinstance(raw, str) or not raw:
+            return None
+        block = load_nested_instructions(self._cwd, raw, self._injected)
+        if not block:
+            return None
+        logger.info("NestedAgentsMdRule: surfaced subdirectory AGENTS.md for %r", raw)
+        return f"{tool_result.content}\n\n{block}"

--- a/rfc/nested-agents-md.md
+++ b/rfc/nested-agents-md.md
@@ -1,0 +1,122 @@
+# RFC: Lazy subdirectory AGENTS.md loading
+
+- Status: Proposed
+- Authors: Yixin Luo
+- Date: 2026-05-24
+
+## Summary
+
+Surface subdirectory `AGENTS.md` files on demand: when the agent reads a file
+inside a subdirectory of the working directory, load every `AGENTS.md` along the
+path from the CWD down to that file's directory and append them to the read
+result. Complements the eager startup load (RFC `agents-md-autoload`, PR #193),
+which covers the CWD and everything above it but never descends into
+subdirectories. Borrows Claude Code's nested-memory mechanism, scoped down.
+
+## Problem
+
+The eager load only walks *upward* from the CWD, so subdirectory rules in a
+monorepo (`backend/AGENTS.md`, `services/api/AGENTS.md`, …) are invisible unless
+you `cd` into them. Loading every subdirectory's AGENTS.md eagerly would bloat
+the prompt and mix conflicting rules. We want subdirectory rules to appear only
+when they become relevant — i.e. when the agent actually touches a file under
+them.
+
+## Goals
+
+- When `read_file` targets a file in a subdirectory of the CWD, inject that
+  subdirectory's `AGENTS.md` (and any on the path down from the CWD).
+- Scan only the single path CWD → target's directory; never sibling subtrees.
+- Parent-first / nearest-last ordering (nearest wins), matching the eager load.
+- Dedup so the same subdirectory AGENTS.md isn't re-injected repeatedly.
+- On by default, with an opt-out.
+
+## Non-goals
+
+- Triggers other than `read_file` (no `@file` mention / IDE-open hooks).
+- `.claude/rules/*.md`, `globs:` conditional rules, `CLAUDE.local.md`.
+- Re-evaluating CWD-level / above files per trigger (they're eagerly loaded).
+- `@import`, size caps, user-global / managed tiers.
+- Session-permanent dedup (we reset per run; see below).
+
+## Proposed Behavior (User-Facing)
+
+- Reading `repo/services/api/handler.py` (CWD `repo`) appends the merged
+  contents of `repo/services/AGENTS.md` + `repo/services/api/AGENTS.md` (those
+  that exist) to the read result, wrapped in `<project_instructions>`.
+- Reading a file directly in the CWD, or outside the CWD, injects nothing.
+- Reading a sibling (`repo/services/db/x.py`) does not pull
+  `repo/services/api/AGENTS.md`.
+- Each subdirectory's AGENTS.md is injected at most once per `Agent.run`.
+- On by default; `AgentBuilder.without_nested_agents_md()` disables it.
+
+## Invariants (Must Not Regress)
+
+- Eager startup load (PR #193) is unchanged; nested load never touches CWD-level
+  or higher directories.
+- A read with no nested AGENTS.md returns the result unchanged (rule returns
+  `None`).
+- Sibling subtrees are never scanned.
+- No LLM calls in the rule; only cheap local stat/read on the per-call path.
+- Layer boundaries intact (rule lives in `ouro.capabilities.rules`).
+
+## Design Sketch (Minimal)
+
+`ouro/capabilities/context/agents_md.py` gains synchronous helpers:
+
+- `_nested_agents_md_paths(cwd, file_path)` — existing AGENTS.md on the path
+  CWD → target dir, parent-first; `[]` for cwd-level / outside-cwd files.
+- `_format_nested(merged)` — `<project_instructions>` wrapper.
+- `load_nested_instructions(cwd, file_path, already_injected)` — filter by the
+  dedup set, read+merge fresh ones, mutate the set, return the block or `""`.
+
+`ouro/capabilities/rules/nested_agents_md.py` — `NestedAgentsMdRule` implements
+the core `Rule` contract. `after_toolcall` watches `read_file`, calls
+`load_nested_instructions`, and appends the block to the result. Dedup set
+self-resets on a new `RunStatistic` identity (like `ReadBeforeWriteRule`).
+
+`AgentBuilder`: `nested_agents_md: bool = True`,
+`without_nested_agents_md()`, wired after `ReadBeforeWriteRule` in `build()`.
+
+### Why a Rule, appending to the read result
+
+`after_toolcall` is purpose-built to "rewrite output and/or record state from
+real results." Appending the subdirectory rules to the very read that triggered
+them places the guidance next to the file the model just looked at — ouro's
+native analog to Claude Code's `nested_memory` attachment. The rule path is
+synchronous, so reads are synchronous; they are tiny, local, and deduped, in the
+spirit of the contract's allowed `os.path.exists` check.
+
+## Alternatives Considered
+
+- Async `Hook.on_iteration_end` injecting a separate message: avoids sync file
+  I/O but needs cross-component coordination and a bespoke message; heavier for
+  no real benefit at this size.
+- Session-permanent dedup (Claude Code's non-evicting set): injects each subdir
+  once ever, but grows unbounded. We chose per-run reset for bounded state and
+  consistency with `ReadBeforeWriteRule`.
+
+## Test Plan
+
+- Unit (`test/test_nested_agents_md.py`): path discovery (down-walk, excludes
+  cwd-level/outside/siblings), load+dedup, rule appends block, ignores non-read
+  tools, per-run dedup reset, no-op returns `None`.
+- Targeted: `./scripts/dev.sh test -q test/test_nested_agents_md.py test/test_loop_rules.py`.
+- Smoke: from a repo with a `sub/AGENTS.md`, `python main.py --task "read sub/x.py and tell me the project rules"`.
+
+## Rollout / Migration
+
+- Backward compatible. On by default; opt out with
+  `without_nested_agents_md()`.
+
+## Risks & Mitigations
+
+- Many/large subdirectory AGENTS.md inflate read results: accepted for MVP (no
+  caps); dedup limits repetition.
+- Sync file reads on the rule path: tiny, local, deduped; negligible next to the
+  `read_file` that triggered them.
+
+## Open Questions
+
+- Whether to later add session-permanent dedup or `@file`-mention triggers
+  (out of scope).

--- a/test/test_nested_agents_md.py
+++ b/test/test_nested_agents_md.py
@@ -1,0 +1,133 @@
+"""Tests for lazy subdirectory AGENTS.md loading (NestedAgentsMdRule + helpers).
+
+Offline, no API keys. Tests scope discovery to a tmp directory via explicit
+``cwd`` / ``file_path`` arguments so results don't depend on the machine.
+"""
+
+from ouro.capabilities.context.agents_md import (
+    _nested_agents_md_paths,
+    load_nested_instructions,
+)
+from ouro.capabilities.rules.nested_agents_md import NestedAgentsMdRule
+from ouro.core.llm import ToolCall, ToolResult
+
+# --- path discovery ----------------------------------------------------------
+
+
+def test_paths_walk_cwd_down_to_target(tmp_path):
+    # cwd/a/b/file.txt with AGENTS.md at a/ and a/b/
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "a" / "AGENTS.md").write_text("A RULE")
+    (tmp_path / "a" / "b" / "AGENTS.md").write_text("B RULE")
+    target = tmp_path / "a" / "b" / "file.txt"
+
+    paths = _nested_agents_md_paths(str(tmp_path), str(target))
+
+    # parent-first, nearest last; only the two on the path, not cwd-level.
+    assert [p.parent.name for p in paths] == ["a", "b"]
+
+
+def test_paths_excludes_cwd_level_and_above(tmp_path):
+    # A file directly in cwd pulls in nothing (cwd & above are eagerly loaded).
+    (tmp_path / "AGENTS.md").write_text("ROOT RULE")
+    target = tmp_path / "file.txt"
+    assert _nested_agents_md_paths(str(tmp_path), str(target)) == []
+
+
+def test_paths_ignores_files_outside_cwd(tmp_path):
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    outside = tmp_path / "other" / "file.txt"
+    outside.parent.mkdir()
+    (tmp_path / "other" / "AGENTS.md").write_text("NOPE")
+    assert _nested_agents_md_paths(str(cwd), str(outside)) == []
+
+
+def test_paths_skips_siblings(tmp_path):
+    # Reading a/b/file.txt must not pull a/c/AGENTS.md (sibling subtree).
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "a" / "c").mkdir()
+    (tmp_path / "a" / "c" / "AGENTS.md").write_text("SIBLING")
+    target = tmp_path / "a" / "b" / "file.txt"
+    assert _nested_agents_md_paths(str(tmp_path), str(target)) == []
+
+
+# --- load + dedup ------------------------------------------------------------
+
+
+def test_load_formats_block_and_dedups(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "AGENTS.md").write_text("SUBDIR RULE")
+    target = tmp_path / "a" / "file.txt"
+    injected: set[str] = set()
+
+    first = load_nested_instructions(str(tmp_path), str(target), injected)
+    assert "<project_instructions>" in first
+    assert "SUBDIR RULE" in first
+
+    # Second read of a file in the same subdir injects nothing (already seen).
+    second = load_nested_instructions(str(tmp_path), str(target), injected)
+    assert second == ""
+
+
+def test_load_returns_empty_when_no_nested_agents_md(tmp_path):
+    (tmp_path / "a").mkdir()
+    target = tmp_path / "a" / "file.txt"
+    assert load_nested_instructions(str(tmp_path), str(target), set()) == ""
+
+
+# --- rule integration --------------------------------------------------------
+
+
+def _ctx():
+    # The rule only uses ctx for run-identity dedup; any sentinel object works.
+    return object()
+
+
+def test_rule_appends_nested_block_to_read_result(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "AGENTS.md").write_text("NESTED RULE")
+    rule = NestedAgentsMdRule(cwd=str(tmp_path))
+    call = ToolCall(id="1", name="read_file", arguments={"file_path": str(tmp_path / "a" / "x.py")})
+    result = ToolResult(tool_call_id="1", content="<file contents>", name="read_file")
+
+    out = rule.after_toolcall(_ctx(), call, result)
+
+    assert out is not None
+    assert out.startswith("<file contents>")
+    assert "NESTED RULE" in out
+    assert "<project_instructions>" in out
+
+
+def test_rule_ignores_non_read_tools(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "AGENTS.md").write_text("NESTED RULE")
+    rule = NestedAgentsMdRule(cwd=str(tmp_path))
+    call = ToolCall(
+        id="1", name="write_file", arguments={"file_path": str(tmp_path / "a" / "x.py")}
+    )
+    result = ToolResult(tool_call_id="1", content="ok", name="write_file")
+    assert rule.after_toolcall(_ctx(), call, result) is None
+
+
+def test_rule_dedups_within_run_but_resets_across_runs(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "AGENTS.md").write_text("NESTED RULE")
+    rule = NestedAgentsMdRule(cwd=str(tmp_path))
+    call = ToolCall(id="1", name="read_file", arguments={"file_path": str(tmp_path / "a" / "x.py")})
+    result = ToolResult(tool_call_id="1", content="c", name="read_file")
+
+    run1 = _ctx()
+    assert rule.after_toolcall(run1, call, result) is not None  # first read in run1
+    assert rule.after_toolcall(run1, call, result) is None  # deduped in run1
+
+    run2 = _ctx()  # new run context identity → dedup set resets
+    assert rule.after_toolcall(run2, call, result) is not None
+
+
+def test_rule_no_nested_returns_none_unchanged(tmp_path):
+    rule = NestedAgentsMdRule(cwd=str(tmp_path))
+    # File directly in cwd → nothing nested.
+    call = ToolCall(id="1", name="read_file", arguments={"file_path": str(tmp_path / "x.py")})
+    result = ToolResult(tool_call_id="1", content="c", name="read_file")
+    assert rule.after_toolcall(_ctx(), call, result) is None


### PR DESCRIPTION
## Summary

Surfaces **subdirectory** `AGENTS.md` on demand. When the agent `read_file`s a file inside a subdirectory of the working directory, every `AGENTS.md` along the path **from the CWD down to that file's directory** is loaded and appended to the read result as a `<project_instructions>` block. Sibling subtrees are never scanned; each subdirectory's AGENTS.md is injected at most once per run.

This is the lazy counterpart to the eager startup load (#193): the eager upward walk covers the CWD and above; this covers below it. Borrows Claude Code's nested-memory mechanism (`NESTED_CLAUDE_MD.md`), scoped down. Design in `rfc/nested-agents-md.md`.

## Scope

- Goals: load subdir AGENTS.md when a file under it is read; scan only CWD → target dir (no siblings); parent-first/nearest-last; dedup; on by default with opt-out.
- Non-goals: triggers other than `read_file`; `.claude/rules/*.md`, `globs:` conditional rules, `CLAUDE.local.md`; cwd-level/above re-eval; `@import`, size caps, user-global tier; session-permanent dedup.

## Invariants (Must Not Regress)

- [x] Eager startup load (#193) unchanged; nested load never touches CWD-level or higher dirs.
- [x] A read with no nested AGENTS.md returns the result unchanged (rule returns `None`).
- [x] Sibling subtrees never scanned; files outside CWD pull nothing.
- [x] No LLM calls in the rule; only cheap local stat/read, deduped, on the per-call path.
- [x] Layer boundaries intact (rule in `ouro.capabilities.rules`; contracts 3/3).

## Acceptance Criteria

- [x] `NestedAgentsMdRule.after_toolcall` appends nested `<project_instructions>` to a `read_file` result under a subdir.
- [x] Path discovery walks CWD → target dir only (parent-first, nearest last).
- [x] On by default; `AgentBuilder.without_nested_agents_md()` disables it.
- [x] Per-run dedup: injected once per subdir per `Agent.run`, resets across runs.

## Test Plan

- [x] `test/test_nested_agents_md.py` (10 tests): down-walk discovery, excludes cwd-level/outside/siblings, load+dedup, rule append/ignore-non-read/per-run-reset/no-op.
- [x] `./scripts/dev.sh check` — contracts kept (3/3), typecheck clean, 636 passed / 1 skipped.

## Smoke Run (Real CLI)

- [x] Wiring smoke: built agent's rule list contains `NestedAgentsMdRule` by default and omits it after `without_nested_agents_md()`; `after_toolcall` appends the nested block end-to-end. (Deterministic; avoids live-LLM cost.)

## Adversarial Review

- **What could break?** The 5 invariants above (eager load untouched, no-op safety, sibling isolation, no LLM/heavy I/O, layer boundaries).
- **Worst-case size?** Many/large subdir AGENTS.md inflate a read result — accepted for MVP (no caps); per-run dedup limits repetition.
- **Secrets/logging?** Logs only the trigger file path on injection; no file contents logged.
- **Async/blocking I/O?** Sync file reads on the rule path are tiny, local, deduped — negligible next to the `read_file` that triggered them; no network/LLM.
- **Failure UX?** Unreadable/empty AGENTS.md are skipped (recorded so they aren't retried); the read result passes through unchanged.

## Docs / Compatibility

- [x] `docs/agents-md-guide.md` updated (eager-vs-lazy mechanisms + `without_nested_agents_md()`).
- [x] No secrets / generated artifacts committed.
- Backward compatible; opt out with `without_nested_agents_md()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)