### PR TITLE
chore: release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-24
+
 ### Added
 
 - **Memory blocks**: named, size-bounded markdown blocks under
@@ -15,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`read` / `replace` / `append` operations). Strict blocks (`user`,
   `project`) reject overflow with an actionable error; `scratch` is lenient
   with FIFO truncation. Inspired by Letta/MemGPT's core memory.
+- **Rules engine**: pluggable `Rule` abstraction for deterministic
+  pre-dispatch guards. `ReadBeforeWriteRule` blocks blind overwrites of
+  unread files; `AGENTS.md` auto-loading is now deterministic via
+  `ContextRule`. Rules are evaluated in order before each tool call (#190,
+  #192, #193).
+- **Lazy subdirectory AGENTS.md loading**: `.md` files in subdirectories
+  are loaded on-demand when a tool accesses that subtree, rather than
+  eagerly at startup (#196).
+- **Commit/PR attribution**: shell tool descriptions now include commit
+  and PR metadata for better traceability (#194).
+- **Conversation search (FTS5)**: full-text search over conversation
+  history backed by SQLite FTS5, replacing the mem0 vector search use case
+  (#188).
 
 ### Changed (BREAKING)
 
@@ -38,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opportunistically dumped during compaction. The conversation itself is
   still searchable via `conversation_search` (FTS5).
 
-### Removed (BREAKING — from PR #189)
+### Removed (BREAKING)
 
 - **mem0 backend removed**. `MEM0_ENABLED`, `MEM0_USER_ID`, and all
   `MEM0_*` env overrides are gone; setting them has no effect. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ouro-ai"
-version = "0.4.2"
+version = "0.4.3"
 description = "General AI Agent System"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bump version to 0.4.3 and update CHANGELOG.

## Changes since v0.4.2

### Added
- **Memory blocks**: named, size-bounded markdown blocks under 
- **Rules engine**: pluggable  abstraction for deterministic pre-dispatch guards
- **Lazy subdirectory AGENTS.md loading**: on-demand loading instead of eager startup
- **Commit/PR attribution**: shell tool descriptions include commit and PR metadata
- **Conversation search (FTS5)**: full-text search over conversation history

### Changed (BREAKING)
-  flag removed (FTS5 always on)
-  replaced by 
- Compaction no longer auto-extracts long-term memories

### Removed (BREAKING)
- mem0 backend and related dependencies removed