### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-24
+
 ### Added
 
 - **Memory blocks**: named, size-bounded markdown blocks under
@@ -15,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`read` / `replace` / `append` operations). Strict blocks (`user`,
   `project`) reject overflow with an actionable error; `scratch` is lenient
   with FIFO truncation. Inspired by Letta/MemGPT's core memory.
+- **Pluggable Rule abstraction**: deterministic pre-dispatch guards for the
+  agent loop. Includes `ReadBeforeWriteRule` to block blind overwrites of
+  unread files (#190, #192).
+- **Deterministic AGENTS.md auto-loading**: project-wide and per-directory
+  rule files are loaded automatically based on the working directory (#193).
+- **Lazy subdirectory AGENTS.md loading**: nested `AGENTS.md` files are
+  loaded on-demand when tools target their directories (#196).
+- **Commit/PR attribution**: shell tool descriptions now include Co-Authored-By
+  and PR attribution footers for ouro-generated commits (#194).
 
 ### Changed (BREAKING)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ouro-ai"
-version = "0.4.2"
+version = "0.4.3"
 description = "General AI Agent System"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Release v0.4.3 — version bump + changelog archive for the memory blocks, rules, and AGENTS.md loading features.

## Scope

- Goals: Cut the v0.4.3 release.
- Non-goals: No code changes; this is a pure release commit.

## Invariants (Must Not Regress)

- [ ] All existing tests pass
- [ ] Import-linter contracts remain intact
- [ ] No functional code changes

## Acceptance Criteria

- [ ] `pyproject.toml` version reads `0.4.3`
- [ ] `CHANGELOG.md` has a dated `[0.4.3]` section with all unreleased items

## Test Plan

- [ ] Targeted tests: N/A (no code changes)
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] N/A — release commit only

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? None — only version + changelog.
- Worst-case input/output size? N/A.
- Any secrets/logging risks? No.
- Any async/blocking I/O added on hot paths? No.
- What error message does the user see on failure? N/A.

## Docs / Compatibility

- [ ] CHANGELOG.md updated
- [ ] No secrets committed; no generated artifacts

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)