### PR TITLE
fix(attribution): update Co-Authored-By email to new GitHub username

### DIFF
--- a/ouro/capabilities/prompts/attribution.py
+++ b/ouro/capabilities/prompts/attribution.py
@@ -12,7 +12,7 @@ The attribution can be disabled (``ATTRIBUTION_ENABLED=false`` in
 has no template prompting it to add the trailers.
 """
 
-COMMIT_TRAILER = "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
+COMMIT_TRAILER = "Co-Authored-By: ouro <197364660+ouro-ai-lab@users.noreply.github.com>"
 PR_FOOTER = "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
 
 

--- a/test/test_attribution.py
+++ b/test/test_attribution.py
@@ -25,7 +25,8 @@ class TestAttributionInstructions:
 
     def test_trailer_constants(self):
         assert (
-            COMMIT_TRAILER == "Co-Authored-By: ouro <197364660+ahahoul007@users.noreply.github.com>"
+            COMMIT_TRAILER
+            == "Co-Authored-By: ouro <197364660+ouro-ai-lab@users.noreply.github.com>"
         )
         assert PR_FOOTER == "🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)"
 


### PR DESCRIPTION
## Summary

Update the Co-Authored-By attribution trailer from the old GitHub username `ahahoul007` to the new username `ouro-ai-lab`.

## Scope

- Goals: Update commit/PR attribution to reflect the new GitHub username.
- Non-goals: No functional behavior changes.

## Invariants (Must Not Regress)

- [ ] Attribution tests pass
- [ ] No other references to `ahahoul007` remain in the codebase

## Acceptance Criteria

- [ ] `ouro/capabilities/prompts/attribution.py` uses `ouro-ai-lab`
- [ ] `test/test_attribution.py` uses `ouro-ai-lab`

## Test Plan

- [ ] Targeted tests: `test/test_attribution.py`
- [ ] `./scripts/dev.sh test -q`

## Smoke Run (Real CLI)

- [ ] N/A — attribution string change only

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? None — string constant update.
- Worst-case input/output size? N/A.
- Any secrets/logging risks? No.
- Any async/blocking I/O added on hot paths? No.
- What error message does the user see on failure? N/A.

## Docs / Compatibility

- [ ] No docs changes needed
- [ ] No secrets committed

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)