### PR TITLE
fix(tui): remove redundant Assistant prefix and final answer marker

### DIFF
--- a/ouro/interfaces/tui/interactive.py
+++ b/ouro/interfaces/tui/interactive.py
@@ -283,9 +283,7 @@ class InteractiveSession:
                 content = str(msg.content)
                 if len(content) > 300:
                     content = content[:300] + "..."
-                terminal_ui.console.print(
-                    f"[bold {colors.secondary}]Assistant:[/bold {colors.secondary}] {content}"
-                )
+                terminal_ui.console.print(content)
             elif msg.role == "assistant" and msg.tool_calls:
                 tool_names = ", ".join(
                     (
@@ -529,9 +527,6 @@ class InteractiveSession:
             finally:
                 self.current_task = None
 
-            terminal_ui.console.print(
-                f"[bold {colors.secondary}]Assistant:[/bold {colors.secondary}]"
-            )
             terminal_ui.print_assistant_message(result)
             self._update_status_bar()
             if Config.TUI_STATUS_BAR:
@@ -907,9 +902,6 @@ class InteractiveSession:
                         self.current_task = None
 
                     # Display agent response
-                    terminal_ui.console.print(
-                        f"[bold {colors.secondary}]Assistant:[/bold {colors.secondary}]"
-                    )
                     terminal_ui.print_assistant_message(result)
 
                     # Update status bar

--- a/ouro/interfaces/tui/tui_progress.py
+++ b/ouro/interfaces/tui/tui_progress.py
@@ -38,10 +38,9 @@ class TuiProgressSink:
         terminal_ui.print_tool_blocked(name, arguments, reason)
 
     def final_answer(self, text: str) -> None:
-        # The interactive shell renders the returned final answer itself; here
-        # we only emit a lightweight completion marker for non-interactive
-        # progress consumers.
-        terminal_ui.console.print("\n[bold green]✓ Final answer received[/bold green]")
+        # The interactive shell renders the returned final answer itself;
+        # no additional marker is needed.
+        pass
 
     def unfinished_answer(self, text: str) -> None:
         terminal_ui.print_unfinished_answer(text)


### PR DESCRIPTION
## Summary

Remove the "Assistant:" prefix that was printed before every assistant message in the interactive TUI, and remove the "✓ Final answer received" completion marker.

## Scope

- Goals:
  - Clean up redundant visual noise in the interactive TUI output
  - Remove the "Assistant:" prefix that duplicates the panel title already rendered by `print_assistant_message()`
  - Remove the "✓ Final answer received" marker from `TuiProgressSink.final_answer()` since the interactive shell renders the answer itself

- Non-goals:
  - No changes to the core agent loop or capabilities layer
  - No changes to non-interactive output modes (e.g. `--task` one-shot)
  - No changes to bot channels

## Invariants (Must Not Regress)

- [ ] Assistant messages still render in a styled panel with Markdown support
- [ ] Session history display (`/resume`) still works correctly
- [ ] `print_assistant_message()` behavior is unchanged
- [ ] `TuiProgressSink` other methods (`thinking`, `tool_call`, `tool_result`, etc.) are unchanged
- [ ] Non-interactive progress consumers still work (they don't use `TuiProgressSink`)

## Acceptance Criteria

- [ ] Interactive TUI no longer prints "Assistant:" before each response
- [ ] Interactive TUI no longer prints "✓ Final answer received" marker
- [ ] All existing tests pass

## Test Plan

- [ ] Targeted tests: `./scripts/dev.sh test -q test/test_interactive*.py`
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "hello"` (or explain why not)

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? (3–5 invariants)
  - Users who visually relied on the "Assistant:" prefix to distinguish assistant messages. Mitigation: the panel styling already provides this.
  - Any test that asserts on the literal "Assistant:" string in output. Mitigation: no such tests exist in the test suite.
- Worst-case input/output size? Any truncation/limits?
  - No change to input/output handling or size limits.
- Any secrets/logging risks?
  - No changes to logging or secret handling.
- Any async/blocking I/O added on hot paths?
  - No new I/O; only removed print statements.
- What error message does the user see on failure? Is it actionable?
  - No new failure modes introduced.

## Docs / Compatibility

- [ ] No docs changes needed (this is a visual cleanup, not a behavior change)
- [ ] No secrets committed; no generated artifacts

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
