### PR TITLE
feat(tui): use ↑↓ arrows for cache read/write in status bar

### DIFF
--- a/ouro/interfaces/tui/status_bar.py
+++ b/ouro/interfaces/tui/status_bar.py
@@ -86,8 +86,8 @@ class StatusBar:
             cache_write = self._format_tokens(self.state.cache_creation_tokens)
             items.append(
                 f"[{colors.text_secondary}]Cache:[/{colors.text_secondary}] "
-                f"[{colors.success}]{cache_read}R[/{colors.success}] "
-                f"[{colors.warning}]{cache_write}W[/{colors.warning}]"
+                f"[{colors.success}]{cache_read}↑[/{colors.success}] "
+                f"[{colors.warning}]{cache_write}↓[/{colors.warning}]"
             )
 
         # Context Tokens


### PR DESCRIPTION
## Summary

Replace R/W suffix with ↑↓ arrows for cache counters to match the Total tokens convention.

## Scope

- Goals: consistent arrow semantics across status bar
- Non-goals: any other UI changes

## Invariants (Must Not Regress)

- [ ] Status bar still renders correctly with and without cache data
- [ ] `./scripts/dev.sh check` passes

## Acceptance Criteria

- [ ] Cache read shows ↑ (input direction)
- [ ] Cache write shows ↓ (output direction)

## Test Plan

- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Adversarial Review

- What existing behavior could this break? Only cache label formatting.
- Any secrets/logging risks? None.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)