### PR TITLE
config: increase MEMORY_COMPRESSION_THRESHOLD default from 60K to 256K

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ Settings live in `~/.ouro/config` (KEY=VALUE format, auto-created with defaults)
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `MEMORY_ENABLED` | `true` | Enable memory management |
-| `MEMORY_COMPRESSION_THRESHOLD` | `60000` | Token count that triggers compression |
+| `MEMORY_COMPRESSION_THRESHOLD` | `256000` | Token count that triggers compression |
 | `MEMORY_SHORT_TERM_MIN_SIZE` | `6` | Minimum messages to always preserve during compression |
 | `MEMORY_COMPRESSION_RATIO` | `0.3` | Target compression ratio (0.3 = 30% of original) |
 

--- a/docs/memory-management.md
+++ b/docs/memory-management.md
@@ -22,7 +22,7 @@ All settings go in `~/.ouro/config`:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `MEMORY_ENABLED` | `true` | Enable memory management |
-| `MEMORY_COMPRESSION_THRESHOLD` | `60000` | Token count that triggers compression |
+| `MEMORY_COMPRESSION_THRESHOLD` | `256000` | Token count that triggers compression |
 | `MEMORY_SHORT_TERM_MIN_SIZE` | `6` | Minimum messages always preserved during compression |
 | `MEMORY_COMPRESSION_RATIO` | `0.3` | Target compression ratio (0.3 = compress to 30%) |
 

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -97,7 +97,7 @@ class Config:
 
     # Memory Management Configuration
     MEMORY_ENABLED = _cfg.get("MEMORY_ENABLED", "true").lower() == "true"
-    MEMORY_COMPRESSION_THRESHOLD = int(_cfg.get("MEMORY_COMPRESSION_THRESHOLD", "60000"))
+    MEMORY_COMPRESSION_THRESHOLD = int(_cfg.get("MEMORY_COMPRESSION_THRESHOLD", "256000"))
     MEMORY_SHORT_TERM_MIN_SIZE = int(_cfg.get("MEMORY_SHORT_TERM_MIN_SIZE", "6"))
     MEMORY_COMPRESSION_RATIO = float(_cfg.get("MEMORY_COMPRESSION_RATIO", "0.3"))
     MEMORY_PRESERVE_SYSTEM_PROMPTS = True

--- a/ouro/interfaces/tui/components.py
+++ b/ouro/interfaces/tui/components.py
@@ -254,7 +254,7 @@ class MemoryStatsDisplay:
         empty = width - filled
         return filled_char * filled + empty_char * empty
 
-    def show(self, stats: Dict[str, Any], context_limit: int = 60000) -> None:
+    def show(self, stats: Dict[str, Any], context_limit: int = 256000) -> None:
         """Display memory statistics.
 
         Args:


### PR DESCRIPTION
## Summary

Raise the default memory compaction trigger threshold from 60K to 256K tokens to better match modern long-context LLMs.

## Scope

- Goals:
  - Update `MEMORY_COMPRESSION_THRESHOLD` default from 60000 to 256000
  - Update `context_limit` default in TUI memory stats display
  - Sync documentation defaults in `docs/configuration.md` and `docs/memory-management.md`
- Non-goals:
  - No behavior change for users who already override the config
  - No change to compaction logic itself

## Invariants (Must Not Regress)

- [ ] Config file override still works (`MEMORY_COMPRESSION_THRESHOLD=...` in `~/.ouro/config`)
- [ ] Compaction still triggers when token count exceeds threshold
- [ ] TUI memory stats display still renders correctly
- [ ] All existing tests pass

## Acceptance Criteria

- [ ] Default threshold is 256000 tokens
- [ ] Documentation reflects the new default
- [ ] `./scripts/dev.sh test -q` passes
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` passes

## Test Plan

- [ ] Targeted tests: `test/memory/test_memory_manager.py`
- [ ] `./scripts/dev.sh test -q` — 642 passed, 1 skipped
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` — no issues

## Smoke Run (Real CLI)

- [ ] Not needed — config default change only, no CLI behavior change

## Adversarial Review

- **What existing behavior could this break?**
  - Users relying on the old 60K default will see later compaction. This is intentional.
  - No breaking change for users with explicit config overrides.
- **Worst-case input/output size?**
  - Max context before compaction is now ~256K tokens. For models with smaller context windows, users should set a lower threshold explicitly.
- **Any secrets/logging risks?**
  - None — only numeric defaults changed.
- **Any async/blocking I/O added on hot paths?**
  - None.
- **What error message does the user see on failure?**
  - N/A — no new failure modes.

## Docs / Compatibility

- [x] Updated `docs/configuration.md`
- [x] Updated `docs/memory-management.md`
- [x] No secrets committed

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)