### PR TITLE
fix(tui): restore status bar state on session resume + add session prefix

### DIFF
--- a/ouro/interfaces/tui/interactive.py
+++ b/ouro/interfaces/tui/interactive.py
@@ -330,6 +330,8 @@ class InteractiveSession:
         stats = self.agent.get_memory_stats()
         model_info = self.agent.get_current_model_info()
         model_name = model_info["name"] if model_info else ""
+        session_id = self.agent.session_id or ""
+        session_prefix = session_id[:8] if session_id else ""
         self.status_bar.update(
             input_tokens=stats.get("total_input_tokens", 0),
             output_tokens=stats.get("total_output_tokens", 0),
@@ -339,6 +341,7 @@ class InteractiveSession:
             model_name=model_name,
             cache_read_tokens=stats.get("cache_read_tokens", 0),
             cache_creation_tokens=stats.get("cache_creation_tokens", 0),
+            session_prefix=session_prefix,
         )
 
     async def _handle_command(self, user_input: str) -> bool | None:
@@ -808,8 +811,9 @@ class InteractiveSession:
             f"[{colors.text_muted}]Tip: Type '/' for command suggestions, Ctrl+T to toggle thinking display[/{colors.text_muted}]\n"
         )
 
-        # Show initial status bar
+        # Show initial status bar (reflect resumed session state if any)
         if Config.TUI_STATUS_BAR:
+            self._update_status_bar()
             self.status_bar.show()
 
         try:

--- a/ouro/interfaces/tui/status_bar.py
+++ b/ouro/interfaces/tui/status_bar.py
@@ -25,6 +25,7 @@ class StatusBarState:
     model_name: str = ""
     cache_read_tokens: int = 0
     cache_creation_tokens: int = 0
+    session_prefix: str = ""
 
 
 class StatusBar:
@@ -66,6 +67,12 @@ class StatusBar:
 
         # Build status items
         items = []
+
+        # Session prefix (if set)
+        if self.state.session_prefix:
+            items.append(
+                f"[{colors.text_secondary}]Session:[/{colors.text_secondary}] [{colors.primary}]{self.state.session_prefix}[/{colors.primary}]"
+            )
 
         # Model name (if set)
         if self.state.model_name:
@@ -132,6 +139,7 @@ class StatusBar:
         model_name: Optional[str] = None,
         cache_read_tokens: Optional[int] = None,
         cache_creation_tokens: Optional[int] = None,
+        session_prefix: Optional[str] = None,
     ) -> None:
         """Update status bar state.
 
@@ -145,6 +153,7 @@ class StatusBar:
             model_name: Current model name
             cache_read_tokens: Total cache read tokens
             cache_creation_tokens: Total cache creation (write) tokens
+            session_prefix: Current session prefix
         """
         if input_tokens is not None:
             self.state.input_tokens = input_tokens
@@ -164,6 +173,8 @@ class StatusBar:
             self.state.cache_read_tokens = cache_read_tokens
         if cache_creation_tokens is not None:
             self.state.cache_creation_tokens = cache_creation_tokens
+        if session_prefix is not None:
+            self.state.session_prefix = session_prefix
 
         # Refresh live display if active
         if self._live is not None:


### PR DESCRIPTION
## Summary

修复 session resume 后状态栏状态丢失的问题，并在状态栏上增加 session prefix 显示。

## Scope

- Goals:
  - `--resume` 或 `/resume` 恢复 session 后，状态栏立即显示正确的 token/cost/context 等统计信息
  - 状态栏上显示当前 session 的前 8 位前缀（如 `Session: a1b2c3d4`），方便用户识别当前 session
- Non-goals:
  - 不改变状态栏的其他显示逻辑或样式
  - 不修改 session 持久化/恢复的核心逻辑

## Invariants (Must Not Regress)

- [ ] 正常新会话启动时状态栏仍正确显示
- [ ] `/reset` 后状态栏清零并正常显示
- [ ] `/compact` 后状态栏更新正常
- [ ] 状态栏的 Model/Cost/Cache/Context/Comp 等字段显示不受影响
- [ ] TUI 的 import-linter 三层架构约束不被破坏

## Acceptance Criteria

- [ ] `ouro-cli --resume <session_prefix>` 启动后，状态栏显示恢复 session 的实际统计值（而非全 0）
- [ ] 交互模式下 `/resume <session_prefix>` 后，状态栏同步更新
- [ ] 状态栏最左侧显示 `Session: xxxxxxxx`（session_id 前 8 位）
- [ ] 无 session 时（如全新会话），不显示 Session 字段

## Test Plan

- [ ] Targeted tests: `./scripts/dev.sh test -q test/test_interactive*.py`
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --resume <latest_session_prefix>` 确认状态栏显示正确

## Adversarial Review (Answer Briefly)

- **What existing behavior could this break?**
  - 初始状态栏显示时机：从直接 `show()` 改为先 `_update_status_bar()` 再 `show()`。如果 `_update_status_bar()` 抛异常，可能导致启动失败。但 `_update_status_bar()` 只读取 agent 的 stats/model/session_id，这些属性在 agent 初始化后始终存在。
- **Worst-case input/output size? Any truncation/limits?**
  - session_prefix 固定取前 8 位，不受 session_id 长度影响。
- **Any secrets/logging risks?**
  - session_id 是 UUID，前 8 位不包含敏感信息。
- **Any async/blocking I/O added on hot paths?**
  - 无，改动全在同步代码路径。
- **What error message does the user see on failure?**
  - 无新增用户可见错误路径。

## Docs / Compatibility

- [ ] 无需更新外部文档（纯 UI 修复）
- [ ] 无 secrets / generated artifacts 提交

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)