### PR TITLE
fix: persist and restore token usage stats on session resume

### DIFF
--- a/ouro/capabilities/memory/manager.py
+++ b/ouro/capabilities/memory/manager.py
@@ -109,6 +109,28 @@ class MemoryManager:
             system_messages=session_data.get("system_messages") or [],
             detached=session_data.get("messages") or [],
         )
+
+        # Restore token usage statistics if present
+        token_stats = session_data.get("token_stats")
+        if token_stats:
+            manager.token_tracker.total_input_tokens = token_stats.get("total_input_tokens", 0)
+            manager.token_tracker.total_output_tokens = token_stats.get("total_output_tokens", 0)
+            manager.token_tracker.total_cache_read_tokens = token_stats.get(
+                "total_cache_read_tokens", 0
+            )
+            manager.token_tracker.total_cache_creation_tokens = token_stats.get(
+                "total_cache_creation_tokens", 0
+            )
+            manager.token_tracker.compression_savings = token_stats.get("compression_savings", 0)
+            manager.token_tracker.compression_cost = token_stats.get("compression_cost", 0)
+            logger.info(
+                f"Restored token stats for session {session_id}: "
+                f"input={manager.token_tracker.total_input_tokens}, "
+                f"output={manager.token_tracker.total_output_tokens}, "
+                f"cache_read={manager.token_tracker.total_cache_read_tokens}, "
+                f"cache_creation={manager.token_tracker.total_cache_creation_tokens}"
+            )
+
         logger.info(
             f"Loaded session {session_id}: "
             f"{len(context.detached)} messages, "
@@ -202,10 +224,21 @@ class MemoryManager:
             logger.debug("Skipping save_memory: no session created")
             return
 
+        # Build token stats snapshot for persistence
+        token_stats = {
+            "total_input_tokens": self.token_tracker.total_input_tokens,
+            "total_output_tokens": self.token_tracker.total_output_tokens,
+            "total_cache_read_tokens": self.token_tracker.total_cache_read_tokens,
+            "total_cache_creation_tokens": self.token_tracker.total_cache_creation_tokens,
+            "compression_savings": self.token_tracker.compression_savings,
+            "compression_cost": self.token_tracker.compression_cost,
+        }
+
         await self._store.save_memory(
             session_id=self.session_id,
             system_messages=sys_msgs,
             messages=messages,
+            token_stats=token_stats,
         )
         # Reindex FTS recall — best-effort, never blocks the save path.
         try:

--- a/ouro/capabilities/memory/store/memory_store.py
+++ b/ouro/capabilities/memory/store/memory_store.py
@@ -40,6 +40,7 @@ class MemoryStore(ABC):
         session_id: str,
         system_messages: List[LLMMessage],
         messages: List[LLMMessage],
+        token_stats: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Save complete memory state (replaces existing data).
 
@@ -47,6 +48,7 @@ class MemoryStore(ABC):
             session_id: Session ID
             system_messages: List of system messages
             messages: List of regular messages
+            token_stats: Optional token usage statistics to persist
         """
 
     @abstractmethod

--- a/ouro/capabilities/memory/store/yaml_file_memory_store.py
+++ b/ouro/capabilities/memory/store/yaml_file_memory_store.py
@@ -247,6 +247,7 @@ class YamlFileMemoryStore(MemoryStore):
         session_id: str,
         system_messages: List[LLMMessage],
         messages: List[LLMMessage],
+        token_stats: Optional[Dict[str, Any]] = None,
     ) -> None:
         dir_name = await self._resolve_session_dir(session_id)
         if not dir_name:
@@ -269,6 +270,13 @@ class YamlFileMemoryStore(MemoryStore):
             data["messages"] = messages_list
 
             data["updated_at"] = datetime.now().isoformat()
+
+            # Persist token usage statistics if provided
+            if token_stats is not None:
+                data["token_stats"] = token_stats
+            elif "token_stats" in data:
+                # Preserve existing token_stats if not explicitly cleared
+                pass
 
             await self._save_session_data(dir_name, data)
 
@@ -298,6 +306,7 @@ class YamlFileMemoryStore(MemoryStore):
             "stats": {
                 "created_at": data.get("created_at", ""),
             },
+            "token_stats": data.get("token_stats"),
         }
 
     async def list_sessions(self, limit: int = 50, offset: int = 0) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

Fix the issue where ouro-cli status bar shows 0 for Total, Cache, and Cost after resuming a session via `/resume`.

## Scope

- Goals: Persist token usage statistics (input/output/cache/compression) alongside session messages, and restore them when loading a session.
- Non-goals: Change token tracking logic, change session file format version, or modify the TUI status bar rendering.

## Invariants (Must Not Regress)

- [ ] Session save/load still works for existing sessions without token_stats.
- [ ] MemoryStore interface backward compatibility (token_stats is optional).
- [ ] TokenTracker cumulative counters remain accurate across new turns after resume.
- [ ] No changes to YAML session file structure beyond the new optional `token_stats` field.

## Acceptance Criteria

- [ ] After `/resume`, status bar displays correct total input/output tokens.
- [ ] After `/resume`, status bar displays correct cache read/creation tokens.
- [ ] After `/resume`, status bar displays correct accumulated cost.
- [ ] New sessions continue to work normally (token_stats absent until first save).

## Test Plan

- [ ] Targeted tests: `./scripts/dev.sh test -q test/memory/`
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] Start a session, send a few messages, note the token stats in the status bar.
- [ ] Exit and run `ouro-cli --resume <session_prefix>`.
- [ ] Verify status bar shows the same (non-zero) token/cost values as before.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Sessions saved before this change lack `token_stats`; they load with zeroed stats (same as before), which is expected.
- Worst-case input/output size? Token stats dict is small (~6 integer fields), negligible overhead.
- Any secrets/logging risks? No; token counts are not sensitive.
- Any async/blocking I/O added on hot paths? No; save/load are already async.
- What error message does the user see on failure? Same as before; token_stats is best-effort and silently absent if missing.

## Docs / Compatibility

- [ ] No docs changes needed; this is a bug fix for expected behavior.
- [ ] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)