### PR TITLE
feat(memory): incremental session persistence

### DIFF
--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -37,6 +37,7 @@ from ouro.core.loop import (
 from .compaction.hook import CompactionHook
 from .context.agents_md import load_agents_md
 from .context.env import format_context_prompt
+from .memory.hook import SessionPersistenceHook
 from .memory.manager import MemoryManager
 from .prompts import DEFAULT_SYSTEM_PROMPT
 from .rules import NestedAgentsMdRule, ReadBeforeWriteRule
@@ -300,6 +301,7 @@ class AgentBuilder:
             )
             memory.set_todo_context_provider(_make_todo_context_provider(todo_list))
             hooks.append(CompactionHook(memory.compaction))
+            hooks.append(SessionPersistenceHook(memory))
 
         # Verification hook (off by default).
         if self.verification_max_iterations > 0:

--- a/ouro/capabilities/memory/hook.py
+++ b/ouro/capabilities/memory/hook.py
@@ -37,6 +37,20 @@ class SessionPersistenceHook:
         """Reset incremental counter at the start of every run."""
         self._last_saved_count = 0
 
+    async def _persist_batch(self, messages: list[Any]) -> None:
+        """Best-effort persistence of a batch of messages."""
+        for msg in messages:
+            try:
+                await self.memory.save_single_message(msg)
+            except Exception:  # noqa: PERF203
+                # Each message is independent; one failure must not
+                # prevent the rest from persisting.
+                logger.warning(
+                    "Failed to incrementally save message for session %s",
+                    self.memory.session_id,
+                    exc_info=True,
+                )
+
     async def on_iteration_end(
         self,
         ctx: LoopContext,
@@ -49,26 +63,41 @@ class SessionPersistenceHook:
         This runs after every iteration (both TOOL_CALLS and STOP),
         ensuring that assistant messages and tool results are flushed
         to disk before the next LLM call.
+
+        When compaction shortens the message list mid-turn, we fall
+        back to a full messages replacement so the persisted state
+        stays consistent.
         """
         if self.memory.session_id is None:
             return ContinueDecision.cont()
 
         current_count = len(messages.snapshot())
+
+        if current_count < self._last_saved_count:
+            # Compaction happened: the message list was replaced with a
+            # shorter summary.  Do a full replacement rather than
+            # incremental append so session.yaml stays consistent.
+            try:
+                await self.memory.replace_messages(messages.snapshot())
+            except Exception:
+                logger.warning(
+                    "Failed to replace messages after compaction for session %s",
+                    self.memory.session_id,
+                    exc_info=True,
+                )
+            self._last_saved_count = current_count
+            logger.debug(
+                "Replaced messages after compaction for session %s (%d messages)",
+                self.memory.session_id,
+                current_count,
+            )
+            return ContinueDecision.cont()
+
         if current_count <= self._last_saved_count:
             return ContinueDecision.cont()
 
         new_messages = messages.snapshot()[self._last_saved_count :]
-        for msg in new_messages:
-            try:
-                await self.memory.save_single_message(msg)
-            except Exception:  # noqa: PERF203
-                # Best-effort: each message is independent; one failure
-                # must not prevent the rest from persisting.
-                logger.warning(
-                    "Failed to incrementally save message for session %s",
-                    self.memory.session_id,
-                    exc_info=True,
-                )
+        await self._persist_batch(new_messages)
 
         self._last_saved_count = current_count
         logger.debug(

--- a/ouro/capabilities/memory/hook.py
+++ b/ouro/capabilities/memory/hook.py
@@ -1,0 +1,79 @@
+"""SessionPersistenceHook — incremental session persistence on every message.
+
+Wires MemoryManager into the core loop so that each new message is
+appended to session.yaml immediately, rather than waiting until the
+entire turn finishes.  This gives crash-safety for long multi-tool
+runs and for long-lived bot processes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ouro.core.log import get_logger
+from ouro.core.loop.message_list import MessageList
+from ouro.core.loop.protocols import ContinueDecision, LoopContext
+
+from .manager import MemoryManager
+
+logger = get_logger(__name__)
+
+
+class SessionPersistenceHook:
+    """Incrementally persist conversation messages to disk.
+
+    Structurally satisfies the ``core.loop.Hook`` Protocol via
+    ``on_run_start`` and ``on_iteration_end``.  We deliberately *don't*
+    inherit from ``Hook``: Protocol method bodies are ``...`` which at
+    runtime resolves to ``return None``.  Inheriting would supply no-op
+    stubs for every lifecycle method.
+    """
+
+    def __init__(self, memory: MemoryManager) -> None:
+        self.memory = memory
+        self._last_saved_count: int = 0
+
+    async def on_run_start(self, ctx: LoopContext, messages: MessageList) -> None:
+        """Reset incremental counter at the start of every run."""
+        self._last_saved_count = 0
+
+    async def on_iteration_end(
+        self,
+        ctx: LoopContext,
+        messages: MessageList,
+        response: Any,
+        finished: bool,
+    ) -> ContinueDecision:
+        """Persist any messages that have been appended since last save.
+
+        This runs after every iteration (both TOOL_CALLS and STOP),
+        ensuring that assistant messages and tool results are flushed
+        to disk before the next LLM call.
+        """
+        if self.memory.session_id is None:
+            return ContinueDecision.cont()
+
+        current_count = len(messages.snapshot())
+        if current_count <= self._last_saved_count:
+            return ContinueDecision.cont()
+
+        new_messages = messages.snapshot()[self._last_saved_count :]
+        for msg in new_messages:
+            try:
+                await self.memory.save_single_message(msg)
+            except Exception:  # noqa: PERF203
+                # Best-effort: each message is independent; one failure
+                # must not prevent the rest from persisting.
+                logger.warning(
+                    "Failed to incrementally save message for session %s",
+                    self.memory.session_id,
+                    exc_info=True,
+                )
+
+        self._last_saved_count = current_count
+        logger.debug(
+            "Incrementally saved %d message(s) for session %s",
+            len(new_messages),
+            self.memory.session_id,
+        )
+        return ContinueDecision.cont()

--- a/ouro/capabilities/memory/manager.py
+++ b/ouro/capabilities/memory/manager.py
@@ -24,6 +24,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ouro.capabilities.compaction import CompactionManager
+from ouro.core.llm.message_types import LLMMessage
 from ouro.core.loop import MessageListContext
 from ouro.core.loop.protocols import NullProgressSink, ProgressSink
 
@@ -202,6 +203,22 @@ class MemoryManager:
     # ------------------------------------------------------------------
     # Operations on a MessageListContext
     # ------------------------------------------------------------------
+
+    async def save_single_message(self, message: LLMMessage, tokens: int = 0) -> None:
+        """Persist a single message incrementally.
+
+        Used by ``SessionPersistenceHook`` to flush messages to disk
+        after every iteration, rather than waiting for the end of the
+        turn.  Lazily creates the session on first call.
+        """
+        if not self._session_created:
+            await self._ensure_session()
+
+        if not self._store or not self._session_created or not self.session_id:
+            logger.debug("Skipping save_single_message: no session created")
+            return
+
+        await self._store.save_message(self.session_id, message, tokens)
 
     async def save_memory(self, *, context: MessageListContext) -> None:
         """Persist the conversation snapshot to disk.

--- a/ouro/capabilities/memory/manager.py
+++ b/ouro/capabilities/memory/manager.py
@@ -220,6 +220,22 @@ class MemoryManager:
 
         await self._store.save_message(self.session_id, message, tokens)
 
+    async def replace_messages(self, messages: list[LLMMessage]) -> None:
+        """Replace the entire messages list in session storage.
+
+        Used when compaction shortens the message list, to keep the
+        persisted state consistent with the in-memory state without
+        losing system_messages or token_stats.
+        """
+        if not self._session_created:
+            await self._ensure_session()
+
+        if not self._store or not self._session_created or not self.session_id:
+            logger.debug("Skipping replace_messages: no session created")
+            return
+
+        await self._store.replace_messages(self.session_id, messages)
+
     async def save_memory(self, *, context: MessageListContext) -> None:
         """Persist the conversation snapshot to disk.
 

--- a/ouro/capabilities/memory/store/memory_store.py
+++ b/ouro/capabilities/memory/store/memory_store.py
@@ -52,6 +52,19 @@ class MemoryStore(ABC):
         """
 
     @abstractmethod
+    async def replace_messages(self, session_id: str, messages: List[LLMMessage]) -> None:
+        """Replace only the messages list, preserving system_messages and token_stats.
+
+        Used by SessionPersistenceHook when compaction shortens the
+        message list, to do a full refresh without losing system
+        messages or accumulated token statistics.
+
+        Args:
+            session_id: Session ID
+            messages: New message list (replaces existing)
+        """
+
+    @abstractmethod
     async def load_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Load complete session state.
 

--- a/ouro/capabilities/memory/store/yaml_file_memory_store.py
+++ b/ouro/capabilities/memory/store/yaml_file_memory_store.py
@@ -286,6 +286,31 @@ class YamlFileMemoryStore(MemoryStore):
             f"{len(messages)} messages"
         )
 
+    async def replace_messages(self, session_id: str, messages: List[LLMMessage]) -> None:
+        """Replace only the messages list, preserving system_messages and token_stats."""
+        dir_name = await self._resolve_session_dir(session_id)
+        if not dir_name:
+            logger.warning(f"Session {session_id} not found")
+            return
+
+        async with self._write_lock:
+            data = await self._load_session_data(dir_name)
+            if not data:
+                logger.warning(f"Session {session_id} not found")
+                return
+
+            messages_list = []
+            for msg in messages:
+                msg_data = serialize_message(msg)
+                msg_data["tokens"] = 0
+                messages_list.append(msg_data)
+            data["messages"] = messages_list
+            data["updated_at"] = datetime.now().isoformat()
+
+            await self._save_session_data(dir_name, data)
+
+        logger.debug(f"Replaced messages for session {session_id}: {len(messages)} messages")
+
     async def load_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         dir_name = await self._resolve_session_dir(session_id)
         if not dir_name:

--- a/test/memory/test_session_persistence_hook.py
+++ b/test/memory/test_session_persistence_hook.py
@@ -1,0 +1,116 @@
+"""Unit tests for SessionPersistenceHook.
+
+Verifies that the hook incrementally persists messages after every
+iteration, rather than waiting until the end of the turn.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ouro.capabilities.memory.hook import SessionPersistenceHook
+from ouro.capabilities.memory.manager import MemoryManager
+from ouro.core.llm.base import LLMMessage
+from ouro.core.loop.message_list import MessageList
+from ouro.core.loop.protocols import ContinueDecision, LoopContext
+
+
+@pytest.fixture
+def mock_loop_ctx():
+    """Minimal LoopContext for hook tests."""
+    ctx = AsyncMock(spec=LoopContext)
+    ctx.progress = AsyncMock()
+    ctx.task = "test task"
+    return ctx
+
+
+class TestSessionPersistenceHook:
+    async def test_on_run_start_resets_counter(self, mock_llm, mock_loop_ctx):
+        """Counter should reset to 0 at the start of each run."""
+        memory = MemoryManager(mock_llm)
+        hook = SessionPersistenceHook(memory)
+        hook._last_saved_count = 5
+
+        messages = MessageList()
+        await hook.on_run_start(mock_loop_ctx, messages)
+
+        assert hook._last_saved_count == 0
+
+    async def test_on_iteration_end_saves_new_messages(self, mock_llm, mock_loop_ctx):
+        """New messages since last save should be persisted incrementally."""
+        memory = MemoryManager(mock_llm)
+        # Create a session so session_id is set
+        await memory._ensure_session()
+        assert memory.session_id is not None
+
+        hook = SessionPersistenceHook(memory)
+        messages = MessageList()
+        messages.append(LLMMessage(role="user", content="hello"))
+        messages.append(LLMMessage(role="assistant", content="hi"))
+
+        result = await hook.on_iteration_end(mock_loop_ctx, messages, response=None, finished=False)
+
+        # Should return CONTINUE (not STOP)
+        assert result.kind == ContinueDecision.cont().kind
+        # Both messages should have been saved
+        assert hook._last_saved_count == 2
+
+        # Verify by loading back
+        loaded = await memory._store.load_session(memory.session_id)
+        assert len(loaded["messages"]) == 2
+        assert loaded["messages"][0].content == "hello"
+        assert loaded["messages"][1].content == "hi"
+
+    async def test_on_iteration_end_skips_when_no_new_messages(self, mock_llm, mock_loop_ctx):
+        """If no messages were added, nothing should be saved."""
+        memory = MemoryManager(mock_llm)
+        await memory._ensure_session()
+
+        hook = SessionPersistenceHook(memory)
+        hook._last_saved_count = 0
+        messages = MessageList()
+
+        result = await hook.on_iteration_end(mock_loop_ctx, messages, response=None, finished=False)
+
+        assert result.kind == ContinueDecision.cont().kind
+        assert hook._last_saved_count == 0
+
+    async def test_on_iteration_end_only_saves_increment(self, mock_llm, mock_loop_ctx):
+        """Only messages appended since last save should be persisted."""
+        memory = MemoryManager(mock_llm)
+        await memory._ensure_session()
+
+        hook = SessionPersistenceHook(memory)
+        messages = MessageList()
+        messages.append(LLMMessage(role="user", content="first"))
+
+        # First save
+        await hook.on_iteration_end(mock_loop_ctx, messages, None, False)
+        assert hook._last_saved_count == 1
+
+        # Add more messages
+        messages.append(LLMMessage(role="assistant", content="second"))
+        messages.append(LLMMessage(role="user", content="third"))
+
+        # Second save — should only persist the 2 new ones
+        await hook.on_iteration_end(mock_loop_ctx, messages, None, False)
+        assert hook._last_saved_count == 3
+
+        loaded = await memory._store.load_session(memory.session_id)
+        assert len(loaded["messages"]) == 3
+        assert [m.content for m in loaded["messages"]] == ["first", "second", "third"]
+
+    async def test_on_iteration_end_no_session_id(self, mock_llm, mock_loop_ctx):
+        """If memory has no session_id, hook should silently continue."""
+        memory = MemoryManager(mock_llm)
+        # session_id is None by default
+        assert memory.session_id is None
+
+        hook = SessionPersistenceHook(memory)
+        messages = MessageList()
+        messages.append(LLMMessage(role="user", content="hello"))
+
+        result = await hook.on_iteration_end(mock_loop_ctx, messages, response=None, finished=False)
+
+        assert result.kind == ContinueDecision.cont().kind
+        assert hook._last_saved_count == 0  # unchanged

--- a/test/memory/test_session_persistence_hook.py
+++ b/test/memory/test_session_persistence_hook.py
@@ -114,3 +114,30 @@ class TestSessionPersistenceHook:
 
         assert result.kind == ContinueDecision.cont().kind
         assert hook._last_saved_count == 0  # unchanged
+
+    async def test_on_iteration_end_after_compaction(self, mock_llm, mock_loop_ctx):
+        """When compaction shortens the list, do a full replacement."""
+        memory = MemoryManager(mock_llm)
+        await memory._ensure_session()
+
+        hook = SessionPersistenceHook(memory)
+        messages = MessageList()
+        messages.append(LLMMessage(role="user", content="a"))
+        messages.append(LLMMessage(role="assistant", content="b"))
+        messages.append(LLMMessage(role="user", content="c"))
+
+        # Save all 3
+        await hook.on_iteration_end(mock_loop_ctx, messages, None, False)
+        assert hook._last_saved_count == 3
+
+        # Simulate compaction: replace with a shorter summary
+        messages.replace([LLMMessage(role="assistant", content="summary")])
+
+        # Hook should detect list got shorter and do full replacement
+        result = await hook.on_iteration_end(mock_loop_ctx, messages, None, False)
+        assert result.kind == ContinueDecision.cont().kind
+        assert hook._last_saved_count == 1
+
+        loaded = await memory._store.load_session(memory.session_id)
+        assert len(loaded["messages"]) == 1
+        assert loaded["messages"][0].content == "summary"


### PR DESCRIPTION
## Summary

Add `SessionPersistenceHook` that flushes each new message to `session.yaml` immediately after every iteration, rather than waiting until the end of the turn. This gives crash-safety for long multi-tool runs and for long-lived bot processes.

## Scope

- **Goals:**
  - Persist messages incrementally (after every iteration)
  - Bot/session crash recovery: resume from last saved state
  - Zero configuration: default on when memory is enabled

- **Non-goals:**
  - Remove or change the end-of-turn `save_memory()` call
  - Add user-facing toggle (can be added later if needed)
  - Change session.yaml format

## Invariants (Must Not Regress)

- [ ] Session YAML format stays backward-compatible
- [ ] `ComposedAgent.run()` still calls `save_memory()` at end of turn
- [ ] Persistence errors never break the agent loop
- [ ] `import-linter` three-layer contract is preserved
- [ ] All existing memory tests pass

## Acceptance Criteria

- [ ] After each iteration, newly appended messages are saved to session.yaml
- [ ] `on_run_start` resets the incremental counter for each new turn
- [ ] Loading a session recovers all incrementally saved messages
- [ ] Hook is auto-registered when `memory_enabled=True` in `AgentBuilder`

## Test Plan

- [ ] Targeted tests: `test/memory/test_session_persistence_hook.py`
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python -m ouro.interfaces.cli.entry --task "What is 2+2?" --verify`

## Adversarial Review

- **What existing behavior could this break?**
  - Disk I/O per iteration increases (one YAML rewrite per iteration). Mitigation: sessions are small; aiofiles + atomic write is fast.
  - If `save_message()` has a bug, it could corrupt session.yaml. Mitigation: atomic tmp+replace; existing tests cover YAML backend.
  - Hook ordering: `SessionPersistenceHook` runs after `CompactionHook` (which may replace messages). The hook saves the post-compaction state, which is correct.

- **Worst-case input/output size?**
  - Each iteration appends 1 assistant message + N tool results. YAML file grows linearly with iteration count. Existing compaction keeps this bounded.

- **Secrets/logging risks?**
  - None new. Message content is already persisted to disk; this only changes timing.

- **Async/blocking I/O on hot paths?**
  - `save_message()` uses `aiofiles` + `asyncio.to_thread(os.replace)`. No blocking I/O on the event loop.

- **What error message does the user see on failure?**
  - Persistence failures are logged at `WARNING` level with exc_info; the loop continues uninterrupted.

## Docs / Compatibility

- [ ] No docs update needed (behavioral change, no new API)
- [ ] No secrets committed

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)