### PR TITLE
cli: print session id on interactive exit

### DIFF
--- a/ouro/interfaces/cli/main.py
+++ b/ouro/interfaces/cli/main.py
@@ -297,7 +297,11 @@ def main():
 
         print(result)
 
-    asyncio.run(_run())
+    try:
+        asyncio.run(_run())
+    finally:
+        if not args.task and agent.session_id:
+            terminal_ui.print_info(f"Session ID: {agent.session_id}")
 
 
 if __name__ == "__main__":

--- a/test/test_main_auth_cli.py
+++ b/test/test_main_auth_cli.py
@@ -224,6 +224,68 @@ def test_main_logout_when_no_state(monkeypatch):
     assert calls["info"][0] == "No chatgpt login state found."
 
 
+def test_main_does_not_print_session_id_after_task_run(monkeypatch):
+    calls, _ = _setup_common(monkeypatch, ["--task", "hello"])
+    agent = SimpleNamespace(
+        session_id="12345678-1234-1234-1234-123456789abc",
+        skills_registry=None,
+        llm=object(),
+        _core=SimpleNamespace(add_hook=lambda hook: None),
+        set_reasoning_effort=lambda effort: None,
+        run=None,
+    )
+
+    async def fake_load():
+        return None
+
+    async def fake_run(task: str, verify: bool = False):
+        assert task == "hello"
+        assert verify is False
+        return "done"
+
+    agent.run = fake_run
+
+    monkeypatch.setattr(ouro_main.Config, "validate", staticmethod(lambda: None))
+    monkeypatch.setattr(ouro_main, "create_agent", lambda model_id=None: agent)
+    monkeypatch.setattr(ouro_main, "SkillsRegistry", lambda: SimpleNamespace(load=fake_load))
+
+    printed: list[str] = []
+    monkeypatch.setattr(
+        "builtins.print", lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args))
+    )
+
+    ouro_main.main()
+
+    assert printed == ["done"]
+    assert "Session ID: 12345678-1234-1234-1234-123456789abc" not in calls["info"]
+
+
+def test_main_prints_session_id_after_interactive_mode(monkeypatch):
+    calls, _ = _setup_common(monkeypatch, [])
+    agent = SimpleNamespace(
+        session_id="abcdefab-cdef-cdef-cdef-abcdefabcdef",
+        set_reasoning_effort=lambda effort: None,
+        load_session=None,
+    )
+
+    async def fake_interactive_mode(passed_agent):
+        assert passed_agent is agent
+        return None
+
+    async def fake_load_session(session_id: str):
+        agent.session_id = session_id
+
+    agent.load_session = fake_load_session
+
+    monkeypatch.setattr(ouro_main.Config, "validate", staticmethod(lambda: None))
+    monkeypatch.setattr(ouro_main, "create_agent", lambda model_id=None: agent)
+    monkeypatch.setattr(ouro_main, "run_interactive_mode", fake_interactive_mode)
+
+    ouro_main.main()
+
+    assert calls["info"][-1] == "Session ID: abcdefab-cdef-cdef-cdef-abcdefabcdef"
+
+
 async def test_pick_auth_provider_cli_filters_for_logout(monkeypatch):
     state = {"providers": None}
 


### PR DESCRIPTION
## Summary

- print the current session id when `ouro-cli` exits from interactive mode
- keep default `--task` runs unchanged so they do not print a session id on exit
- add CLI tests covering interactive and task exit behavior

## Scope

- Goals:
  - Show users the current session id when leaving interactive mode
  - Preserve existing `--task` output behavior
- Non-goals:
  - No change to session persistence semantics
  - No new CLI flags or resume flow changes

## Invariants (Must Not Regress)

- [x] `ouro-cli --task \"...\"` still prints only the task result by default
- [x] Interactive mode still exits normally without changing commands/keybindings
- [x] Existing login/logout CLI flows remain unchanged
- [x] No cross-layer architecture violations are introduced

## Acceptance Criteria

- [x] Interactive `ouro-cli` exit prints `Session ID: <id>` when a session exists
- [x] Default `ouro-cli --task ...` exit does not print a session id
- [x] Behavior is covered by deterministic CLI tests

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_main_auth_cli.py`
- [x] `./scripts/dev.sh test -q`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "<...>" --verify` (not run; this change is covered by deterministic CLI tests and full `./scripts/dev.sh check`)

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? (3–5 invariants)
  - interactive exit output formatting
  - `--task` output cleanliness
  - login/logout early-return flows
  - resume/session-id handling during shutdown
- Worst-case input/output size? Any truncation/limits?
  - constant-size extra line on interactive exit only
- Any secrets/logging risks?
  - prints session id already used for resume; no new secret material
- Any async/blocking I/O added on hot paths?
  - no
- What error message does the user see on failure? Is it actionable?
  - unchanged from existing CLI behavior

## Docs / Compatibility

- [x] Updated relevant docs (`README.md`, `docs/examples.md`, `docs/configuration.md`) when needed
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)

## Context Hygiene (Avoid Token/Attention Waste)

Small, localized CLI-only change with targeted tests.

## CI

GitHub Actions runs `./scripts/dev.sh precommit`, `./scripts/dev.sh test -q`, and strict typecheck on PRs.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)