### PR TITLE
[codex] Update subscription model discovery

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -34,7 +34,7 @@ models:
   anthropic/claude-sonnet-4:
     api_key: sk-ant-...
 
-  chatgpt/gpt-5.2-codex:
+  chatgpt/gpt-5.4:
     timeout: 600
 
   ollama/llama2:
@@ -45,7 +45,7 @@ current: openai/gpt-4o
 ```
 
 For `chatgpt/*` subscription models, run `ouro --login` (or `/login` in interactive mode) and select provider before use.
-OAuth models shown in `/model` are seeded from ouro's bundled catalog (synced from pi-ai `openai-codex` model list).
+OAuth models shown in `/model` are refreshed dynamically at login.
 Login uses a browser-based OAuth (PKCE) flow with a localhost callback server. If browser auto-open fails, ouro prints a URL you can open manually (for remote machines, SSH port-forwarding may be required).
 
 See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for the full list. For advanced OAuth overrides, see [Configuration](configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ models:
   openai/gpt-4o:
     api_key: sk-...
 
-  chatgpt/gpt-5.2-codex:
+  chatgpt/gpt-5.4:
     timeout: 600
 
   ollama/llama2:
@@ -55,7 +55,7 @@ For `chatgpt/*` models, login with OAuth before first use:
 - Interactive: `/login` (then pick provider)
 - Logout: `ouro --logout` or `/logout`
 - After login, use `/model` to pick one of the added `chatgpt/*` models.
-- The added set comes from ouro's bundled OAuth catalog (synced from pi-ai `openai-codex` model list).
+- The added set is refreshed dynamically at login. ChatGPT models are discovered from pi-ai `openai-codex` plus ChatGPT subscription models documented by OpenAI and supported by LiteLLM; Copilot models are discovered from GitHub's supported-models docs.
 
 Login uses a browser-based OAuth (PKCE) flow with a localhost callback server, which works in workspaces that disable the OAuth device-code grant. If browser launch is blocked, ouro prints a URL you can open manually. For remote machines, you may need SSH port-forwarding to reach the localhost callback server.
 
@@ -91,6 +91,8 @@ Settings live in `~/.ouro/config` (KEY=VALUE format, auto-created with defaults)
 | `MAX_ITERATIONS` | `1000` | Maximum agent loop iterations |
 | `TOOL_TIMEOUT` | `600` | Tool execution timeout in seconds |
 | `RALPH_LOOP_MAX_ITERATIONS` | `3` | Max Ralph verification attempts |
+| `OAUTH_MODEL_DYNAMIC_REFRESH` | `true` | Refresh ChatGPT/Copilot model lists at login; set to `false` to use the bundled catalog instead |
+| `OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS` | `10` | HTTP timeout for dynamic OAuth model discovery |
 
 ### Memory
 

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -29,6 +29,11 @@ MAX_ITERATIONS=1000
 # Commit / PR attribution: append "Co-Authored-By: ouro" to commits and
 # "Generated with ouro" to PR bodies the agent authors. Set to false to disable.
 # ATTRIBUTION_ENABLED=true
+
+# OAuth model discovery: refresh ChatGPT/Copilot model lists at login and fall
+# back to the bundled offline catalog if discovery fails.
+# OAUTH_MODEL_DYNAMIC_REFRESH=true
+# OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS=10
 """
 
 
@@ -89,6 +94,12 @@ class Config:
 
     # Commit / PR attribution (append ouro trailers to commits/PRs)
     ATTRIBUTION_ENABLED = _cfg.get("ATTRIBUTION_ENABLED", "true").lower() == "true"
+
+    # OAuth model discovery
+    OAUTH_MODEL_DYNAMIC_REFRESH = _cfg.get("OAUTH_MODEL_DYNAMIC_REFRESH", "true").lower() == "true"
+    OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS = float(
+        _cfg.get("OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS", "10")
+    )
 
     # Ralph Loop (outer verification loop)
     RALPH_LOOP_MAX_ITERATIONS = int(_cfg.get("RALPH_LOOP_MAX_ITERATIONS", "3"))

--- a/ouro/core/llm/oauth_model_catalog.py
+++ b/ouro/core/llm/oauth_model_catalog.py
@@ -2,36 +2,35 @@
 
 This file is intentionally deterministic and runtime-offline.
 
-To refresh the chatgpt provider from pi-ai's latest published model registry, run:
+To refresh from pi-ai's latest published model registry, run:
 
     python scripts/update_oauth_model_catalog.py
-
-The copilot provider list is curated manually from GitHub's supported-models
-reference. Refresh from:
-    https://docs.github.com/en/copilot/reference/ai-models/supported-models
-Only chat-mode models are included; `/responses`-mode codex variants are omitted
-because the adapter routes through LiteLLM's `acompletion` endpoint.
 """
 
 from __future__ import annotations
 
-PI_AI_VERSION = "0.52.12"
+from ouro.config import Config
+from ouro.core.llm.oauth_model_discovery import discover_oauth_provider_model_ids
+
+PI_AI_VERSION = "0.73.1"
 PI_AI_PROVIDER_ID = "openai-codex"
 
-# Synced from pi-ai openai-codex provider model IDs, filtered to those supported by
-# the pinned LiteLLM chatgpt provider, and mapped to ouro's chatgpt/* namespace.
-# Copilot entries target LiteLLM's built-in `github_copilot/*` namespace and cover
-# the chat-capable models exposed to Copilot subscribers.
+# ChatGPT entries are synced from pi-ai openai-codex provider model IDs,
+# filtered to those supported by the installed LiteLLM chatgpt provider.
+# Other OAuth provider entries are preserved from the existing catalog.
 OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {
     "chatgpt": (
-        "chatgpt/gpt-5.1",
         "chatgpt/gpt-5.1-codex-max",
         "chatgpt/gpt-5.1-codex-mini",
         "chatgpt/gpt-5.2",
         "chatgpt/gpt-5.2-codex",
+        "chatgpt/gpt-5.3-codex",
+        "chatgpt/gpt-5.3-codex-spark",
+        "chatgpt/gpt-5.4",
+        "chatgpt/gpt-5.3-instant",
+        "chatgpt/gpt-5.4-pro",
     ),
     "copilot": (
-        # Anthropic (GA)
         "github_copilot/claude-opus-4.8",
         "github_copilot/claude-opus-4.7",
         "github_copilot/claude-opus-4.6",
@@ -39,23 +38,30 @@ OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {
         "github_copilot/claude-sonnet-4.6",
         "github_copilot/claude-sonnet-4.5",
         "github_copilot/claude-haiku-4.5",
-        # OpenAI (GA)
         "github_copilot/gpt-5.5",
         "github_copilot/gpt-5.4",
         "github_copilot/gpt-5.4-mini",
         "github_copilot/gpt-5.3-codex",
-        # Google (GA + preview)
         "github_copilot/gemini-2.5-pro",
         "github_copilot/gemini-3.1-pro",
         "github_copilot/gemini-3.5-flash",
-        # Microsoft (GA)
         "github_copilot/mai-code-1-flash",
     ),
 }
 
 
-def get_oauth_provider_model_ids(provider: str) -> tuple[str, ...]:
+def _dynamic_refresh_enabled() -> bool:
+    return bool(Config.OAUTH_MODEL_DYNAMIC_REFRESH)
+
+
+def get_bundled_oauth_provider_model_ids(provider: str) -> tuple[str, ...]:
     try:
         return OAUTH_PROVIDER_MODEL_IDS[provider]
     except KeyError as e:
         raise ValueError(f"Unsupported provider: {provider}") from e
+
+
+def get_oauth_provider_model_ids(provider: str, *, dynamic: bool = True) -> tuple[str, ...]:
+    if dynamic and _dynamic_refresh_enabled():
+        return discover_oauth_provider_model_ids(provider)
+    return get_bundled_oauth_provider_model_ids(provider)

--- a/ouro/core/llm/oauth_model_discovery.py
+++ b/ouro/core/llm/oauth_model_discovery.py
@@ -1,0 +1,260 @@
+"""Runtime OAuth model discovery for subscription-backed providers."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import tarfile
+import urllib.request
+from contextlib import suppress
+
+from ouro.config import Config
+
+NPM_PKG = "@mariozechner/pi-ai"
+NPM_REGISTRY = "https://registry.npmjs.org"
+PI_PROVIDER_ID = "openai-codex"
+OURO_CHATGPT_PROVIDER_ID = "chatgpt"
+PI_DIST_MODELS_PATH_SUFFIX = "package/dist/models.generated.js"
+GITHUB_COPILOT_MODELS_MARKDOWN_URL = (
+    "https://docs.github.com/api/article/body"
+    "?pathname=/en/copilot/reference/ai-models/supported-models&m=1"
+)
+
+OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS = (
+    "gpt-5.3-instant",
+    "gpt-5.4-pro",
+)
+
+
+def _get_timeout_seconds() -> float:
+    with suppress(TypeError, ValueError):
+        value = float(Config.OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS)
+        if value > 0:
+            return value
+    return 10.0
+
+
+def _http_text(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=_get_timeout_seconds()) as r:  # noqa: S310
+        return r.read().decode("utf-8")
+
+
+def _http_bytes(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=_get_timeout_seconds()) as r:  # noqa: S310
+        return r.read()
+
+
+def _merge_model_ids(primary: list[str], additional: tuple[str, ...]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for model_id in [*primary, *additional]:
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        out.append(model_id)
+    return out
+
+
+def _extract_pi_provider_block(models_js: str, provider_id: str) -> str:
+    marker = f'"{provider_id}":'
+    idx = models_js.find(marker)
+    if idx < 0:
+        raise RuntimeError(f"Provider '{provider_id}' not found in models.generated.js")
+
+    brace_start = models_js.find("{", idx)
+    if brace_start < 0:
+        raise RuntimeError(f"Malformed provider block for '{provider_id}'")
+
+    depth = 0
+    in_string = False
+    escaped = False
+
+    for i in range(brace_start, len(models_js)):
+        ch = models_js[i]
+
+        if in_string:
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+                continue
+            if ch == '"':
+                in_string = False
+            continue
+
+        if ch == '"':
+            in_string = True
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return models_js[brace_start + 1 : i]
+
+    raise RuntimeError(f"Unclosed provider block for '{provider_id}'")
+
+
+def _extract_pi_provider_model_ids(provider_block: str) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+
+    i = 0
+    depth = 0
+    n = len(provider_block)
+
+    while i < n:
+        ch = provider_block[i]
+
+        if depth == 0 and ch == '"':
+            j = i + 1
+            while j < n:
+                if provider_block[j] == '"' and provider_block[j - 1] != "\\":
+                    break
+                j += 1
+            if j >= n:
+                break
+
+            key = provider_block[i + 1 : j]
+            k = j + 1
+            while k < n and provider_block[k].isspace():
+                k += 1
+
+            if k < n and provider_block[k] == ":":
+                k += 1
+                while k < n and provider_block[k].isspace():
+                    k += 1
+                if k < n and provider_block[k] == "{" and key not in seen:
+                    seen.add(key)
+                    out.append(key)
+
+            i = j + 1
+            continue
+
+        if ch == "{":
+            depth += 1
+        elif ch == "}" and depth > 0:
+            depth -= 1
+
+        i += 1
+
+    return out
+
+
+def _filter_chatgpt_model_ids_for_litellm(model_ids: list[str]) -> list[str]:
+    try:
+        import litellm  # type: ignore
+    except Exception:
+        return model_ids
+
+    supported = getattr(litellm, "chatgpt_models", None)
+    if not isinstance(supported, (set, list, tuple)):
+        return model_ids
+
+    supported_ids = {str(x) for x in supported}
+    return [mid for mid in model_ids if f"{OURO_CHATGPT_PROVIDER_ID}/{mid}" in supported_ids]
+
+
+def discover_chatgpt_model_ids() -> tuple[str, ...]:
+    """Discover current ChatGPT subscription model IDs."""
+    latest = json.loads(_http_text(f"{NPM_REGISTRY}/{NPM_PKG}/latest"))
+    tarball_url = latest["dist"]["tarball"]
+    tgz = _http_bytes(tarball_url)
+
+    with tarfile.open(fileobj=io.BytesIO(tgz), mode="r:gz") as tf:
+        member = next(
+            (m for m in tf.getmembers() if m.name.endswith(PI_DIST_MODELS_PATH_SUFFIX)),
+            None,
+        )
+        if member is None:
+            raise RuntimeError(f"Could not find {PI_DIST_MODELS_PATH_SUFFIX} in npm tarball")
+
+        f = tf.extractfile(member)
+        if f is None:
+            raise RuntimeError(f"Failed to extract {member.name}")
+
+        models_js = f.read().decode("utf-8")
+
+    provider_block = _extract_pi_provider_block(models_js, PI_PROVIDER_ID)
+    model_ids = _extract_pi_provider_model_ids(provider_block)
+    model_ids = _merge_model_ids(model_ids, OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS)
+    model_ids = _filter_chatgpt_model_ids_for_litellm(model_ids)
+    if not model_ids:
+        raise RuntimeError("No compatible ChatGPT subscription models discovered")
+    return tuple(f"{OURO_CHATGPT_PROVIDER_ID}/{mid}" for mid in model_ids)
+
+
+_COPILOT_NAME_OVERRIDES = {
+    "claude opus 4.1": "claude-opus-41",
+    "claude opus 4.6 fast mode preview": "claude-opus-4.6-fast",
+    "gemini 3 pro": "gemini-3-pro-preview",
+}
+
+
+def _normalize_copilot_model_name(name: str) -> str:
+    name = re.sub(r"\[\^[^\]]+\]", "", name)
+    name = re.sub(r"<[^>]+>", "", name)
+    name = name.replace("(", " ").replace(")", " ")
+    name = re.sub(r"\s+", " ", name).strip()
+    return name
+
+
+def _copilot_model_name_to_id(name: str) -> str | None:
+    normalized = _normalize_copilot_model_name(name)
+    if not normalized or normalized.lower() in {"model", "available models"}:
+        return None
+
+    key = normalized.lower()
+    if key in _COPILOT_NAME_OVERRIDES:
+        return f"github_copilot/{_COPILOT_NAME_OVERRIDES[key]}"
+
+    model = key.replace(".", ".").replace("/", "-")
+    model = re.sub(r"[^a-z0-9.]+", "-", model).strip("-")
+    if not model:
+        return None
+    return f"github_copilot/{model}"
+
+
+def _extract_copilot_model_names(markdown: str) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for line in markdown.splitlines():
+        if not line.startswith("| "):
+            continue
+        columns = [col.strip() for col in line.strip("|").split("|")]
+        if not columns:
+            continue
+        name = _normalize_copilot_model_name(columns[0])
+        if not name or name.lower() in {"model", "model name", "available models"}:
+            continue
+        if set(name) == {"-"}:
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def discover_copilot_model_ids() -> tuple[str, ...]:
+    """Discover current GitHub Copilot subscription model IDs from GitHub Docs."""
+    markdown = _http_text(GITHUB_COPILOT_MODELS_MARKDOWN_URL)
+    model_ids = [
+        model_id
+        for name in _extract_copilot_model_names(markdown)
+        if (model_id := _copilot_model_name_to_id(name)) is not None
+    ]
+    if not model_ids:
+        raise RuntimeError("No Copilot subscription models discovered")
+    return tuple(model_ids)
+
+
+def discover_oauth_provider_model_ids(provider: str) -> tuple[str, ...]:
+    if provider == "chatgpt":
+        return discover_chatgpt_model_ids()
+    if provider == "copilot":
+        return discover_copilot_model_ids()
+    raise ValueError(f"Unsupported provider: {provider}")

--- a/scripts/update_oauth_model_catalog.py
+++ b/scripts/update_oauth_model_catalog.py
@@ -9,6 +9,7 @@ reads the `openai-codex` provider model IDs, maps them to `chatgpt/*`, and rewri
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import io
 import json
 import tarfile
@@ -20,6 +21,14 @@ NPM_REGISTRY = "https://registry.npmjs.org"
 PI_PROVIDER_ID = "openai-codex"
 OURO_PROVIDER_ID = "chatgpt"
 DIST_MODELS_PATH_SUFFIX = "package/dist/models.generated.js"
+
+# pi-ai's openai-codex registry tracks Codex-backed subscription models. These
+# additional ChatGPT subscription models are listed in OpenAI's ChatGPT model
+# availability docs and are kept only when the installed LiteLLM supports them.
+OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS = (
+    "gpt-5.3-instant",
+    "gpt-5.4-pro",
+)
 
 
 def _http_json(url: str) -> dict:
@@ -149,8 +158,48 @@ def _extract_provider_model_ids(provider_block: str) -> list[str]:
     return out
 
 
-def _render_catalog_module(pi_ai_version: str, model_ids: list[str]) -> str:
+def _merge_model_ids(primary: list[str], additional: tuple[str, ...]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for model_id in [*primary, *additional]:
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        out.append(model_id)
+    return out
+
+
+def _load_existing_provider_model_ids(output: Path) -> dict[str, tuple[str, ...]]:
+    """Load existing provider IDs so non-ChatGPT provider catalogs are preserved."""
+    if not output.exists():
+        return {}
+
+    spec = importlib.util.spec_from_file_location("existing_oauth_model_catalog", output)
+    if spec is None or spec.loader is None:
+        return {}
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    existing = getattr(module, "OAUTH_PROVIDER_MODEL_IDS", {})
+    if not isinstance(existing, dict):
+        return {}
+
+    out: dict[str, tuple[str, ...]] = {}
+    for provider, ids in existing.items():
+        if not isinstance(provider, str) or not isinstance(ids, (list, tuple)):
+            continue
+        out[provider] = tuple(str(model_id) for model_id in ids)
+    return out
+
+
+def _render_catalog_module(
+    pi_ai_version: str,
+    model_ids: list[str],
+    preserved_provider_model_ids: dict[str, tuple[str, ...]] | None = None,
+) -> str:
     chatgpt_ids = [f"{OURO_PROVIDER_ID}/{mid}" for mid in model_ids]
+    provider_model_ids = dict(preserved_provider_model_ids or {})
+    provider_model_ids[OURO_PROVIDER_ID] = tuple(chatgpt_ids)
 
     lines = [
         '"""OAuth model catalog used to seed `~/.ouro/models.yaml` after login.',
@@ -164,28 +213,47 @@ def _render_catalog_module(pi_ai_version: str, model_ids: list[str]) -> str:
         "",
         "from __future__ import annotations",
         "",
+        "from ouro.config import Config",
+        "from ouro.core.llm.oauth_model_discovery import discover_oauth_provider_model_ids",
+        "",
         f'PI_AI_VERSION = "{pi_ai_version}"',
         f'PI_AI_PROVIDER_ID = "{PI_PROVIDER_ID}"',
         "",
-        "# Synced from pi-ai openai-codex provider model IDs, mapped to ouro's chatgpt/*",
-        "# LiteLLM provider namespace.",
+        "# ChatGPT entries are synced from pi-ai openai-codex provider model IDs,",
+        "# filtered to those supported by the installed LiteLLM chatgpt provider.",
+        "# Other OAuth provider entries are preserved from the existing catalog.",
         "OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {",
-        f'    "{OURO_PROVIDER_ID}": (',
     ]
 
-    lines.extend(f'        "{model_id}",' for model_id in chatgpt_ids)
+    ordered_providers = [OURO_PROVIDER_ID] + [
+        provider for provider in provider_model_ids if provider != OURO_PROVIDER_ID
+    ]
+
+    for provider in ordered_providers:
+        lines.append(f'    "{provider}": (')
+        lines.extend(f'        "{model_id}",' for model_id in provider_model_ids[provider])
+        lines.append("    ),")
 
     lines.extend(
         [
-            "    ),",
             "}",
             "",
             "",
-            "def get_oauth_provider_model_ids(provider: str) -> tuple[str, ...]:",
+            "def _dynamic_refresh_enabled() -> bool:",
+            "    return bool(Config.OAUTH_MODEL_DYNAMIC_REFRESH)",
+            "",
+            "",
+            "def get_bundled_oauth_provider_model_ids(provider: str) -> tuple[str, ...]:",
             "    try:",
             "        return OAUTH_PROVIDER_MODEL_IDS[provider]",
             "    except KeyError as e:",
             '        raise ValueError(f"Unsupported provider: {provider}") from e',
+            "",
+            "",
+            "def get_oauth_provider_model_ids(provider: str, *, dynamic: bool = True) -> tuple[str, ...]:",
+            "    if dynamic and _dynamic_refresh_enabled():",
+            "        return discover_oauth_provider_model_ids(provider)",
+            "    return get_bundled_oauth_provider_model_ids(provider)",
             "",
         ]
     )
@@ -213,8 +281,8 @@ def main() -> None:
     parser.add_argument("--pi-ai-version", help="Pin specific @mariozechner/pi-ai version")
     parser.add_argument(
         "--output",
-        default="llm/oauth_model_catalog.py",
-        help="Output module path (default: llm/oauth_model_catalog.py)",
+        default="ouro/core/llm/oauth_model_catalog.py",
+        help="Output module path (default: ouro/core/llm/oauth_model_catalog.py)",
     )
     args = parser.parse_args()
 
@@ -226,14 +294,15 @@ def main() -> None:
     if not model_ids:
         raise RuntimeError("No model IDs extracted from openai-codex provider block")
 
+    model_ids = _merge_model_ids(model_ids, OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS)
     model_ids = _filter_model_ids_for_litellm(model_ids)
     if not model_ids:
         raise RuntimeError(
             "No compatible ChatGPT model IDs found for the installed LiteLLM version."
         )
-    content = _render_catalog_module(version, model_ids)
-
     output = Path(args.output)
+    existing_provider_model_ids = _load_existing_provider_model_ids(output)
+    content = _render_catalog_module(version, model_ids, existing_provider_model_ids)
     output.write_text(content, encoding="utf-8")
 
     print(f"Updated {output}")

--- a/test/test_interactive_auth_commands.py
+++ b/test/test_interactive_auth_commands.py
@@ -170,7 +170,7 @@ async def test_handle_login_syncs_models(monkeypatch):
     monkeypatch.setattr(session, "_pick_auth_provider", fake_pick)
     monkeypatch.setattr(interactive, "login_auth_provider", fake_login)
     monkeypatch.setattr(
-        interactive, "sync_oauth_models", lambda mm, provider: ["chatgpt/gpt-5.2-codex"]
+        interactive, "sync_oauth_models", lambda mm, provider: ["chatgpt/gpt-5.4"]
     )  # noqa: ARG005
     monkeypatch.setattr(interactive.terminal_ui, "print_info", lambda msg: infos.append(msg))
     monkeypatch.setattr(interactive.terminal_ui, "console", console)

--- a/test/test_main_auth_cli.py
+++ b/test/test_main_auth_cli.py
@@ -81,7 +81,7 @@ def test_main_login_success(monkeypatch):
     monkeypatch.setattr(
         ouro_main,
         "sync_oauth_models",
-        lambda model_manager, provider: ["chatgpt/gpt-5.2-codex"],
+        lambda model_manager, provider: ["chatgpt/gpt-5.4"],
     )
 
     async def fake_pick(mode: str):
@@ -155,7 +155,7 @@ def test_main_logout_success(monkeypatch):
     monkeypatch.setattr(
         ouro_main,
         "remove_oauth_models",
-        lambda model_manager, provider: ["chatgpt/gpt-5.2-codex"],
+        lambda model_manager, provider: ["chatgpt/gpt-5.4"],
     )
 
     async def fake_pick(mode: str):

--- a/test/test_oauth_model_catalog.py
+++ b/test/test_oauth_model_catalog.py
@@ -1,17 +1,24 @@
 import pytest
 
-from ouro.core.llm.oauth_model_catalog import get_oauth_provider_model_ids
+import ouro.core.llm.oauth_model_catalog as catalog
+from ouro.core.llm.oauth_model_catalog import (
+    get_bundled_oauth_provider_model_ids,
+    get_oauth_provider_model_ids,
+)
 
 
-def test_chatgpt_catalog_includes_gpt52():
+def test_chatgpt_catalog_includes_latest_subscription_models():
     model_ids = get_oauth_provider_model_ids("chatgpt")
 
+    assert "chatgpt/gpt-5.3-instant" in model_ids
+    assert "chatgpt/gpt-5.4" in model_ids
+    assert "chatgpt/gpt-5.4-pro" in model_ids
     assert "chatgpt/gpt-5.2" in model_ids
     assert "chatgpt/gpt-5.2-codex" in model_ids
 
 
 def test_copilot_catalog_includes_expected_models():
-    model_ids = get_oauth_provider_model_ids("copilot")
+    model_ids = get_bundled_oauth_provider_model_ids("copilot")
 
     assert "github_copilot/claude-opus-4.8" in model_ids
     assert "github_copilot/claude-sonnet-4.6" in model_ids
@@ -24,3 +31,39 @@ def test_copilot_catalog_includes_expected_models():
 def test_catalog_rejects_unsupported_provider():
     with pytest.raises(ValueError, match="Unsupported provider"):
         get_oauth_provider_model_ids("unknown")
+
+
+def test_catalog_uses_dynamic_models_when_available(monkeypatch):
+    monkeypatch.setattr(catalog.Config, "OAUTH_MODEL_DYNAMIC_REFRESH", True)
+    monkeypatch.setattr(
+        catalog,
+        "discover_oauth_provider_model_ids",
+        lambda provider: (f"{provider}/latest",),
+    )
+
+    assert get_oauth_provider_model_ids("chatgpt") == ("chatgpt/latest",)
+
+
+def test_catalog_can_disable_dynamic_refresh(monkeypatch):
+    monkeypatch.setattr(catalog.Config, "OAUTH_MODEL_DYNAMIC_REFRESH", False)
+    monkeypatch.setattr(
+        catalog,
+        "discover_oauth_provider_model_ids",
+        lambda provider: (_ for _ in ()).throw(AssertionError("should not refresh")),
+    )
+
+    assert get_oauth_provider_model_ids("chatgpt") == get_bundled_oauth_provider_model_ids(
+        "chatgpt"
+    )
+
+
+def test_catalog_dynamic_refresh_failure_raises(monkeypatch):
+    monkeypatch.setattr(catalog.Config, "OAUTH_MODEL_DYNAMIC_REFRESH", True)
+    monkeypatch.setattr(
+        catalog,
+        "discover_oauth_provider_model_ids",
+        lambda provider: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    with pytest.raises(RuntimeError, match="offline"):
+        get_oauth_provider_model_ids("copilot")

--- a/test/test_oauth_model_discovery.py
+++ b/test/test_oauth_model_discovery.py
@@ -1,0 +1,56 @@
+import sys
+from types import SimpleNamespace
+
+import ouro.core.llm.oauth_model_discovery as discovery
+
+
+def test_copilot_markdown_extracts_model_ids():
+    markdown = """
+| Model name | Provider | Release status |
+| ---------- | -------- | -------------- |
+| GPT-5 mini | OpenAI | GA |
+| GPT-5.3-Codex | OpenAI | GA |
+| Claude Opus 4.6 (fast mode) (preview) | Anthropic | Preview |
+| MAI-Code-1-Flash[^mai-code-1-flash] | Microsoft | GA |
+"""
+
+    names = discovery._extract_copilot_model_names(markdown)
+    model_ids = [discovery._copilot_model_name_to_id(name) for name in names]
+
+    assert model_ids == [
+        "github_copilot/gpt-5-mini",
+        "github_copilot/gpt-5.3-codex",
+        "github_copilot/claude-opus-4.6-fast",
+        "github_copilot/mai-code-1-flash",
+    ]
+
+
+def test_chatgpt_litellm_filter_includes_official_additions(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm",
+        SimpleNamespace(
+            chatgpt_models={
+                "chatgpt/gpt-5.4",
+                "chatgpt/gpt-5.3-instant",
+                "chatgpt/gpt-5.4-pro",
+            }
+        ),
+    )
+
+    model_ids = discovery._merge_model_ids(
+        ["gpt-5.4"],
+        discovery.OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS,
+    )
+
+    assert discovery._filter_chatgpt_model_ids_for_litellm(model_ids) == [
+        "gpt-5.4",
+        "gpt-5.3-instant",
+        "gpt-5.4-pro",
+    ]
+
+
+def test_timeout_seconds_uses_config(monkeypatch):
+    monkeypatch.setattr(discovery.Config, "OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS", 2.5)
+
+    assert discovery._get_timeout_seconds() == 2.5

--- a/test/test_oauth_model_sync.py
+++ b/test/test_oauth_model_sync.py
@@ -1,5 +1,13 @@
+import pytest
+
+from ouro.config import Config
 from ouro.core.llm.model_manager import ModelManager
 from ouro.core.llm.oauth_model_sync import remove_oauth_models, sync_oauth_models
+
+
+@pytest.fixture(autouse=True)
+def _disable_dynamic_model_refresh(monkeypatch):
+    monkeypatch.setattr(Config, "OAUTH_MODEL_DYNAMIC_REFRESH", False)
 
 
 def _write_models_yaml(path, content: str) -> None:
@@ -26,6 +34,7 @@ def test_sync_oauth_models_adds_chatgpt_models(tmp_path):
     added = sync_oauth_models(manager, "chatgpt")
 
     assert added
+    assert "chatgpt/gpt-5.4" in manager.models
     assert "chatgpt/gpt-5.2-codex" in manager.models
     assert manager.models["chatgpt/gpt-5.2-codex"].extra.get("oauth_managed") is True
 
@@ -37,7 +46,7 @@ def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
         "\n".join(
             [
                 "models:",
-                "  chatgpt/gpt-5.3-codex:",
+                "  chatgpt/legacy-codex:",
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
@@ -45,7 +54,7 @@ def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
-                "default: chatgpt/gpt-5.3-codex",
+                "default: chatgpt/legacy-codex",
                 "",
             ]
         ),
@@ -54,9 +63,10 @@ def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
     manager = ModelManager(config_path=str(config_path))
     sync_oauth_models(manager, "chatgpt")
 
-    assert "chatgpt/gpt-5.3-codex" not in manager.models
+    assert "chatgpt/legacy-codex" not in manager.models
+    assert "chatgpt/gpt-5.4" in manager.models
     assert "chatgpt/gpt-5.2-codex" in manager.models
-    assert manager.default_model_id == "chatgpt/gpt-5.2-codex"
+    assert manager.default_model_id in manager.models
 
 
 def test_remove_oauth_models_removes_only_managed_entries(tmp_path):

--- a/test/test_update_oauth_model_catalog.py
+++ b/test/test_update_oauth_model_catalog.py
@@ -59,6 +59,17 @@ def test_extract_provider_model_ids_uses_top_level_keys_only():
     assert ids == ["gpt-5.2-codex", "gpt-5.2-codex-spark"]
 
 
+def test_merge_model_ids_appends_additional_without_duplicates():
+    m = _load_module()
+
+    ids = m._merge_model_ids(
+        ["gpt-5.4", "gpt-5.3-instant"],
+        ("gpt-5.3-instant", "gpt-5.4-pro"),
+    )
+
+    assert ids == ["gpt-5.4", "gpt-5.3-instant", "gpt-5.4-pro"]
+
+
 def test_render_catalog_module_maps_prefix():
     m = _load_module()
 
@@ -66,6 +77,23 @@ def test_render_catalog_module_maps_prefix():
 
     assert 'PI_AI_VERSION = "0.52.12"' in rendered
     assert '"chatgpt/gpt-5.2-codex"' in rendered
+    assert "from ouro.config import Config" in rendered
+    assert "def get_bundled_oauth_provider_model_ids" in rendered
+    assert "Config.OAUTH_MODEL_DYNAMIC_REFRESH" in rendered
+
+
+def test_render_catalog_module_preserves_other_providers():
+    m = _load_module()
+
+    rendered = m._render_catalog_module(
+        "0.73.1",
+        ["gpt-5.4"],
+        {"copilot": ("github_copilot/gpt-5.5",)},
+    )
+
+    assert '"chatgpt/gpt-5.4"' in rendered
+    assert '"copilot": (' in rendered
+    assert '"github_copilot/gpt-5.5"' in rendered
 
 
 def test_filter_model_ids_for_litellm_keeps_supported_only(monkeypatch):


### PR DESCRIPTION
## Summary

Adds dynamic OAuth model discovery for ChatGPT and GitHub Copilot subscriptions so login-time model sync can use the current upstream subscription lists instead of requiring code changes for routine model updates.

## Scope

- Goals:
  - Discover ChatGPT subscription models dynamically from pi-ai `openai-codex`, plus OpenAI-documented ChatGPT subscription additions supported by LiteLLM.
  - Discover GitHub Copilot subscription models dynamically from GitHub Docs supported-models markdown.
  - Control refresh behavior through `~/.ouro/config` via `OAUTH_MODEL_DYNAMIC_REFRESH` and `OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS`.
  - Update bundled ChatGPT catalog to pi-ai `0.73.1` for explicit non-dynamic mode.
- Non-goals:
  - Do not change OAuth credential/login flows.
  - Do not call live LLM APIs.
  - Do not remove bundled catalog support when dynamic refresh is explicitly disabled.

## Invariants (Must Not Regress)

- [x] `chatgpt/*` and `github_copilot/*` models still do not require API keys in model validation.
- [x] OAuth-managed models are still marked with `oauth_managed` and `oauth_provider` in `models.yaml`.
- [x] `remove_oauth_models` only removes managed OAuth entries.
- [x] Unsupported OAuth providers still raise `ValueError`.
- [x] Import-linter layer contracts remain intact.

## Acceptance Criteria

- [x] Default login sync attempts dynamic ChatGPT/Copilot model discovery.
- [x] `OAUTH_MODEL_DYNAMIC_REFRESH=false` uses the bundled catalog instead.
- [x] Dynamic discovery failures propagate when refresh is enabled.
- [x] Refresh script preserves non-ChatGPT provider catalogs.
- [x] Docs describe config-based control rather than env vars.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_oauth_model_catalog.py test/test_oauth_model_discovery.py test/test_oauth_model_sync.py test/test_update_oauth_model_catalog.py`
- [x] Full check: `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] `.venv/bin/python -m ouro.interfaces.cli.entry -h`
- [x] Dynamic discovery smoke: ChatGPT discovered 9 models; Copilot discovered 43 models.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Login-time model sync now depends on upstream availability when dynamic refresh is enabled; users can set `OAUTH_MODEL_DYNAMIC_REFRESH=false` to use the bundled catalog.
- Worst-case input/output size? GitHub Docs markdown and pi-ai generated model registry are small enough for bounded parsing; HTTP timeout defaults to 10 seconds.
- Any secrets/logging risks? No tokens or credentials are used for discovery; no secrets are logged.
- Any async/blocking I/O added on hot paths? Discovery uses blocking HTTP during login model sync only, not during LLM calls.
- What error message does the user see on failure? The sync call propagates the upstream discovery error when dynamic refresh is enabled.

## Docs / Compatibility

- [x] Updated `docs/configuration.md` and `docs/cli-guide.md`.
- [x] No secrets committed; no generated artifacts committed.
