### PR TITLE
[codex] Add OpenAI Codex subscription adapter

### DIFF
--- a/docs/bot-guide.md
+++ b/docs/bot-guide.md
@@ -36,7 +36,7 @@ current: openai/gpt-4o
 
 See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for the full list. For advanced model settings, see [Configuration](configuration.md).
 
-> **Note:** Bot mode does not support OAuth (`chatgpt/*`) models yet. Use API-key-based providers.
+> **Note:** Bot mode does not support OAuth (`openai-codex/*`) models yet. Use API-key-based providers.
 
 ## Quick Start
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -34,7 +34,7 @@ models:
   anthropic/claude-sonnet-4:
     api_key: sk-ant-...
 
-  chatgpt/gpt-5.4:
+  openai-codex/gpt-5.5:
     timeout: 600
 
   ollama/llama2:
@@ -44,11 +44,11 @@ default: openai/gpt-4o
 current: openai/gpt-4o
 ```
 
-For `chatgpt/*` subscription models, run `ouro --login` (or `/login` in interactive mode) and select provider before use.
+For `openai-codex/*` subscription models, run `ouro --login` (or `/login` in interactive mode) and select provider before use.
 OAuth models shown in `/model` are refreshed dynamically at login.
 Login uses a browser-based OAuth (PKCE) flow with a localhost callback server. If browser auto-open fails, ouro prints a URL you can open manually (for remote machines, SSH port-forwarding may be required).
 
-See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for the full list. For advanced OAuth overrides, see [Configuration](configuration.md).
+See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for API-key providers. For advanced OAuth overrides, see [Configuration](configuration.md).
 
 ## Usage
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ models:
   openai/gpt-4o:
     api_key: sk-...
 
-  chatgpt/gpt-5.4:
+  openai-codex/gpt-5.5:
     timeout: 600
 
   ollama/llama2:
@@ -24,7 +24,7 @@ default: anthropic/claude-3-5-sonnet-20241022
 current: anthropic/claude-3-5-sonnet-20241022
 ```
 
-The model ID (key under `models`) uses the LiteLLM `provider/model` format. See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for supported providers.
+The model ID (key under `models`) uses the `provider/model` format. Most providers route through LiteLLM; ChatGPT subscription Codex models use ouro's `openai-codex/*` adapter.
 
 ### Model Fields
 
@@ -35,7 +35,7 @@ The model ID (key under `models`) uses the LiteLLM `provider/model` format. See 
 | `timeout` | No | Request timeout in seconds |
 | `drop_params` | No | Drop unsupported params silently |
 
-*Not required for local models (e.g., Ollama) or `chatgpt/*` subscription models.
+*Not required for local models (e.g., Ollama) or `openai-codex/*` subscription models.
 
 ### Model Management
 
@@ -49,23 +49,23 @@ The model ID (key under `models`) uses the LiteLLM `provider/model` format. See 
 
 ### ChatGPT / Codex Subscription Login
 
-For `chatgpt/*` models, login with OAuth before first use:
+For `openai-codex/*` models, login with OAuth before first use:
 
 - CLI: `ouro --login` (then pick provider)
 - Interactive: `/login` (then pick provider)
 - Logout: `ouro --logout` or `/logout`
-- After login, use `/model` to pick one of the added `chatgpt/*` models.
-- The added set is refreshed dynamically at login. ChatGPT models are discovered from pi-ai `openai-codex` plus ChatGPT subscription models documented by OpenAI and supported by LiteLLM; Copilot models are discovered from GitHub's supported-models docs.
+- After login, use `/model` to pick one of the added `openai-codex/*` models.
+- The added set is refreshed dynamically at login. ChatGPT models are discovered from pi-ai `openai-codex` plus ChatGPT subscription models documented by OpenAI; Copilot models are discovered from GitHub's supported-models docs.
 
 Login uses a browser-based OAuth (PKCE) flow with a localhost callback server, which works in workspaces that disable the OAuth device-code grant. If browser launch is blocked, ouro prints a URL you can open manually. For remote machines, you may need SSH port-forwarding to reach the localhost callback server.
 
-Credentials are stored under `~/.ouro/auth/chatgpt/` (LiteLLM-compatible `auth.json`).
+Credentials are stored under `~/.ouro/auth/chatgpt/`.
 
 Advanced environment overrides (rarely needed; defaults work for most users):
 
 | Env var | Default | Notes |
 |--------|---------|------|
-| `CHATGPT_TOKEN_DIR` | `~/.ouro/auth/chatgpt/` | Where `auth.json` is stored (also used by LiteLLM). |
+| `CHATGPT_TOKEN_DIR` | `~/.ouro/auth/chatgpt/` | Where `auth.json` is stored. |
 | `CHATGPT_AUTH_FILE` | `auth.json` | Override the auth filename under `CHATGPT_TOKEN_DIR`. |
 | `OURO_NO_BROWSER` | unset | Set to `1` to disable auto-opening the browser (URL is still printed). |
 | `OURO_CHATGPT_OAUTH_TIMEOUT_SECONDS` | `600` | How long to wait for the localhost callback before prompting for manual paste. |

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -30,8 +30,8 @@ MAX_ITERATIONS=1000
 # "Generated with ouro" to PR bodies the agent authors. Set to false to disable.
 # ATTRIBUTION_ENABLED=true
 
-# OAuth model discovery: refresh ChatGPT/Copilot model lists at login and fall
-# back to the bundled offline catalog if discovery fails.
+# OAuth model discovery: refresh ChatGPT/Copilot model lists at login. When
+# enabled, discovery failures fail login model sync instead of using stale data.
 # OAUTH_MODEL_DYNAMIC_REFRESH=true
 # OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS=10
 """

--- a/ouro/core/llm/litellm_adapter.py
+++ b/ouro/core/llm/litellm_adapter.py
@@ -55,7 +55,7 @@ class LiteLLMAdapter:
         self.drop_params = kwargs.pop("drop_params", True)
         self.timeout = kwargs.pop("timeout", 600)
 
-        if self.provider == "chatgpt":
+        if self.provider == "chatgpt" or self.provider == "openai-codex":
             from .chatgpt_auth import configure_chatgpt_auth_env
 
             configure_chatgpt_auth_env()
@@ -197,6 +197,15 @@ class LiteLLMAdapter:
         **kwargs,
     ) -> LLMResponse:
         """Async LLM call via LiteLLM with automatic retry."""
+        if self.provider == "openai-codex":
+            from .openai_codex_adapter import OpenAICodexAdapter
+
+            return await OpenAICodexAdapter(
+                self.model,
+                api_base=self.api_base,
+                timeout=self.timeout,
+            ).call_async(messages, tools=tools, max_tokens=max_tokens, **kwargs)
+
         await self._ensure_provider_ready()
         litellm_messages, call_params = self._build_call_params(
             messages=messages,

--- a/ouro/core/llm/model_manager.py
+++ b/ouro/core/llm/model_manager.py
@@ -253,7 +253,8 @@ class ModelManager:
         if not model.model_id:
             return False, "Model ID is missing."
         if (
-            model.provider not in {"ollama", "localhost", "chatgpt", "github_copilot"}
+            model.provider
+            not in {"ollama", "localhost", "chatgpt", "openai-codex", "github_copilot"}
             and not _is_local_api_base(model.api_base)
             and not (model.api_key or "").strip()
         ):

--- a/ouro/core/llm/oauth_model_catalog.py
+++ b/ouro/core/llm/oauth_model_catalog.py
@@ -15,20 +15,21 @@ from ouro.core.llm.oauth_model_discovery import discover_oauth_provider_model_id
 PI_AI_VERSION = "0.73.1"
 PI_AI_PROVIDER_ID = "openai-codex"
 
-# ChatGPT entries are synced from pi-ai openai-codex provider model IDs,
-# filtered to those supported by the installed LiteLLM chatgpt provider.
+# ChatGPT entries are synced from pi-ai openai-codex provider model IDs.
 # Other OAuth provider entries are preserved from the existing catalog.
 OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {
     "chatgpt": (
-        "chatgpt/gpt-5.1-codex-max",
-        "chatgpt/gpt-5.1-codex-mini",
-        "chatgpt/gpt-5.2",
-        "chatgpt/gpt-5.2-codex",
-        "chatgpt/gpt-5.3-codex",
-        "chatgpt/gpt-5.3-codex-spark",
-        "chatgpt/gpt-5.4",
-        "chatgpt/gpt-5.3-instant",
-        "chatgpt/gpt-5.4-pro",
+        "openai-codex/gpt-5.5",
+        "openai-codex/gpt-5.5-pro",
+        "openai-codex/gpt-5.4",
+        "openai-codex/gpt-5.4-pro",
+        "openai-codex/gpt-5.3-instant",
+        "openai-codex/gpt-5.3-codex",
+        "openai-codex/gpt-5.3-codex-spark",
+        "openai-codex/gpt-5.2",
+        "openai-codex/gpt-5.2-codex",
+        "openai-codex/gpt-5.1-codex-max",
+        "openai-codex/gpt-5.1-codex-mini",
     ),
     "copilot": (
         "github_copilot/claude-opus-4.8",

--- a/ouro/core/llm/oauth_model_discovery.py
+++ b/ouro/core/llm/oauth_model_discovery.py
@@ -14,7 +14,7 @@ from ouro.config import Config
 NPM_PKG = "@mariozechner/pi-ai"
 NPM_REGISTRY = "https://registry.npmjs.org"
 PI_PROVIDER_ID = "openai-codex"
-OURO_CHATGPT_PROVIDER_ID = "chatgpt"
+OURO_CHATGPT_PROVIDER_ID = "openai-codex"
 PI_DIST_MODELS_PATH_SUFFIX = "package/dist/models.generated.js"
 GITHUB_COPILOT_MODELS_MARKDOWN_URL = (
     "https://docs.github.com/api/article/body"
@@ -22,6 +22,7 @@ GITHUB_COPILOT_MODELS_MARKDOWN_URL = (
 )
 
 OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS = (
+    "gpt-5.5-pro",
     "gpt-5.3-instant",
     "gpt-5.4-pro",
 )
@@ -144,20 +145,6 @@ def _extract_pi_provider_model_ids(provider_block: str) -> list[str]:
     return out
 
 
-def _filter_chatgpt_model_ids_for_litellm(model_ids: list[str]) -> list[str]:
-    try:
-        import litellm  # type: ignore
-    except Exception:
-        return model_ids
-
-    supported = getattr(litellm, "chatgpt_models", None)
-    if not isinstance(supported, (set, list, tuple)):
-        return model_ids
-
-    supported_ids = {str(x) for x in supported}
-    return [mid for mid in model_ids if f"{OURO_CHATGPT_PROVIDER_ID}/{mid}" in supported_ids]
-
-
 def discover_chatgpt_model_ids() -> tuple[str, ...]:
     """Discover current ChatGPT subscription model IDs."""
     latest = json.loads(_http_text(f"{NPM_REGISTRY}/{NPM_PKG}/latest"))
@@ -181,7 +168,6 @@ def discover_chatgpt_model_ids() -> tuple[str, ...]:
     provider_block = _extract_pi_provider_block(models_js, PI_PROVIDER_ID)
     model_ids = _extract_pi_provider_model_ids(provider_block)
     model_ids = _merge_model_ids(model_ids, OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS)
-    model_ids = _filter_chatgpt_model_ids_for_litellm(model_ids)
     if not model_ids:
         raise RuntimeError("No compatible ChatGPT subscription models discovered")
     return tuple(f"{OURO_CHATGPT_PROVIDER_ID}/{mid}" for mid in model_ids)

--- a/ouro/core/llm/openai_codex_adapter.py
+++ b/ouro/core/llm/openai_codex_adapter.py
@@ -1,0 +1,457 @@
+"""OpenAI Codex subscription adapter backed by ChatGPT OAuth.
+
+The ChatGPT subscription Codex endpoint is Responses-compatible but is not
+covered by LiteLLM's ChatGPT provider catalog. This adapter keeps the runtime
+surface in ouro's standard LLMMessage/LLMResponse types while using the
+subscription endpoint directly.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import platform
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from ouro.core.log import get_logger
+
+from .content_utils import extract_text
+from .message_types import LLMMessage, LLMResponse, StopReason, ToolCallBlock
+from .retry import with_retry
+
+logger = get_logger(__name__)
+
+DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api"
+JWT_CLAIM_PATH = "https://api.openai.com/auth"
+
+
+class OpenAICodexAdapter:
+    """Adapter for ChatGPT subscription models exposed as openai-codex/*."""
+
+    def __init__(self, model: str, **kwargs: Any):
+        self.model = model
+        self.model_name = model.split("/", 1)[1] if "/" in model else model
+        self.api_base = kwargs.pop("api_base", None)
+        self.timeout = kwargs.pop("timeout", 600)
+        self._extra_kwargs = kwargs
+        logger.info(f"Initialized OpenAI Codex adapter for model: {model}")
+
+    async def call_async(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        token = await self._ensure_access_token()
+        account_id = _extract_account_id(token)
+        body = self._build_request_body(messages, tools, max_tokens, **kwargs)
+        events = await self._request_events(token=token, account_id=account_id, body=body)
+        return _convert_response_events(events)
+
+    async def _ensure_access_token(self) -> str:
+        from .chatgpt_auth import ChatGPTLoginRequiredError, ensure_chatgpt_access_token
+
+        try:
+            return await ensure_chatgpt_access_token(interactive=False)
+        except ChatGPTLoginRequiredError as e:
+            raise RuntimeError(
+                "ChatGPT is not logged in (or your session expired). "
+                "Run `/login` to authenticate."
+            ) from e
+
+    def _build_request_body(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        instructions, input_items = self._convert_messages(messages)
+        body: dict[str, Any] = {
+            "model": self.model_name,
+            "store": False,
+            "stream": True,
+            "instructions": instructions or "You are a helpful assistant.",
+            "input": input_items,
+            "text": {"verbosity": kwargs.pop("text_verbosity", "low")},
+            "include": ["reasoning.encrypted_content"],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+        if max_tokens is not None:
+            body["max_output_tokens"] = max_tokens
+        if tools:
+            body["tools"] = self._convert_tools(tools)
+        if "temperature" in kwargs:
+            body["temperature"] = kwargs.pop("temperature")
+        if "reasoning_effort" in kwargs:
+            body["reasoning"] = {
+                "effort": kwargs.pop("reasoning_effort"),
+                "summary": kwargs.pop("reasoning_summary", "auto"),
+            }
+        if "service_tier" in kwargs:
+            body["service_tier"] = kwargs.pop("service_tier")
+
+        body.update(kwargs)
+        return body
+
+    def _convert_messages(self, messages: list[LLMMessage]) -> tuple[str, list[dict[str, Any]]]:
+        instructions: list[str] = []
+        input_items: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.role == "system":
+                instructions.append(_message_text(msg))
+            elif msg.role == "user":
+                input_items.append(
+                    {
+                        "role": "user",
+                        "content": _responses_input_content(msg.content),
+                    }
+                )
+            elif msg.role == "assistant":
+                if msg.content:
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": _message_text(msg),
+                                    "annotations": [],
+                                }
+                            ],
+                            "status": "completed",
+                            "id": f"msg_{uuid.uuid4().hex[:24]}",
+                        }
+                    )
+                for tool_call in msg.tool_calls or []:
+                    call_id, item_id = _split_tool_call_id(tool_call["id"])
+                    input_items.append(
+                        {
+                            "type": "function_call",
+                            "id": item_id,
+                            "call_id": call_id,
+                            "name": tool_call["function"]["name"],
+                            "arguments": tool_call["function"]["arguments"],
+                        }
+                    )
+            elif msg.role == "tool":
+                call_id, _ = _split_tool_call_id(msg.tool_call_id or "")
+                input_items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": _message_text(msg),
+                    }
+                )
+
+        return "\n\n".join(part for part in instructions if part), input_items
+
+    def _convert_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "name": tool["name"],
+                "description": tool["description"],
+                "parameters": tool["input_schema"],
+            }
+            for tool in tools
+        ]
+
+    @with_retry()
+    async def _request_events(
+        self,
+        *,
+        token: str,
+        account_id: str,
+        body: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        headers = _build_sse_headers(token=token, account_id=account_id)
+        timeout = httpx.Timeout(float(self.timeout))
+        events: list[dict[str, Any]] = []
+        async with (
+            httpx.AsyncClient(timeout=timeout) as client,
+            client.stream(
+                "POST",
+                _resolve_codex_url(self.api_base),
+                headers=headers,
+                json=body,
+            ) as response,
+        ):
+            if response.status_code >= 400:
+                raise RuntimeError(await _format_error_response(response))
+            events.extend([event async for event in _iter_sse_events(response)])
+        return events
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse):
+        from .litellm_adapter import LiteLLMAdapter
+
+        return LiteLLMAdapter(self.model).extract_tool_calls(response)
+
+    def extract_thinking(self, response: LLMResponse) -> str | None:
+        return response.thinking
+
+    def format_tool_results(self, results):
+        from .litellm_adapter import LiteLLMAdapter
+
+        return LiteLLMAdapter(self.model).format_tool_results(results)
+
+    @property
+    def supports_tools(self) -> bool:
+        return True
+
+    @property
+    def provider_name(self) -> str:
+        return "OPENAI-CODEX"
+
+
+def _message_text(msg: LLMMessage) -> str:
+    if isinstance(msg.content, str):
+        return msg.content
+    return extract_text(msg.content)
+
+
+def _responses_input_content(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, list):
+        out: list[dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "text":
+                out.append({"type": "input_text", "text": str(block.get("text", ""))})
+            elif block_type == "image_url":
+                image = block.get("image_url")
+                image_url = image.get("url") if isinstance(image, dict) else image
+                if image_url:
+                    out.append(
+                        {
+                            "type": "input_image",
+                            "detail": "auto",
+                            "image_url": str(image_url),
+                        }
+                    )
+        if out:
+            return out
+    return [{"type": "input_text", "text": extract_text(content)}]
+
+
+def _split_tool_call_id(tool_call_id: str) -> tuple[str, str | None]:
+    if "|" not in tool_call_id:
+        return tool_call_id, None
+    call_id, item_id = tool_call_id.split("|", 1)
+    return call_id, item_id or None
+
+
+def _extract_account_id(token: str) -> str:
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            raise ValueError("invalid JWT")
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64).decode("utf-8"))
+        account_id = payload.get(JWT_CLAIM_PATH, {}).get("chatgpt_account_id")
+    except Exception as e:
+        raise RuntimeError("Failed to extract ChatGPT account ID from access token.") from e
+    if not isinstance(account_id, str) or not account_id:
+        raise RuntimeError("ChatGPT account ID is missing from access token.")
+    return account_id
+
+
+def _build_sse_headers(*, token: str, account_id: str) -> dict[str, str]:
+    request_id = str(uuid.uuid4())
+    return {
+        "Authorization": f"Bearer {token}",
+        "chatgpt-account-id": account_id,
+        "originator": "ouro",
+        "User-Agent": f"ouro ({platform.system()} {platform.release()}; {platform.machine()})",
+        "OpenAI-Beta": "responses=experimental",
+        "accept": "text/event-stream",
+        "content-type": "application/json",
+        "session-id": request_id,
+        "x-client-request-id": request_id,
+    }
+
+
+def _resolve_codex_url(base_url: str | None) -> str:
+    raw = base_url.strip() if base_url else DEFAULT_CODEX_BASE_URL
+    normalized = raw.rstrip("/")
+    if normalized.endswith("/codex/responses"):
+        return normalized
+    if normalized.endswith("/codex"):
+        return f"{normalized}/responses"
+    return f"{normalized}/codex/responses"
+
+
+async def _iter_sse_events(response: httpx.Response) -> AsyncIterator[dict[str, Any]]:
+    buffer = ""
+    async for chunk in response.aiter_text():
+        buffer += chunk
+        while "\n\n" in buffer:
+            raw_event, buffer = buffer.split("\n\n", 1)
+            data_lines = [
+                line.removeprefix("data:").strip()
+                for line in raw_event.splitlines()
+                if line.startswith("data:")
+            ]
+            data = "\n".join(data_lines).strip()
+            if not data or data == "[DONE]":
+                continue
+            event = json.loads(data)
+            if isinstance(event, dict):
+                yield event
+
+
+async def _format_error_response(response: httpx.Response) -> str:
+    text = await response.aread()
+    try:
+        payload = json.loads(text.decode("utf-8"))
+    except Exception:
+        return f"Codex request failed with HTTP {response.status_code}: {text.decode('utf-8')}"
+    message = payload.get("detail") or payload.get("message") or payload.get("error") or payload
+    return f"Codex request failed with HTTP {response.status_code}: {message}"
+
+
+def _convert_response_events(events: list[dict[str, Any]]) -> LLMResponse:
+    text_parts: list[str] = []
+    current_text_parts: list[str] = []
+    thinking_parts: list[str] = []
+    tool_calls: list[ToolCallBlock] = []
+    current_tool: dict[str, Any] | None = None
+    current_tool_args = ""
+    usage: dict[str, int] | None = None
+    stop_reason = StopReason.STOP
+
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "error":
+            raise RuntimeError(str(event.get("message") or event))
+        if event_type == "response.failed":
+            response = _dict_value(event, "response")
+            error = _dict_value(response, "error")
+            raise RuntimeError(str(error.get("message") or error.get("code") or event))
+        if event_type == "response.output_item.added":
+            item = _dict_value(event, "item")
+            if item.get("type") == "message":
+                current_text_parts = []
+            if item.get("type") == "function_call":
+                current_tool = item
+                current_tool_args = str(item.get("arguments") or "")
+        elif event_type == "response.output_text.delta":
+            current_text_parts.append(str(event.get("delta") or ""))
+        elif event_type in {
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+        }:
+            thinking_parts.append(str(event.get("delta") or ""))
+        elif event_type == "response.function_call_arguments.delta":
+            current_tool_args += str(event.get("delta") or "")
+        elif event_type == "response.function_call_arguments.done":
+            current_tool_args = str(event.get("arguments") or current_tool_args)
+        elif event_type == "response.output_item.done":
+            item = _dict_value(event, "item")
+            item_type = item.get("type")
+            if item_type == "message":
+                item_text_parts = _extract_output_text_from_item(item)
+                text_parts.extend(item_text_parts or current_text_parts)
+                current_text_parts = []
+            elif item_type == "reasoning":
+                thinking_parts.extend(_extract_reasoning_from_item(item))
+            elif item_type == "function_call":
+                source = current_tool if current_tool is not None else item
+                arguments = current_tool_args or str(item.get("arguments") or "")
+                tool_calls.append(_normalize_codex_tool_call(source, arguments))
+                current_tool = None
+                current_tool_args = ""
+        elif event_type in {"response.completed", "response.done", "response.incomplete"}:
+            response = _dict_value(event, "response")
+            usage = _normalize_usage(response.get("usage"))
+            stop_reason = _map_stop_reason(response.get("status"))
+
+    if tool_calls and stop_reason == StopReason.STOP:
+        stop_reason = StopReason.TOOL_CALLS
+
+    text_parts.extend(current_text_parts)
+    content = "".join(text_parts) or None
+    thinking = "".join(thinking_parts).strip() or None
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or None,
+        stop_reason=stop_reason,
+        usage=usage,
+        thinking=thinking,
+    )
+
+
+def _dict_value(mapping: dict[str, Any], key: str) -> dict[str, Any]:
+    value = mapping.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _extract_output_text_from_item(item: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    content = item.get("content")
+    if not isinstance(content, list):
+        return out
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "output_text":
+            out.append(str(part.get("text") or ""))
+        elif part.get("type") == "refusal":
+            out.append(str(part.get("refusal") or ""))
+    return out
+
+
+def _extract_reasoning_from_item(item: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for key in ("summary", "content"):
+        value = item.get(key)
+        if isinstance(value, list):
+            out.extend(str(part.get("text") or "") for part in value if isinstance(part, dict))
+    return out
+
+
+def _normalize_codex_tool_call(item: dict[str, Any], arguments: str) -> ToolCallBlock:
+    call_id = str(item.get("call_id") or item.get("id") or f"call_{uuid.uuid4().hex[:12]}")
+    item_id = str(item.get("id") or f"fc_{uuid.uuid4().hex[:12]}")
+    return {
+        "id": f"{call_id}|{item_id}",
+        "type": "function",
+        "function": {
+            "name": str(item.get("name") or ""),
+            "arguments": arguments or "{}",
+        },
+    }
+
+
+def _normalize_usage(raw_usage: Any) -> dict[str, int] | None:
+    if not isinstance(raw_usage, dict):
+        return None
+    details = raw_usage.get("input_tokens_details")
+    cached = details.get("cached_tokens", 0) if isinstance(details, dict) else 0
+    input_tokens = int(raw_usage.get("input_tokens") or 0)
+    return {
+        "input_tokens": max(0, input_tokens - int(cached or 0)),
+        "output_tokens": int(raw_usage.get("output_tokens") or 0),
+        "cache_read_tokens": int(cached or 0),
+        "cache_creation_tokens": 0,
+    }
+
+
+def _map_stop_reason(status: Any) -> str:
+    if status == "incomplete":
+        return StopReason.LENGTH
+    if status in {"failed", "cancelled"}:
+        return "error"
+    return StopReason.STOP

--- a/scripts/update_oauth_model_catalog.py
+++ b/scripts/update_oauth_model_catalog.py
@@ -2,7 +2,7 @@
 """Update OAuth model catalog from published pi-ai package.
 
 This script fetches @mariozechner/pi-ai from npm, extracts `dist/models.generated.js`,
-reads the `openai-codex` provider model IDs, maps them to `chatgpt/*`, and rewrites
+reads the `openai-codex` provider model IDs, maps them to `openai-codex/*`, and rewrites
 `llm/oauth_model_catalog.py`.
 """
 
@@ -20,12 +20,14 @@ NPM_PKG = "@mariozechner/pi-ai"
 NPM_REGISTRY = "https://registry.npmjs.org"
 PI_PROVIDER_ID = "openai-codex"
 OURO_PROVIDER_ID = "chatgpt"
+OURO_MODEL_PROVIDER_ID = "openai-codex"
 DIST_MODELS_PATH_SUFFIX = "package/dist/models.generated.js"
 
 # pi-ai's openai-codex registry tracks Codex-backed subscription models. These
 # additional ChatGPT subscription models are listed in OpenAI's ChatGPT model
-# availability docs and are kept only when the installed LiteLLM supports them.
+# availability docs.
 OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS = (
+    "gpt-5.5-pro",
     "gpt-5.3-instant",
     "gpt-5.4-pro",
 )
@@ -197,7 +199,7 @@ def _render_catalog_module(
     model_ids: list[str],
     preserved_provider_model_ids: dict[str, tuple[str, ...]] | None = None,
 ) -> str:
-    chatgpt_ids = [f"{OURO_PROVIDER_ID}/{mid}" for mid in model_ids]
+    chatgpt_ids = [f"{OURO_MODEL_PROVIDER_ID}/{mid}" for mid in model_ids]
     provider_model_ids = dict(preserved_provider_model_ids or {})
     provider_model_ids[OURO_PROVIDER_ID] = tuple(chatgpt_ids)
 
@@ -219,8 +221,7 @@ def _render_catalog_module(
         f'PI_AI_VERSION = "{pi_ai_version}"',
         f'PI_AI_PROVIDER_ID = "{PI_PROVIDER_ID}"',
         "",
-        "# ChatGPT entries are synced from pi-ai openai-codex provider model IDs,",
-        "# filtered to those supported by the installed LiteLLM chatgpt provider.",
+        "# ChatGPT entries are synced from pi-ai openai-codex provider model IDs.",
         "# Other OAuth provider entries are preserved from the existing catalog.",
         "OAUTH_PROVIDER_MODEL_IDS: dict[str, tuple[str, ...]] = {",
     ]
@@ -260,22 +261,6 @@ def _render_catalog_module(
     return "\n".join(lines)
 
 
-def _filter_model_ids_for_litellm(model_ids: list[str]) -> list[str]:
-    """Filter pi-ai model IDs down to those supported by the installed LiteLLM."""
-    try:
-        import litellm  # type: ignore
-    except Exception:
-        return model_ids
-
-    supported = getattr(litellm, "chatgpt_models", None)
-    if not isinstance(supported, (set, list, tuple)):
-        return model_ids
-
-    supported_ids = {str(x) for x in supported}
-    filtered = [mid for mid in model_ids if f"{OURO_PROVIDER_ID}/{mid}" in supported_ids]
-    return filtered
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pi-ai-version", help="Pin specific @mariozechner/pi-ai version")
@@ -295,11 +280,8 @@ def main() -> None:
         raise RuntimeError("No model IDs extracted from openai-codex provider block")
 
     model_ids = _merge_model_ids(model_ids, OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS)
-    model_ids = _filter_model_ids_for_litellm(model_ids)
     if not model_ids:
-        raise RuntimeError(
-            "No compatible ChatGPT model IDs found for the installed LiteLLM version."
-        )
+        raise RuntimeError("No ChatGPT subscription model IDs found.")
     output = Path(args.output)
     existing_provider_model_ids = _load_existing_provider_model_ids(output)
     content = _render_catalog_module(version, model_ids, existing_provider_model_ids)

--- a/test/test_oauth_model_catalog.py
+++ b/test/test_oauth_model_catalog.py
@@ -7,14 +7,15 @@ from ouro.core.llm.oauth_model_catalog import (
 )
 
 
-def test_chatgpt_catalog_includes_latest_subscription_models():
+def test_chatgpt_catalog_includes_latest_subscription_models(monkeypatch):
+    monkeypatch.setattr(catalog.Config, "OAUTH_MODEL_DYNAMIC_REFRESH", False)
     model_ids = get_oauth_provider_model_ids("chatgpt")
 
-    assert "chatgpt/gpt-5.3-instant" in model_ids
-    assert "chatgpt/gpt-5.4" in model_ids
-    assert "chatgpt/gpt-5.4-pro" in model_ids
-    assert "chatgpt/gpt-5.2" in model_ids
-    assert "chatgpt/gpt-5.2-codex" in model_ids
+    assert "openai-codex/gpt-5.5" in model_ids
+    assert "openai-codex/gpt-5.5-pro" in model_ids
+    assert "openai-codex/gpt-5.4" in model_ids
+    assert "openai-codex/gpt-5.4-pro" in model_ids
+    assert "openai-codex/gpt-5.2-codex" in model_ids
 
 
 def test_copilot_catalog_includes_expected_models():
@@ -38,10 +39,10 @@ def test_catalog_uses_dynamic_models_when_available(monkeypatch):
     monkeypatch.setattr(
         catalog,
         "discover_oauth_provider_model_ids",
-        lambda provider: (f"{provider}/latest",),
+        lambda provider: ("openai-codex/latest",),
     )
 
-    assert get_oauth_provider_model_ids("chatgpt") == ("chatgpt/latest",)
+    assert get_oauth_provider_model_ids("chatgpt") == ("openai-codex/latest",)
 
 
 def test_catalog_can_disable_dynamic_refresh(monkeypatch):

--- a/test/test_oauth_model_discovery.py
+++ b/test/test_oauth_model_discovery.py
@@ -1,6 +1,3 @@
-import sys
-from types import SimpleNamespace
-
 import ouro.core.llm.oauth_model_discovery as discovery
 
 
@@ -25,26 +22,15 @@ def test_copilot_markdown_extracts_model_ids():
     ]
 
 
-def test_chatgpt_litellm_filter_includes_official_additions(monkeypatch):
-    monkeypatch.setitem(
-        sys.modules,
-        "litellm",
-        SimpleNamespace(
-            chatgpt_models={
-                "chatgpt/gpt-5.4",
-                "chatgpt/gpt-5.3-instant",
-                "chatgpt/gpt-5.4-pro",
-            }
-        ),
-    )
-
+def test_chatgpt_model_merge_includes_official_additions():
     model_ids = discovery._merge_model_ids(
         ["gpt-5.4"],
         discovery.OFFICIAL_CHATGPT_SUBSCRIPTION_MODEL_IDS,
     )
 
-    assert discovery._filter_chatgpt_model_ids_for_litellm(model_ids) == [
+    assert model_ids == [
         "gpt-5.4",
+        "gpt-5.5-pro",
         "gpt-5.3-instant",
         "gpt-5.4-pro",
     ]

--- a/test/test_oauth_model_sync.py
+++ b/test/test_oauth_model_sync.py
@@ -34,9 +34,10 @@ def test_sync_oauth_models_adds_chatgpt_models(tmp_path):
     added = sync_oauth_models(manager, "chatgpt")
 
     assert added
-    assert "chatgpt/gpt-5.4" in manager.models
-    assert "chatgpt/gpt-5.2-codex" in manager.models
-    assert manager.models["chatgpt/gpt-5.2-codex"].extra.get("oauth_managed") is True
+    assert "openai-codex/gpt-5.5" in manager.models
+    assert "openai-codex/gpt-5.4" in manager.models
+    assert "openai-codex/gpt-5.2-codex" in manager.models
+    assert manager.models["openai-codex/gpt-5.5"].extra.get("oauth_managed") is True
 
 
 def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
@@ -46,15 +47,15 @@ def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
         "\n".join(
             [
                 "models:",
-                "  chatgpt/legacy-codex:",
+                "  openai-codex/legacy-codex:",
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
-                "  chatgpt/gpt-5.2-codex:",
+                "  openai-codex/gpt-5.2-codex:",
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
-                "default: chatgpt/legacy-codex",
+                "default: openai-codex/legacy-codex",
                 "",
             ]
         ),
@@ -63,9 +64,9 @@ def test_sync_oauth_models_removes_stale_managed_entries(tmp_path):
     manager = ModelManager(config_path=str(config_path))
     sync_oauth_models(manager, "chatgpt")
 
-    assert "chatgpt/legacy-codex" not in manager.models
-    assert "chatgpt/gpt-5.4" in manager.models
-    assert "chatgpt/gpt-5.2-codex" in manager.models
+    assert "openai-codex/legacy-codex" not in manager.models
+    assert "openai-codex/gpt-5.5" in manager.models
+    assert "openai-codex/gpt-5.2-codex" in manager.models
     assert manager.default_model_id in manager.models
 
 
@@ -76,7 +77,7 @@ def test_remove_oauth_models_removes_only_managed_entries(tmp_path):
         "\n".join(
             [
                 "models:",
-                "  chatgpt/gpt-5.2-codex:",
+                "  openai-codex/gpt-5.2-codex:",
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
@@ -84,7 +85,7 @@ def test_remove_oauth_models_removes_only_managed_entries(tmp_path):
                 "    timeout: 600",
                 "  openai/gpt-4o:",
                 "    api_key: test",
-                "default: chatgpt/gpt-5.2-codex",
+                "default: openai-codex/gpt-5.2-codex",
                 "",
             ]
         ),
@@ -93,8 +94,8 @@ def test_remove_oauth_models_removes_only_managed_entries(tmp_path):
     manager = ModelManager(config_path=str(config_path))
     removed = remove_oauth_models(manager, "chatgpt")
 
-    assert "chatgpt/gpt-5.2-codex" in removed
-    assert "chatgpt/gpt-5.2-codex" not in manager.models
+    assert "openai-codex/gpt-5.2-codex" in removed
+    assert "openai-codex/gpt-5.2-codex" not in manager.models
     # Unmanaged entry should remain
     assert "chatgpt/gpt-5.2" in manager.models
     # Default should be repaired
@@ -108,13 +109,13 @@ def test_remove_oauth_models_removes_stale_managed_entries(tmp_path):
         "\n".join(
             [
                 "models:",
-                "  chatgpt/legacy-codex:",
+                "  openai-codex/legacy-codex:",
                 "    timeout: 600",
                 "    oauth_managed: true",
                 "    oauth_provider: chatgpt",
                 "  openai/gpt-4o:",
                 "    api_key: test",
-                "default: chatgpt/legacy-codex",
+                "default: openai-codex/legacy-codex",
                 "",
             ]
         ),
@@ -123,6 +124,6 @@ def test_remove_oauth_models_removes_stale_managed_entries(tmp_path):
     manager = ModelManager(config_path=str(config_path))
     removed = remove_oauth_models(manager, "chatgpt")
 
-    assert removed == ["chatgpt/legacy-codex"]
-    assert "chatgpt/legacy-codex" not in manager.models
+    assert removed == ["openai-codex/legacy-codex"]
+    assert "openai-codex/legacy-codex" not in manager.models
     assert manager.default_model_id in manager.models

--- a/test/test_openai_codex_adapter.py
+++ b/test/test_openai_codex_adapter.py
@@ -1,0 +1,180 @@
+import base64
+import json
+
+from ouro.core.llm.message_types import LLMMessage, StopReason
+from ouro.core.llm.model_manager import ModelManager, ModelProfile
+from ouro.core.llm.openai_codex_adapter import (
+    OpenAICodexAdapter,
+    _build_sse_headers,
+    _convert_response_events,
+    _extract_account_id,
+    _resolve_codex_url,
+)
+
+
+def _jwt(payload: dict) -> str:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def test_extract_account_id_from_chatgpt_access_token() -> None:
+    token = _jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"}})
+
+    assert _extract_account_id(token) == "acct_123"
+
+
+def test_build_sse_headers_include_chatgpt_codex_requirements() -> None:
+    headers = _build_sse_headers(token="token", account_id="acct_123")
+
+    assert headers["Authorization"] == "Bearer token"
+    assert headers["chatgpt-account-id"] == "acct_123"
+    assert headers["OpenAI-Beta"] == "responses=experimental"
+    assert headers["accept"] == "text/event-stream"
+    assert headers["content-type"] == "application/json"
+    assert headers["originator"] == "ouro"
+    assert headers["session-id"]
+    assert headers["x-client-request-id"] == headers["session-id"]
+
+
+def test_resolve_codex_url_normalizes_base_url() -> None:
+    assert _resolve_codex_url(None) == "https://chatgpt.com/backend-api/codex/responses"
+    assert (
+        _resolve_codex_url("https://chatgpt.com/backend-api")
+        == "https://chatgpt.com/backend-api/codex/responses"
+    )
+    assert (
+        _resolve_codex_url("https://chatgpt.com/backend-api/codex")
+        == "https://chatgpt.com/backend-api/codex/responses"
+    )
+    assert (
+        _resolve_codex_url("https://chatgpt.com/backend-api/codex/responses")
+        == "https://chatgpt.com/backend-api/codex/responses"
+    )
+
+
+def test_build_request_body_uses_responses_protocol() -> None:
+    adapter = OpenAICodexAdapter("openai-codex/gpt-5.5")
+    body = adapter._build_request_body(
+        [
+            LLMMessage(role="system", content="Be brief."),
+            LLMMessage(role="user", content="Call a tool."),
+        ],
+        tools=[
+            {
+                "name": "lookup",
+                "description": "Look up a value",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ],
+        max_tokens=123,
+    )
+
+    assert body["model"] == "gpt-5.5"
+    assert body["stream"] is True
+    assert body["store"] is False
+    assert body["instructions"] == "Be brief."
+    assert body["max_output_tokens"] == 123
+    assert body["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "Call a tool."}]}
+    ]
+    assert body["tools"] == [
+        {
+            "type": "function",
+            "name": "lookup",
+            "description": "Look up a value",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+
+
+def test_convert_response_events_extracts_text_tool_calls_and_usage() -> None:
+    response = _convert_response_events(
+        [
+            {"type": "response.output_text.delta", "delta": "Hello"},
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": "",
+                },
+            },
+            {"type": "response.function_call_arguments.delta", "delta": '{"q"'},
+            {"type": "response.function_call_arguments.done", "arguments": '{"q":"x"}'},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_123",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": '{"q":"x"}',
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 3,
+                        "input_tokens_details": {"cached_tokens": 4},
+                    },
+                },
+            },
+        ]
+    )
+
+    assert response.content == "Hello"
+    assert response.stop_reason == StopReason.TOOL_CALLS
+    assert response.tool_calls == [
+        {
+            "id": "call_123|fc_123",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"q":"x"}'},
+        }
+    ]
+    assert response.usage == {
+        "input_tokens": 6,
+        "output_tokens": 3,
+        "cache_read_tokens": 4,
+        "cache_creation_tokens": 0,
+    }
+
+
+def test_convert_response_events_prefers_done_text_over_duplicate_deltas() -> None:
+    response = _convert_response_events(
+        [
+            {
+                "type": "response.output_item.added",
+                "item": {"type": "message"},
+            },
+            {"type": "response.output_text.delta", "delta": "Hel"},
+            {"type": "response.output_text.delta", "delta": "lo"},
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello",
+                        }
+                    ],
+                },
+            },
+            {"type": "response.completed", "response": {"status": "completed"}},
+        ]
+    )
+
+    assert response.content == "Hello"
+
+
+def test_openai_codex_model_does_not_require_api_key(tmp_path) -> None:
+    manager = ModelManager(config_path=str(tmp_path / "models.yaml"))
+    valid, message = manager.validate_model(ModelProfile(model_id="openai-codex/gpt-5.5"))
+
+    assert valid is True
+    assert message == ""

--- a/test/test_update_oauth_model_catalog.py
+++ b/test/test_update_oauth_model_catalog.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 
 def _load_module():
@@ -76,7 +74,7 @@ def test_render_catalog_module_maps_prefix():
     rendered = m._render_catalog_module("0.52.12", ["gpt-5.2-codex"])
 
     assert 'PI_AI_VERSION = "0.52.12"' in rendered
-    assert '"chatgpt/gpt-5.2-codex"' in rendered
+    assert '"openai-codex/gpt-5.2-codex"' in rendered
     assert "from ouro.config import Config" in rendered
     assert "def get_bundled_oauth_provider_model_ids" in rendered
     assert "Config.OAUTH_MODEL_DYNAMIC_REFRESH" in rendered
@@ -91,32 +89,15 @@ def test_render_catalog_module_preserves_other_providers():
         {"copilot": ("github_copilot/gpt-5.5",)},
     )
 
-    assert '"chatgpt/gpt-5.4"' in rendered
+    assert '"openai-codex/gpt-5.4"' in rendered
     assert '"copilot": (' in rendered
     assert '"github_copilot/gpt-5.5"' in rendered
 
 
-def test_filter_model_ids_for_litellm_keeps_supported_only(monkeypatch):
+def test_render_catalog_module_keeps_chatgpt_as_auth_provider_key():
     m = _load_module()
-    monkeypatch.setitem(
-        sys.modules,
-        "litellm",
-        SimpleNamespace(chatgpt_models={"chatgpt/gpt-5.2-codex"}),
-    )
 
-    result = m._filter_model_ids_for_litellm(["gpt-5.2-codex", "gpt-5.3-codex"])
+    rendered = m._render_catalog_module("0.73.1", ["gpt-5.5"])
 
-    assert result == ["gpt-5.2-codex"]
-
-
-def test_filter_model_ids_for_litellm_can_return_empty(monkeypatch):
-    m = _load_module()
-    monkeypatch.setitem(
-        sys.modules,
-        "litellm",
-        SimpleNamespace(chatgpt_models={"chatgpt/gpt-5.2-codex"}),
-    )
-
-    result = m._filter_model_ids_for_litellm(["gpt-5.3-codex"])
-
-    assert result == []
+    assert '"chatgpt": (' in rendered
+    assert '"openai-codex/gpt-5.5"' in rendered


### PR DESCRIPTION
## Summary

Adds an ouro-owned `openai-codex/*` ChatGPT subscription adapter so subscription models such as `openai-codex/gpt-5.5` and `openai-codex/gpt-5.5-pro` are no longer blocked by LiteLLM's ChatGPT model catalog.

## Scope

- Goals:
  - Seed ChatGPT OAuth login models as `openai-codex/*` IDs, including GPT-5.5.
  - Route `openai-codex/*` through a direct ChatGPT Codex Responses SSE adapter using existing ChatGPT OAuth credentials.
  - Keep Copilot and normal LiteLLM providers unchanged.
  - Update docs and catalog refresh script to match the new provider IDs.
- Non-goals:
  - No live LLM smoke run.
  - No WebSocket session reuse; this starts with the SSE path.
  - No changes to GitHub Copilot runtime routing.

## Invariants (Must Not Regress)

- [x] Existing LiteLLM providers still route through `LiteLLMAdapter`.
- [x] `chatgpt` remains the OAuth login provider key.
- [x] Copilot catalog discovery and sync remain supported.
- [x] Model config validation still requires API keys for normal hosted providers.
- [x] Three-layer import boundaries remain intact.

## Acceptance Criteria

- [x] ChatGPT OAuth model sync exposes `openai-codex/gpt-5.5` and `openai-codex/gpt-5.5-pro`.
- [x] `openai-codex/*` models validate without an API key.
- [x] `openai-codex/*` calls use ChatGPT OAuth credentials and the Codex Responses SSE endpoint.
- [x] Responses SSE parsing handles text, tool calls, usage, and avoids duplicate text from deltas plus done events.
- [x] Catalog update tooling no longer filters ChatGPT subscription models through LiteLLM.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_oauth_model_sync.py test/test_oauth_model_catalog.py test/test_oauth_model_discovery.py test/test_update_oauth_model_catalog.py test/test_openai_codex_adapter.py test/test_litellm_adapter.py test/test_model_manager_chatgpt.py`
- [x] `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check` typecheck stage

## Smoke Run (Real CLI)

- [ ] Live LLM smoke not run. This requires ChatGPT subscription network usage and explicit live-LLM confirmation.
- [x] Non-live catalog smoke: bundled ChatGPT models start with `openai-codex/gpt-5.5`, `openai-codex/gpt-5.5-pro`, `openai-codex/gpt-5.4`, `openai-codex/gpt-5.4-pro`.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? ChatGPT subscription model IDs change from `chatgpt/*` to `openai-codex/*`; stale manually configured `chatgpt/*` entries may still route through LiteLLM but are no longer seeded by login.
- Worst-case input/output size? Same conversation payload size as existing adapter path; SSE events are accumulated for one response before conversion.
- Any secrets/logging risks? OAuth token is only sent as an Authorization header and is not logged.
- Any async/blocking I/O added on hot paths? Uses `httpx.AsyncClient.stream`; no blocking network I/O added.
- What error message does the user see on failure? Missing/expired login asks the user to run `/login`; HTTP failures include Codex HTTP status and response details when available.

## Docs / Compatibility

- [x] Updated relevant docs (`docs/configuration.md`, `docs/cli-guide.md`, `docs/bot-guide.md`).
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).
