### PR TITLE
[codex] Introduce LLM adapter factory

### DIFF
--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -19,9 +19,10 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable, Protocol
 
 from ouro.core.llm import (
-    LiteLLMAdapter,
+    LLMAdapter,
     LLMMessage,
     ModelManager,
+    create_llm_adapter,
     display_reasoning_effort,
 )
 from ouro.core.log import get_logger
@@ -93,7 +94,7 @@ class AgentBuilder:
     fully wired `ComposedAgent`.
     """
 
-    llm: LiteLLMAdapter | None = None
+    llm: LLMAdapter | None = None
     model_manager: ModelManager | None = None
     tools: list[BaseTool] = field(default_factory=list)
     max_iterations: int = 1000
@@ -122,7 +123,7 @@ class AgentBuilder:
     # ---- LLM ----------------------------------------------------------------
 
     def with_llm(
-        self, llm: LiteLLMAdapter, *, model_manager: ModelManager | None = None
+        self, llm: LLMAdapter, *, model_manager: ModelManager | None = None
     ) -> AgentBuilder:
         self.llm = llm
         self.model_manager = model_manager
@@ -415,7 +416,7 @@ class ComposedAgent:
         self,
         *,
         core: Agent,
-        llm: LiteLLMAdapter,
+        llm: LLMAdapter,
         model_manager: ModelManager | None,
         tool_executor: ToolExecutor,
         todo_list: TodoList,
@@ -629,7 +630,7 @@ class ComposedAgent:
         if not new_profile:
             logger.error(f"Failed to switch to model '{model_id}'")
             return False
-        new_llm = LiteLLMAdapter(
+        new_llm = create_llm_adapter(
             model=new_profile.model_id,
             api_key=new_profile.api_key,
             api_base=new_profile.api_base,

--- a/ouro/capabilities/compaction/compressor.py
+++ b/ouro/capabilities/compaction/compressor.py
@@ -14,7 +14,7 @@ from .types import CompressedMemory, CompressionStrategy
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ouro.core.llm import LiteLLMAdapter
+    from ouro.core.llm import LLMAdapter
 
 
 class WorkingMemoryCompressor:
@@ -68,7 +68,7 @@ Original messages ({count} messages, ~{tokens} tokens):
         "will be kept verbatim and don't need to be in your summary."
     )
 
-    def __init__(self, llm: "LiteLLMAdapter"):
+    def __init__(self, llm: "LLMAdapter"):
         """Initialize compressor.
 
         Args:

--- a/ouro/capabilities/compaction/manager.py
+++ b/ouro/capabilities/compaction/manager.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from ouro.core.llm import LiteLLMAdapter
+    from ouro.core.llm import LLMAdapter
 
 
 class CompactionManager:
@@ -34,7 +34,7 @@ class CompactionManager:
     on lists passed in by callers (e.g. ``MemoryManager``).
     """
 
-    def __init__(self, llm: LiteLLMAdapter) -> None:
+    def __init__(self, llm: LLMAdapter) -> None:
         self.llm = llm
         self.compressor = WorkingMemoryCompressor(llm)
 

--- a/ouro/capabilities/memory/blocks/manager.py
+++ b/ouro/capabilities/memory/blocks/manager.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ouro.core.llm import LiteLLMAdapter
+    from ouro.core.llm import LLMAdapter
 
 
 # Default blocks shipped with ouro. Users can add their own by writing a file
@@ -49,7 +49,7 @@ class _Block:
     tokens: int
 
 
-def _count_tokens(text: str, llm: LiteLLMAdapter | None) -> int:
+def _count_tokens(text: str, llm: LLMAdapter | None) -> int:
     """Token count via litellm with a safe fallback heuristic."""
     if not text:
         return 0
@@ -70,7 +70,7 @@ def _count_tokens(text: str, llm: LiteLLMAdapter | None) -> int:
     return max(1, len(text) // 3)
 
 
-def _fifo_truncate(existing: str, addition: str, budget: int, llm: LiteLLMAdapter | None) -> str:
+def _fifo_truncate(existing: str, addition: str, budget: int, llm: LLMAdapter | None) -> str:
     """Drop oldest paragraphs from *existing* until *existing + addition* fits the budget.
 
     Splits on blank lines so we trim whole "entries" instead of mid-sentence.
@@ -128,7 +128,7 @@ class MemoryBlockManager:
 
     def __init__(
         self,
-        llm: LiteLLMAdapter | None = None,
+        llm: LLMAdapter | None = None,
         memory_dir: str | None = None,
         block_budgets: dict[str, int] | None = None,
     ) -> None:

--- a/ouro/capabilities/memory/manager.py
+++ b/ouro/capabilities/memory/manager.py
@@ -34,7 +34,7 @@ from .token_tracker import TokenTracker
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ouro.core.llm import LiteLLMAdapter
+    from ouro.core.llm import LLMAdapter
 
 
 class MemoryManager:
@@ -42,7 +42,7 @@ class MemoryManager:
 
     def __init__(
         self,
-        llm: LiteLLMAdapter,
+        llm: LLMAdapter,
         session_id: str | None = None,
         sessions_dir: str | None = None,
         memory_dir: str | None = None,
@@ -82,7 +82,7 @@ class MemoryManager:
     async def from_session(
         cls,
         session_id: str,
-        llm: LiteLLMAdapter,
+        llm: LLMAdapter,
         sessions_dir: str | None = None,
         memory_dir: str | None = None,
         progress: ProgressSink | None = None,

--- a/ouro/core/llm/__init__.py
+++ b/ouro/core/llm/__init__.py
@@ -2,6 +2,8 @@
 
 # Import new types from message_types (primary source)
 # Import compatibility utilities
+# Import adapters
+from .adapter import LLMAdapter, create_llm_adapter
 from .compat import ensure_new_format, migrate_messages, normalize_stop_reason
 
 # Import utilities
@@ -11,8 +13,6 @@ from .content_utils import (
     extract_tool_calls_from_content,
     message_to_dict,
 )
-
-# Import adapter
 from .litellm_adapter import LiteLLMAdapter
 from .message_types import (
     FunctionCall,
@@ -42,7 +42,9 @@ __all__ = [
     "StopReason",
     "ToolOutput",
     # Adapter
+    "LLMAdapter",
     "LiteLLMAdapter",
+    "create_llm_adapter",
     # Model Manager
     "ModelManager",
     "ModelProfile",

--- a/ouro/core/llm/adapter.py
+++ b/ouro/core/llm/adapter.py
@@ -1,0 +1,49 @@
+"""LLM adapter protocol and provider router."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .message_types import LLMMessage, LLMResponse, ToolCall, ToolResult
+
+
+@runtime_checkable
+class LLMAdapter(Protocol):
+    """Runtime interface shared by concrete LLM provider adapters."""
+
+    model: str
+
+    async def call_async(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse: ...
+
+    def extract_text(self, response: LLMResponse) -> str: ...
+
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]: ...
+
+    def extract_thinking(self, response: LLMResponse) -> str | None: ...
+
+    def format_tool_results(self, results: list[ToolResult]) -> LLMMessage | list[LLMMessage]: ...
+
+    @property
+    def supports_tools(self) -> bool: ...
+
+    @property
+    def provider_name(self) -> str: ...
+
+
+def create_llm_adapter(model: str, **kwargs: Any) -> LLMAdapter:
+    """Create the concrete adapter for a model ID."""
+    provider = model.split("/", 1)[0] if "/" in model else "unknown"
+    if provider == "openai-codex":
+        from .openai_codex_adapter import OpenAICodexAdapter
+
+        return OpenAICodexAdapter(model, **kwargs)
+
+    from .litellm_adapter import LiteLLMAdapter
+
+    return LiteLLMAdapter(model, **kwargs)

--- a/ouro/core/llm/litellm_adapter.py
+++ b/ouro/core/llm/litellm_adapter.py
@@ -55,7 +55,7 @@ class LiteLLMAdapter:
         self.drop_params = kwargs.pop("drop_params", True)
         self.timeout = kwargs.pop("timeout", 600)
 
-        if self.provider == "chatgpt" or self.provider == "openai-codex":
+        if self.provider == "chatgpt":
             from .chatgpt_auth import configure_chatgpt_auth_env
 
             configure_chatgpt_auth_env()
@@ -197,15 +197,6 @@ class LiteLLMAdapter:
         **kwargs,
     ) -> LLMResponse:
         """Async LLM call via LiteLLM with automatic retry."""
-        if self.provider == "openai-codex":
-            from .openai_codex_adapter import OpenAICodexAdapter
-
-            return await OpenAICodexAdapter(
-                self.model,
-                api_base=self.api_base,
-                timeout=self.timeout,
-            ).call_async(messages, tools=tools, max_tokens=max_tokens, **kwargs)
-
         await self._ensure_provider_ready()
         litellm_messages, call_params = self._build_call_params(
             messages=messages,

--- a/ouro/core/llm/openai_codex_adapter.py
+++ b/ouro/core/llm/openai_codex_adapter.py
@@ -20,7 +20,7 @@ import httpx
 from ouro.core.log import get_logger
 
 from .content_utils import extract_text
-from .message_types import LLMMessage, LLMResponse, StopReason, ToolCallBlock
+from .message_types import LLMMessage, LLMResponse, StopReason, ToolCall, ToolCallBlock, ToolResult
 from .retry import with_retry
 
 logger = get_logger(__name__)
@@ -193,18 +193,39 @@ class OpenAICodexAdapter:
     def extract_text(self, response: LLMResponse) -> str:
         return response.content or ""
 
-    def extract_tool_calls(self, response: LLMResponse):
-        from .litellm_adapter import LiteLLMAdapter
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]:
+        if not response.tool_calls:
+            return []
 
-        return LiteLLMAdapter(self.model).extract_tool_calls(response)
+        tool_calls: list[ToolCall] = []
+        for tc in response.tool_calls:
+            try:
+                arguments = json.loads(tc["function"]["arguments"])
+            except (json.JSONDecodeError, KeyError):
+                arguments = {}
+
+            tool_calls.append(
+                ToolCall(
+                    id=tc["id"],
+                    name=tc["function"]["name"],
+                    arguments=arguments,
+                )
+            )
+        return tool_calls
 
     def extract_thinking(self, response: LLMResponse) -> str | None:
         return response.thinking
 
-    def format_tool_results(self, results):
-        from .litellm_adapter import LiteLLMAdapter
-
-        return LiteLLMAdapter(self.model).format_tool_results(results)
+    def format_tool_results(self, results: list[ToolResult]) -> list[LLMMessage]:
+        return [
+            LLMMessage(
+                role="tool",
+                content=result.content,
+                tool_call_id=result.tool_call_id,
+                name=result.name,
+            )
+            for result in results
+        ]
 
     @property
     def supports_tools(self) -> bool:

--- a/ouro/interfaces/cli/factory.py
+++ b/ouro/interfaces/cli/factory.py
@@ -20,7 +20,7 @@ from ouro.capabilities.tools.builtins.smart_edit import SmartEditTool
 from ouro.capabilities.tools.builtins.web_fetch import WebFetchTool
 from ouro.capabilities.tools.builtins.web_search import WebSearchTool
 from ouro.config import Config
-from ouro.core.llm import LiteLLMAdapter, ModelManager
+from ouro.core.llm import ModelManager, create_llm_adapter
 from ouro.interfaces.tui import terminal_ui
 from ouro.interfaces.tui.json_progress import JsonProgressSink
 from ouro.interfaces.tui.tui_progress import TuiProgressSink
@@ -73,7 +73,7 @@ def create_agent(
     if not is_valid:
         raise ValueError(error_msg)
 
-    llm = LiteLLMAdapter(
+    llm = create_llm_adapter(
         model=current_profile.model_id,
         api_key=current_profile.api_key,
         api_base=current_profile.api_base,

--- a/test/test_llm_adapter_factory.py
+++ b/test/test_llm_adapter_factory.py
@@ -1,0 +1,22 @@
+from ouro.core.llm import LLMAdapter, create_llm_adapter
+from ouro.core.llm.litellm_adapter import LiteLLMAdapter
+from ouro.core.llm.openai_codex_adapter import OpenAICodexAdapter
+
+
+def test_create_llm_adapter_routes_openai_codex_models() -> None:
+    adapter = create_llm_adapter("openai-codex/gpt-5.5", timeout=123)
+
+    assert isinstance(adapter, OpenAICodexAdapter)
+    assert isinstance(adapter, LLMAdapter)
+    assert adapter.model == "openai-codex/gpt-5.5"
+    assert adapter.timeout == 123
+
+
+def test_create_llm_adapter_routes_other_models_to_litellm() -> None:
+    adapter = create_llm_adapter("openai/gpt-4o", api_key="test", timeout=123)
+
+    assert isinstance(adapter, LiteLLMAdapter)
+    assert isinstance(adapter, LLMAdapter)
+    assert adapter.model == "openai/gpt-4o"
+    assert adapter.api_key == "test"
+    assert adapter.timeout == 123


### PR DESCRIPTION
## Summary

Introduces a core `LLMAdapter` protocol and `create_llm_adapter()` factory so concrete model providers can live as sibling adapters instead of being routed from inside `LiteLLMAdapter`.

## Scope

- Goals:
  - Make `LiteLLMAdapter` and `OpenAICodexAdapter` peer implementations of a shared adapter contract.
  - Move `openai-codex/*` routing out of `LiteLLMAdapter` and into a core adapter factory.
  - Update production adapter creation points to use `create_llm_adapter()`.
  - Type memory/compaction wiring against the shared `LLMAdapter` protocol.
- Non-goals:
  - No provider behavior changes.
  - No live LLM smoke run.
  - No replacement of LiteLLM for existing API-key providers.

## Invariants (Must Not Regress)

- [x] Non-`openai-codex` models still route to `LiteLLMAdapter`.
- [x] `openai-codex/*` models still route to `OpenAICodexAdapter`.
- [x] Existing direct `LiteLLMAdapter` unit tests remain valid.
- [x] Model switching still rebuilds the correct adapter for the selected model.
- [x] Three-layer import boundaries remain intact.

## Acceptance Criteria

- [x] `create_llm_adapter("openai-codex/gpt-5.5")` returns `OpenAICodexAdapter`.
- [x] `create_llm_adapter("openai/gpt-4o")` returns `LiteLLMAdapter`.
- [x] Production agent creation uses the factory.
- [x] Runtime model switching uses the factory.
- [x] `LiteLLMAdapter` no longer special-cases `openai-codex`.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_llm_adapter_factory.py test/test_openai_codex_adapter.py test/test_litellm_adapter.py test/test_model_manager_chatgpt.py`
- [x] `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check` typecheck stage

## Smoke Run (Real CLI)

- [ ] Live LLM smoke not run; this is an internal routing/type refactor and live model calls require explicit confirmation.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Adapter creation during startup or model switching; covered by factory tests and full suite.
- Worst-case input/output size? Unchanged; no message payload behavior changes.
- Any secrets/logging risks? No new credential handling.
- Any async/blocking I/O added on hot paths? No new I/O.
- What error message does the user see on failure? Existing adapter/auth errors are preserved.

## Docs / Compatibility

- [x] No user-facing docs needed; this is internal architecture.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).
