### PR TITLE
Refactor progress reporting into a single event bus

### DIFF
--- a/ouro/capabilities/swarm/auto_swarm_hook.py
+++ b/ouro/capabilities/swarm/auto_swarm_hook.py
@@ -7,6 +7,7 @@ from ouro.capabilities.swarm.coordinator import SwarmCoordinator
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.core.llm import LLMMessage
 from ouro.core.log import get_logger
+from ouro.core.loop import ProgressEvent
 
 logger = get_logger(__name__)
 
@@ -39,7 +40,12 @@ class AutoSwarmHook:
             return
 
         logger.info(f"AutoSwarm: Analyzing task complexity: {task[:100]}...")
-        ctx.progress.info("Analyzing task complexity for possible swarm execution...")
+        ctx.progress.emit(
+            ProgressEvent(
+                kind="info",
+                payload={"message": "Analyzing task complexity for possible swarm execution..."},
+            )
+        )
         analysis = await self.analyzer.analyze(task)
 
         logger.info(
@@ -52,12 +58,14 @@ class AutoSwarmHook:
             return
 
         subtasks = analysis.subtasks or []
-        ctx.progress.event(
-            "swarm_header",
-            {
-                "line": f"Swarm selected: complexity={analysis.complexity_score:.2f}, subtasks={len(subtasks)}",
-                "title": "Swarm",
-            },
+        ctx.progress.emit(
+            ProgressEvent(
+                kind="swarm_header",
+                payload={
+                    "line": f"Swarm selected: complexity={analysis.complexity_score:.2f}, subtasks={len(subtasks)}",
+                    "title": "Swarm",
+                },
+            )
         )
         logger.info(f"AutoSwarm: Decomposing into {len(subtasks)} subtasks")
 
@@ -67,11 +75,13 @@ class AutoSwarmHook:
         db_path = Path(tempfile.gettempdir()) / f"ouro-swarm-{id(task)}.db"
         store = TaskStore(str(db_path))
 
-        ctx.progress.event("swarm_reset", {"keep_headers": True})
+        ctx.progress.emit(ProgressEvent(kind="swarm_reset", payload={"keep_headers": True}))
         for idx, subtask in enumerate(subtasks, start=1):
-            ctx.progress.event(
-                "swarm_plan_item",
-                {"line": f"#{idx} {subtask['subject']}", "title": "Swarm Plan"},
+            ctx.progress.emit(
+                ProgressEvent(
+                    kind="swarm_plan_item",
+                    payload={"line": f"#{idx} {subtask['subject']}", "title": "Swarm Plan"},
+                )
             )
             store.create(
                 subject=subtask["subject"],
@@ -89,9 +99,11 @@ class AutoSwarmHook:
         num_agents = min(len(subtasks), self.max_agents)
         await coordinator.spawn_agents(n=num_agents)
 
-        ctx.progress.event(
-            "swarm_header",
-            {"line": f"Starting swarm with {num_agents} agent(s)...", "title": "Swarm"},
+        ctx.progress.emit(
+            ProgressEvent(
+                kind="swarm_header",
+                payload={"line": f"Starting swarm with {num_agents} agent(s)...", "title": "Swarm"},
+            )
         )
         logger.info(f"AutoSwarm: Running {num_agents} agents...")
         await coordinator.run_until_done()
@@ -99,14 +111,16 @@ class AutoSwarmHook:
         status = coordinator.get_status()
         tasks = store.list_all()
 
-        ctx.progress.event(
-            "swarm_status",
-            {
-                "line": "Swarm complete: "
-                f"{status.completed}/{status.total_tasks} tasks done, "
-                f"{status.in_progress} running, {status.blocked} blocked",
-                "title": "Swarm Result",
-            },
+        ctx.progress.emit(
+            ProgressEvent(
+                kind="swarm_status",
+                payload={
+                    "line": "Swarm complete: "
+                    f"{status.completed}/{status.total_tasks} tasks done, "
+                    f"{status.in_progress} running, {status.blocked} blocked",
+                    "title": "Swarm Result",
+                },
+            )
         )
 
         result_parts = [

--- a/ouro/capabilities/swarm/coordinator.py
+++ b/ouro/capabilities/swarm/coordinator.py
@@ -20,7 +20,7 @@ from ouro.capabilities.tasks.engine import TaskEngine
 from ouro.capabilities.tasks.models import TaskStatus
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.core.log import get_logger
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 if TYPE_CHECKING:
     from ouro.capabilities.builder import ComposedAgent
@@ -94,7 +94,9 @@ class SwarmCoordinator:
             self.agents[agent_id] = handle
             ids.append(agent_id)
             logger.info(f"Spawned agent {agent_id}")
-            self.progress.event("swarm_agent", {"agent": agent_id, "title": "Swarm"})
+            self.progress.emit(
+                ProgressEvent(kind="swarm_agent", payload={"agent": agent_id, "title": "Swarm"})
+            )
         return ids
 
     async def remove_agent(self, agent_id: str) -> bool:
@@ -116,16 +118,18 @@ class SwarmCoordinator:
         idle_count = 0
         while not self._shutdown:
             status = self.get_status()
-            self.progress.event(
-                "swarm_status",
-                {
-                    "line": "Swarm status: "
-                    f"{status.completed}/{status.total_tasks} done, "
-                    f"{status.in_progress} running, "
-                    f"{status.blocked} blocked, "
-                    f"{status.pending} pending",
-                    "title": "Swarm Status",
-                },
+            self.progress.emit(
+                ProgressEvent(
+                    kind="swarm_status",
+                    payload={
+                        "line": "Swarm status: "
+                        f"{status.completed}/{status.total_tasks} done, "
+                        f"{status.in_progress} running, "
+                        f"{status.blocked} blocked, "
+                        f"{status.pending} pending",
+                        "title": "Swarm Status",
+                    },
+                )
             )
             if status.pending == 0 and status.in_progress == 0:
                 idle_count += 1
@@ -160,13 +164,15 @@ class SwarmCoordinator:
             if result.success:
                 handle.task_ids.append(task.id)
                 handle.last_heartbeat = time.time()
-                self.progress.event(
-                    "swarm_assignment",
-                    {
-                        "agent": handle.agent_id,
-                        "assignment": f"task #{task.id}: {task.activeForm or task.subject}",
-                        "title": "Swarm",
-                    },
+                self.progress.emit(
+                    ProgressEvent(
+                        kind="swarm_assignment",
+                        payload={
+                            "agent": handle.agent_id,
+                            "assignment": f"task #{task.id}: {task.activeForm or task.subject}",
+                            "title": "Swarm",
+                        },
+                    )
                 )
                 # Fire-and-forget task execution
                 asyncio.create_task(
@@ -181,13 +187,15 @@ class SwarmCoordinator:
             return
 
         try:
-            self.progress.event(
-                "swarm_assignment",
-                {
-                    "agent": handle.agent_id,
-                    "assignment": f"task #{task_id}: {task.activeForm or task.subject}",
-                    "title": "Swarm",
-                },
+            self.progress.emit(
+                ProgressEvent(
+                    kind="swarm_assignment",
+                    payload={
+                        "agent": handle.agent_id,
+                        "assignment": f"task #{task_id}: {task.activeForm or task.subject}",
+                        "title": "Swarm",
+                    },
+                )
             )
             # Build the task prompt
             prompt = self._build_task_prompt(task)
@@ -199,25 +207,29 @@ class SwarmCoordinator:
             self.engine.complete_task(task_id)
             handle.total_tasks_completed += 1
             logger.info(f"Agent {handle.agent_id} completed task {task_id}")
-            self.progress.event(
-                "swarm_assignment",
-                {
-                    "agent": handle.agent_id,
-                    "assignment": f"completed #{task_id}: {task.subject}",
-                    "title": "Swarm",
-                },
+            self.progress.emit(
+                ProgressEvent(
+                    kind="swarm_assignment",
+                    payload={
+                        "agent": handle.agent_id,
+                        "assignment": f"completed #{task_id}: {task.subject}",
+                        "title": "Swarm",
+                    },
+                )
             )
 
         except Exception as e:
             logger.error(f"Agent {handle.agent_id} failed task {task_id}: {e}")
             handle.total_tasks_failed += 1
-            self.progress.event(
-                "swarm_assignment",
-                {
-                    "agent": handle.agent_id,
-                    "assignment": f"failed #{task_id}; returning it to the queue",
-                    "title": "Swarm",
-                },
+            self.progress.emit(
+                ProgressEvent(
+                    kind="swarm_assignment",
+                    payload={
+                        "agent": handle.agent_id,
+                        "assignment": f"failed #{task_id}; returning it to the queue",
+                        "title": "Swarm",
+                    },
+                )
             )
             # Unassign so another agent can try
             self.store.unassign(task_id)

--- a/ouro/capabilities/tools/builtins/task_claim.py
+++ b/ouro/capabilities/tools/builtins/task_claim.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.capabilities.tools.base import BaseTool
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 class TaskClaimTool(BaseTool):
@@ -75,13 +75,15 @@ Returns:
         if result.success:
             assert result.task is not None
             display = result.task.activeForm or result.task.subject
-            self._progress.event(
-                "task_status",
-                {
-                    "line": f"[in_progress] #{taskId} ({owner}) {display}",
-                    "summary": f"Claimed task #{taskId}: {result.task.subject}",
-                    "title": "Task Claimed",
-                },
+            self._progress.emit(
+                ProgressEvent(
+                    kind="task_status",
+                    payload={
+                        "line": f"[in_progress] #{taskId} ({owner}) {display}",
+                        "summary": f"Claimed task #{taskId}: {result.task.subject}",
+                        "title": "Task Claimed",
+                    },
+                )
             )
             return f"Claimed task #{taskId}: {result.task.subject}"
 

--- a/ouro/capabilities/tools/builtins/task_create.py
+++ b/ouro/capabilities/tools/builtins/task_create.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.capabilities.tools.base import BaseTool
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 class TaskCreateTool(BaseTool):
@@ -97,12 +97,14 @@ The task will be created with status "pending" and can be claimed later."""
             # Update task's blockedBy
             self._store.update(task.id, blockedBy=list(blockedBy))
 
-        self._progress.event(
-            "task_status",
-            {
-                "line": f"[pending] #{task.id} {task.activeForm or task.subject}",
-                "summary": f"Created task #{task.id}: {task.subject}",
-                "title": "Task Created",
-            },
+        self._progress.emit(
+            ProgressEvent(
+                kind="task_status",
+                payload={
+                    "line": f"[pending] #{task.id} {task.activeForm or task.subject}",
+                    "summary": f"Created task #{task.id}: {task.subject}",
+                    "title": "Task Created",
+                },
+            )
         )
         return f"Created task #{task.id}: {task.subject}"

--- a/ouro/capabilities/tools/builtins/task_list.py
+++ b/ouro/capabilities/tools/builtins/task_list.py
@@ -7,7 +7,7 @@ from typing import Any
 from ouro.capabilities.tasks.engine import TaskEngine
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.capabilities.tools.base import BaseTool
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 class TaskListTool(BaseTool):
@@ -61,5 +61,5 @@ No parameters required."""
 
     async def execute(self, **kwargs: Any) -> str:
         structured = self.execute_structured()
-        self._progress.event(structured["kind"], structured["payload"])
+        self._progress.emit(ProgressEvent(kind=structured["kind"], payload=structured["payload"]))
         return self._engine.format_task_list()

--- a/ouro/capabilities/tools/builtins/task_update.py
+++ b/ouro/capabilities/tools/builtins/task_update.py
@@ -7,7 +7,7 @@ from typing import Any
 from ouro.capabilities.tasks.models import TaskStatus
 from ouro.capabilities.tasks.store import TaskStore
 from ouro.capabilities.tools.base import BaseTool
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 class TaskUpdateTool(BaseTool):
@@ -214,12 +214,14 @@ EXAMPLES:
         if updated.owner:
             line += f" ({updated.owner})"
         line += f" {display}"
-        self._progress.event(
-            "task_status",
-            {
-                "line": line,
-                "summary": f"Updated task #{taskId}: {changes or 'fields updated'}",
-                "title": "Task Updated",
-            },
+        self._progress.emit(
+            ProgressEvent(
+                kind="task_status",
+                payload={
+                    "line": line,
+                    "summary": f"Updated task #{taskId}: {changes or 'fields updated'}",
+                    "title": "Task Updated",
+                },
+            )
         )
         return f"Updated task #{taskId}: {changes or 'fields updated'}"

--- a/ouro/capabilities/verification/hook.py
+++ b/ouro/capabilities/verification/hook.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 
 from ouro.core.llm import LLMMessage, LLMResponse
 from ouro.core.log import get_logger
-from ouro.core.loop.protocols import ContinueDecision, LoopContext, NullProgressSink, ProgressSink
+from ouro.core.loop.protocols import (
+    ContinueDecision,
+    LoopContext,
+    NullProgressSink,
+    ProgressEvent,
+    ProgressSink,
+)
 
 from .verifier import LLMVerifier, VerificationResult, Verifier
 
@@ -48,8 +54,13 @@ class VerificationHook:
 
         self._outer_iteration += 1
         if self._outer_iteration >= self._max_iterations:
-            ctx.progress.unfinished_answer(
-                f"Verification skipped (max iterations {self._max_iterations} reached)."
+            ctx.progress.emit(
+                ProgressEvent(
+                    kind="unfinished_answer",
+                    payload={
+                        "text": f"Verification skipped (max iterations {self._max_iterations} reached)."
+                    },
+                )
             )
             return ContinueDecision.stop()
 
@@ -78,8 +89,16 @@ class VerificationHook:
         self._previous_results.append(verification)
 
         if verification.complete:
-            ctx.progress.info(
-                f"✓ Verification passed (attempt {self._outer_iteration}/{self._max_iterations}): {verification.reason}"
+            ctx.progress.emit(
+                ProgressEvent(
+                    kind="verification_status",
+                    payload={
+                        "status": "passed",
+                        "attempt": self._outer_iteration,
+                        "max_attempts": self._max_iterations,
+                        "reason": verification.reason,
+                    },
+                )
             )
             return ContinueDecision.stop()
 
@@ -88,8 +107,16 @@ class VerificationHook:
             f"Feedback: {verification.reason}\n\n"
             f"Please address the feedback and provide a complete answer."
         )
-        ctx.progress.unfinished_answer(final)
-        ctx.progress.info(
-            f"⟳ Verification feedback (attempt {self._outer_iteration}/{self._max_iterations}): {verification.reason}"
+        ctx.progress.emit(ProgressEvent(kind="unfinished_answer", payload={"text": final}))
+        ctx.progress.emit(
+            ProgressEvent(
+                kind="verification_status",
+                payload={
+                    "status": "failed",
+                    "attempt": self._outer_iteration,
+                    "max_attempts": self._max_iterations,
+                    "reason": verification.reason,
+                },
+            )
         )
         return ContinueDecision.retry_with_feedback(LLMMessage(role="user", content=feedback))

--- a/ouro/core/loop/__init__.py
+++ b/ouro/core/loop/__init__.py
@@ -23,6 +23,8 @@ from .protocols import (
     Hook,
     LoopContext,
     NullProgressSink,
+    ProgressEvent,
+    ProgressEventKind,
     ProgressSink,
     ToolRegistry,
 )
@@ -38,6 +40,8 @@ __all__ = [
     "Hook",
     "LoopContext",
     "NullProgressSink",
+    "ProgressEvent",
+    "ProgressEventKind",
     "ProgressSink",
     "ToolRegistry",
     "Rule",

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -23,6 +23,7 @@ from .protocols import (
     Hook,
     LoopContext,
     NullProgressSink,
+    ProgressEvent,
     ProgressSink,
     ToolRegistry,
 )
@@ -123,7 +124,7 @@ class Agent:
             if extract_thinking is not None:
                 thinking = extract_thinking(response)
                 if thinking:
-                    self.progress.thinking(thinking)
+                    self.progress.emit(ProgressEvent(kind="thinking", payload={"text": thinking}))
 
             if response.stop_reason == StopReason.STOP:
                 # Persist the assistant's final reply into the loop's
@@ -134,7 +135,9 @@ class Agent:
                 final_answer = self.llm.extract_text(response)
                 cont = await self._aggregate_continue(ctx, messages, response, finished=True)
                 if cont.kind == ContinueKind.STOP:
-                    self.progress.final_answer(final_answer)
+                    self.progress.emit(
+                        ProgressEvent(kind="final_answer", payload={"text": final_answer})
+                    )
                     return final_answer
                 if cont.kind == ContinueKind.RETRY:
                     for fb in cont.feedback_messages:
@@ -144,7 +147,12 @@ class Agent:
 
             if response.stop_reason == StopReason.TOOL_CALLS:
                 if response.content:
-                    self.progress.assistant_message(response.content)
+                    self.progress.emit(
+                        ProgressEvent(
+                            kind="assistant_message",
+                            payload={"text": response.content},
+                        )
+                    )
 
                 tool_calls = self.llm.extract_tool_calls(response)
                 if not tool_calls:
@@ -163,7 +171,16 @@ class Agent:
                     blocked = self._rules_before(ctx, tool_calls)
                     for tc in tool_calls:
                         if tc.id in blocked:
-                            self.progress.tool_blocked(tc.name, tc.arguments, blocked[tc.id])
+                            self.progress.emit(
+                                ProgressEvent(
+                                    kind="tool_blocked",
+                                    payload={
+                                        "name": tc.name,
+                                        "arguments": tc.arguments,
+                                        "reason": blocked[tc.id],
+                                    },
+                                )
+                            )
                     remaining = [tc for tc in tool_calls if tc.id not in blocked]
 
                     contents: dict[str, str] = dict(blocked)
@@ -213,7 +230,9 @@ class Agent:
                     len(partial),
                 )
                 final_answer = partial or f"[truncated at max_tokens={self.max_tokens_per_call}]"
-                self.progress.unfinished_answer(final_answer)
+                self.progress.emit(
+                    ProgressEvent(kind="unfinished_answer", payload={"text": final_answer})
+                )
                 return final_answer
 
             # Unknown / unexpected stop_reason — terminate instead of
@@ -349,10 +368,15 @@ class Agent:
     ) -> list[ToolResult]:
         results: list[ToolResult] = []
         for tc in tool_calls:
-            self.progress.tool_call(tc.name, tc.arguments)
+            self.progress.emit(
+                ProgressEvent(
+                    kind="tool_call",
+                    payload={"name": tc.name, "arguments": tc.arguments},
+                )
+            )
             async with self.progress.spinner(f"Executing {tc.name}...", title="Working"):
                 output = await self.tools.execute_tool_call(tc.name, tc.arguments)
-            self.progress.tool_result(str(output))
+            self.progress.emit(ProgressEvent(kind="tool_result", payload={"text": output.content}))
             results.append(
                 ToolResult(
                     tool_call_id=tc.id,
@@ -367,7 +391,12 @@ class Agent:
         self, ctx: RunStatistic, tool_calls: list[ToolCall]
     ) -> list[ToolResult]:
         for tc in tool_calls:
-            self.progress.tool_call(tc.name, tc.arguments)
+            self.progress.emit(
+                ProgressEvent(
+                    kind="tool_call",
+                    payload={"name": tc.name, "arguments": tc.arguments},
+                )
+            )
 
         outputs: list[ToolOutput | None] = [None] * len(tool_calls)
 
@@ -386,7 +415,7 @@ class Agent:
         for i, tc in enumerate(tool_calls):
             out = outputs[i]
             content = out.content if out is not None else ""
-            self.progress.tool_result(content)
+            self.progress.emit(ProgressEvent(kind="tool_result", payload={"text": content}))
             results.append(
                 ToolResult(
                     tool_call_id=tc.id,

--- a/ouro/core/loop/protocols.py
+++ b/ouro/core/loop/protocols.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Protocol,
-    runtime_checkable,
-)
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from ouro.core.llm import LLMMessage, LLMResponse, ToolOutput
@@ -31,6 +26,34 @@ class ToolRegistry(Protocol):
     async def execute_tool_call(self, name: str, arguments: dict[str, Any]) -> ToolOutput: ...
 
 
+ProgressEventKind = Literal[
+    "info",
+    "thinking",
+    "assistant_message",
+    "tool_call",
+    "tool_result",
+    "tool_blocked",
+    "task_list",
+    "task_status",
+    "swarm_reset",
+    "swarm_header",
+    "swarm_plan_item",
+    "swarm_agent",
+    "swarm_assignment",
+    "swarm_status",
+    "verification_status",
+    "final_answer",
+    "unfinished_answer",
+    "session_loaded",
+]
+
+
+@dataclass(frozen=True)
+class ProgressEvent:
+    kind: ProgressEventKind
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
 class _NullSpinner:
     async def __aenter__(self) -> _NullSpinner:
         return self
@@ -41,45 +64,13 @@ class _NullSpinner:
 
 @runtime_checkable
 class ProgressSink(Protocol):
-    def info(self, msg: str) -> None: ...
-    def event(self, kind: str, payload: dict[str, Any]) -> None: ...
-    def thinking(self, text: str) -> None: ...
-    def assistant_message(self, content: Any) -> None: ...
-    def tool_call(self, name: str, arguments: dict[str, Any]) -> None: ...
-    def tool_result(self, result: str) -> None: ...
-    def tool_blocked(self, name: str, arguments: dict[str, Any], reason: str) -> None: ...
-    def final_answer(self, text: str) -> None: ...
-    def unfinished_answer(self, text: str) -> None: ...
+    def emit(self, event: ProgressEvent) -> None: ...
     def spinner(self, label: str, title: str | None = None) -> AbstractAsyncContextManager[Any]: ...
     def on_session_loaded(self, messages: list[Any]) -> None: ...
 
 
 class NullProgressSink:
-    def info(self, msg: str) -> None:
-        pass
-
-    def event(self, kind: str, payload: dict[str, Any]) -> None:
-        pass
-
-    def thinking(self, text: str) -> None:
-        pass
-
-    def assistant_message(self, content: Any) -> None:
-        pass
-
-    def tool_call(self, name: str, arguments: dict[str, Any]) -> None:
-        pass
-
-    def tool_result(self, result: str) -> None:
-        pass
-
-    def tool_blocked(self, name: str, arguments: dict[str, Any], reason: str) -> None:
-        pass
-
-    def final_answer(self, text: str) -> None:
-        pass
-
-    def unfinished_answer(self, text: str) -> None:
+    def emit(self, event: ProgressEvent) -> None:
         pass
 
     def spinner(self, label: str, title: str | None = None) -> AbstractAsyncContextManager[Any]:

--- a/ouro/interfaces/tui/json_progress.py
+++ b/ouro/interfaces/tui/json_progress.py
@@ -6,7 +6,7 @@ import json
 from contextlib import AbstractAsyncContextManager
 from typing import Any
 
-from ouro.core.loop import NullProgressSink
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 class JsonProgressSink:
@@ -24,42 +24,11 @@ class JsonProgressSink:
             if callable(flush):
                 flush()
 
-    def info(self, msg: str) -> None:
-        self._emit({"type": "info", "message": msg})
-
-    def event(self, kind: str, payload: dict[str, Any]) -> None:
-        self._emit({"type": "event", "kind": kind, "payload": payload})
-
-    def thinking(self, text: str) -> None:
-        self._emit({"type": "thinking", "text": text})
-
-    def assistant_message(self, content: Any) -> None:
-        self._emit({"type": "assistant_message", "content": content})
-
-    def tool_call(self, name: str, arguments: dict[str, Any]) -> None:
-        self._emit({"type": "tool_call", "name": name, "arguments": arguments})
-
-    def tool_result(self, result: str) -> None:
-        self._emit({"type": "tool_result", "result": result})
-
-    def tool_blocked(self, name: str, arguments: dict[str, Any], reason: str) -> None:
-        self._emit(
-            {
-                "type": "tool_blocked",
-                "name": name,
-                "arguments": arguments,
-                "reason": reason,
-            }
-        )
-
-    def final_answer(self, text: str) -> None:
-        self._emit({"type": "final_answer", "text": text})
-
-    def unfinished_answer(self, text: str) -> None:
-        self._emit({"type": "unfinished_answer", "text": text})
+    def emit(self, event: ProgressEvent) -> None:
+        self._emit({"kind": event.kind, "payload": event.payload})
 
     def spinner(self, label: str, title: str | None = None) -> AbstractAsyncContextManager[Any]:
         return self._null.spinner(label, title)
 
     def on_session_loaded(self, messages: list[Any]) -> None:
-        self._emit({"type": "session_loaded", "count": len(messages)})
+        self.emit(ProgressEvent(kind="session_loaded", payload={"count": len(messages)}))

--- a/ouro/interfaces/tui/tui_progress.py
+++ b/ouro/interfaces/tui/tui_progress.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from contextlib import AbstractAsyncContextManager
 from typing import Any
 
+from ouro.core.loop import ProgressEvent
 from ouro.interfaces.tui import terminal_ui
 from ouro.interfaces.tui.progress import AsyncSpinner
 
@@ -25,116 +26,68 @@ class TuiProgressSink:
         self._swarm_header_lines: list[str] = []
         self._swarm_status_line: str | None = None
 
-    def info(self, msg: str) -> None:
-        if not msg:
+    def emit(self, event: ProgressEvent) -> None:
+        kind = event.kind
+        payload = event.payload
+
+        if kind == "info":
+            message = payload.get("message")
+            if isinstance(message, str) and message:
+                terminal_ui.print_info(message)
             return
 
-        if msg.startswith("Tasks:\n"):
-            self._render_task_list(msg)
+        if kind == "thinking":
+            text = payload.get("text")
+            if isinstance(text, str) and text:
+                terminal_ui.print_thinking(text)
             return
 
-        if msg == "Swarm plan:":
-            self._reset_swarm_state(keep_headers=True)
+        if kind == "assistant_message":
+            content = payload.get("text", payload.get("content"))
+            if content is not None:
+                terminal_ui.print_assistant_message(content)
             return
 
-        if msg.startswith("  #"):
-            self._swarm_plan_lines.append(msg.strip())
-            self._render_swarm_runtime("Swarm Plan")
+        if kind == "tool_call":
+            name = payload.get("name")
+            arguments = payload.get("arguments")
+            if isinstance(name, str) and isinstance(arguments, dict):
+                terminal_ui.print_tool_call(name, arguments)
             return
 
-        if msg.startswith("Swarm selected:") or msg.startswith("Starting swarm with "):
-            self._swarm_header_lines.append(msg)
-            self._render_swarm_runtime()
+        if kind == "tool_result":
+            result = payload.get("text")
+            if isinstance(result, str):
+                terminal_ui.print_tool_result(result)
             return
 
-        if msg.startswith("Swarm agent ready:"):
-            agent = msg.removeprefix("Swarm agent ready:").strip()
-            if agent and agent not in self._swarm_agents:
-                self._swarm_agents.append(agent)
-            self._render_swarm_runtime()
+        if kind == "tool_blocked":
+            name = payload.get("name")
+            arguments = payload.get("arguments")
+            reason = payload.get("reason")
+            if isinstance(name, str) and isinstance(arguments, dict) and isinstance(reason, str):
+                terminal_ui.print_tool_blocked(name, arguments, reason)
             return
 
-        if " claimed task #" in msg:
-            agent, task = msg.split(" claimed task #", 1)
-            self._swarm_assignments[agent.strip()] = f"task #{task.strip()}"
-            self._render_swarm_runtime()
+        if kind == "final_answer":
+            # The interactive shell renders the returned final answer itself;
+            # no additional marker is needed.
             return
 
-        if " is working on task #" in msg:
-            agent, task = msg.split(" is working on task #", 1)
-            self._swarm_assignments[agent.strip()] = f"task #{task.strip()}"
-            self._render_swarm_runtime()
+        if kind == "unfinished_answer":
+            text = payload.get("text")
+            if isinstance(text, str):
+                terminal_ui.print_unfinished_answer(text)
             return
 
-        if " completed task #" in msg:
-            agent, task = msg.split(" completed task #", 1)
-            self._swarm_assignments[agent.strip()] = f"completed #{task.strip()}"
-            self._render_swarm_runtime()
-            return
-
-        if " failed task #" in msg:
-            agent, task = msg.split(" failed task #", 1)
-            self._swarm_assignments[agent.strip()] = f"failed #{task.strip()}"
-            self._render_swarm_runtime()
-            return
-
-        if msg.startswith("Swarm status:"):
-            self._swarm_status_line = msg
-            self._render_swarm_runtime("Swarm Status")
-            return
-
-        if msg.startswith("Swarm complete:"):
-            self._swarm_status_line = msg
-            self._render_swarm_runtime("Swarm Result")
-            return
-
-        terminal_ui.print_info(msg)
-
-    def _render_task_list(self, msg: str) -> None:
-        lines = msg.splitlines()
-        task_lines = [line for line in lines[1:] if line and not line.startswith("Summary:")]
-        summary = next((line for line in lines if line.startswith("Summary:")), None)
-        terminal_ui.print_task_summary(task_lines, summary=summary)
-
-    def _reset_swarm_state(self, keep_headers: bool = False) -> None:
-        self._swarm_plan_lines = []
-        self._swarm_agents = []
-        self._swarm_assignments = {}
-        self._swarm_status_line = None
-        if not keep_headers:
-            self._swarm_header_lines = []
-
-    def _render_swarm_runtime(self, title: str = "Swarm") -> None:
-        lines: list[str] = []
-        if self._swarm_header_lines:
-            lines.extend(self._swarm_header_lines)
-        if self._swarm_plan_lines:
-            if lines:
-                lines.append("")
-            lines.append("Plan:")
-            lines.extend(self._swarm_plan_lines)
-        if self._swarm_agents:
-            if lines:
-                lines.append("")
-            lines.append(f"Agents: {', '.join(self._swarm_agents)}")
-        if self._swarm_assignments:
-            if lines:
-                lines.append("")
-            lines.append("Assignments:")
-            lines.extend(
-                f"- {agent}: {self._swarm_assignments[agent]}"
-                for agent in sorted(self._swarm_assignments)
-            )
-        if self._swarm_status_line:
-            if lines:
-                lines.append("")
-            lines.append(self._swarm_status_line)
-        terminal_ui.print_swarm_summary(lines, title=title)
-
-    def event(self, kind: str, payload: dict[str, Any]) -> None:
         if kind == "task_list":
-            task_lines = list(payload.get("task_lines", []))
+            task_lines = payload.get("task_lines")
             summary = payload.get("summary")
+            if not isinstance(task_lines, list) or not all(
+                isinstance(line, str) for line in task_lines
+            ):
+                terminal_ui.print_info(f"[{kind}] {payload}")
+                return
             terminal_ui.print_task_summary(task_lines, summary=summary)
             return
 
@@ -147,6 +100,22 @@ class TuiProgressSink:
                 summary=summary,
                 title=payload.get("title", "Task Update"),
             )
+            return
+
+        if kind == "verification_status":
+            status = payload.get("status")
+            attempt = payload.get("attempt")
+            max_attempts = payload.get("max_attempts")
+            reason = payload.get("reason")
+            if (
+                all(isinstance(value, int) for value in (attempt, max_attempts))
+                and isinstance(status, str)
+                and isinstance(reason, str)
+            ):
+                prefix = "✓" if status == "passed" else "⟳"
+                terminal_ui.print_info(
+                    f"{prefix} Verification {status} (attempt {attempt}/{max_attempts}): {reason}"
+                )
             return
 
         if kind == "swarm_reset":
@@ -191,28 +160,40 @@ class TuiProgressSink:
 
         terminal_ui.print_info(f"[{kind}] {payload}")
 
-    def thinking(self, text: str) -> None:
-        terminal_ui.print_thinking(text)
+    def _reset_swarm_state(self, keep_headers: bool = False) -> None:
+        self._swarm_plan_lines = []
+        self._swarm_agents = []
+        self._swarm_assignments = {}
+        self._swarm_status_line = None
+        if not keep_headers:
+            self._swarm_header_lines = []
 
-    def assistant_message(self, content: Any) -> None:
-        terminal_ui.print_assistant_message(content)
-
-    def tool_call(self, name: str, arguments: dict[str, Any]) -> None:
-        terminal_ui.print_tool_call(name, arguments)
-
-    def tool_result(self, result: str) -> None:
-        terminal_ui.print_tool_result(result)
-
-    def tool_blocked(self, name: str, arguments: dict[str, Any], reason: str) -> None:
-        terminal_ui.print_tool_blocked(name, arguments, reason)
-
-    def final_answer(self, text: str) -> None:
-        # The interactive shell renders the returned final answer itself;
-        # no additional marker is needed.
-        pass
-
-    def unfinished_answer(self, text: str) -> None:
-        terminal_ui.print_unfinished_answer(text)
+    def _render_swarm_runtime(self, title: str = "Swarm") -> None:
+        lines: list[str] = []
+        if self._swarm_header_lines:
+            lines.extend(self._swarm_header_lines)
+        if self._swarm_plan_lines:
+            if lines:
+                lines.append("")
+            lines.append("Plan:")
+            lines.extend(self._swarm_plan_lines)
+        if self._swarm_agents:
+            if lines:
+                lines.append("")
+            lines.append(f"Agents: {', '.join(self._swarm_agents)}")
+        if self._swarm_assignments:
+            if lines:
+                lines.append("")
+            lines.append("Assignments:")
+            lines.extend(
+                f"- {agent}: {self._swarm_assignments[agent]}"
+                for agent in sorted(self._swarm_assignments)
+            )
+        if self._swarm_status_line:
+            if lines:
+                lines.append("")
+            lines.append(self._swarm_status_line)
+        terminal_ui.print_swarm_summary(lines, title=title)
 
     def spinner(self, label: str, title: str | None = None) -> AbstractAsyncContextManager[Any]:
         return AsyncSpinner(terminal_ui.console, label, title=title or "Working")

--- a/test/tasks/test_tools.py
+++ b/test/tasks/test_tools.py
@@ -14,6 +14,7 @@ from ouro.capabilities.tools.builtins.task_delete import TaskDeleteTool
 from ouro.capabilities.tools.builtins.task_get import TaskGetTool
 from ouro.capabilities.tools.builtins.task_list import TaskListTool
 from ouro.capabilities.tools.builtins.task_update import TaskUpdateTool
+from ouro.core.loop import ProgressEvent
 
 
 @pytest.fixture
@@ -21,11 +22,11 @@ async def tools():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / "tasks.db"
         store = TaskStore(db_path)
-        events: list[tuple[str, dict]] = []
+        events: list[ProgressEvent] = []
 
         class _Progress:
-            def event(self, kind: str, payload: dict) -> None:
-                events.append((kind, payload))
+            def emit(self, event: ProgressEvent) -> None:
+                events.append(event)
 
         progress = _Progress()
         yield {
@@ -64,9 +65,9 @@ class TestTaskCreateTool:
 
     async def test_create_emits_task_status_event(self, tools: dict) -> None:
         await tools["create"].execute(subject="Fix bug", description="Fix auth")
-        assert tools["events"][-1] == (
-            "task_status",
-            {
+        assert tools["events"][-1] == ProgressEvent(
+            kind="task_status",
+            payload={
                 "line": "[pending] #1 Fix bug",
                 "summary": "Created task #1: Fix bug",
                 "title": "Task Created",
@@ -79,9 +80,9 @@ class TestTaskClaimTool:
         task = tools["store"].create(subject="Claim me", description="...")
         result = await tools["claim"].execute(taskId=task.id)
         assert "Claimed task #1" in result
-        assert tools["events"][-1] == (
-            "task_status",
-            {
+        assert tools["events"][-1] == ProgressEvent(
+            kind="task_status",
+            payload={
                 "line": "[in_progress] #1 (agent-1) Claim me",
                 "summary": "Claimed task #1: Claim me",
                 "title": "Task Claimed",
@@ -125,9 +126,9 @@ class TestTaskUpdateTool:
     async def test_update_emits_task_status_event(self, tools: dict) -> None:
         task = tools["store"].create(subject="Test", description="...")
         await tools["update"].execute(taskId=task.id, status="completed", owner="alice")
-        assert tools["events"][-1] == (
-            "task_status",
-            {
+        assert tools["events"][-1] == ProgressEvent(
+            kind="task_status",
+            payload={
                 "line": "[completed] #1 (alice) Test",
                 "summary": "Updated task #1: status=completed, owner=alice",
                 "title": "Task Updated",
@@ -151,9 +152,9 @@ class TestTaskListTool:
     async def test_list_emits_task_list_event(self, tools: dict) -> None:
         tools["store"].create(subject="Task A", description="...")
         await tools["list"].execute()
-        assert tools["events"][-1] == (
-            "task_list",
-            {
+        assert tools["events"][-1] == ProgressEvent(
+            kind="task_list",
+            payload={
                 "task_lines": ["[pending] #1 Task A"],
                 "summary": "Summary: 0 done, 0 running, 0 blocked, 1 pending",
                 "counts": {"done": 0, "running": 0, "blocked": 0, "pending": 1},
@@ -181,13 +182,15 @@ class TestTaskProgressEvents:
         )
 
         sink = TuiProgressSink()
-        sink.event(
-            "task_status",
-            {
-                "line": "[running] #1 Implement feature",
-                "summary": "Summary: 0 done, 1 running, 0 blocked, 0 pending",
-                "title": "Task Update",
-            },
+        sink.emit(
+            ProgressEvent(
+                kind="task_status",
+                payload={
+                    "line": "[running] #1 Implement feature",
+                    "summary": "Summary: 0 done, 1 running, 0 blocked, 0 pending",
+                    "title": "Task Update",
+                },
+            )
         )
 
         assert calls == [

--- a/test/test_json_progress_sink.py
+++ b/test/test_json_progress_sink.py
@@ -3,36 +3,43 @@ from __future__ import annotations
 import io
 import json
 
+from ouro.core.loop import ProgressEvent
 from ouro.interfaces.tui.json_progress import JsonProgressSink
 
 
-def test_json_progress_sink_emits_info_and_event_records():
+def test_json_progress_sink_emits_records_from_progress_events():
     stream = io.StringIO()
     sink = JsonProgressSink(stream=stream)
 
-    sink.info("hello")
-    sink.event("swarm_status", {"line": "Swarm status: 1/2 done"})
+    sink.emit(ProgressEvent(kind="info", payload={"message": "hello"}))
+    sink.emit(ProgressEvent(kind="swarm_status", payload={"line": "Swarm status: 1/2 done"}))
+    sink.emit(
+        ProgressEvent(
+            kind="tool_call",
+            payload={"name": "read_file", "arguments": {"file_path": "a.py"}},
+        )
+    )
+    sink.emit(ProgressEvent(kind="tool_result", payload={"text": "ok"}))
+    sink.emit(ProgressEvent(kind="final_answer", payload={"text": "done"}))
 
     lines = [json.loads(line) for line in stream.getvalue().splitlines()]
     assert lines == [
-        {"type": "info", "message": "hello"},
-        {"type": "event", "kind": "swarm_status", "payload": {"line": "Swarm status: 1/2 done"}},
+        {"kind": "info", "payload": {"message": "hello"}},
+        {"kind": "swarm_status", "payload": {"line": "Swarm status: 1/2 done"}},
+        {
+            "kind": "tool_call",
+            "payload": {"name": "read_file", "arguments": {"file_path": "a.py"}},
+        },
+        {"kind": "tool_result", "payload": {"text": "ok"}},
+        {"kind": "final_answer", "payload": {"text": "done"}},
     ]
 
 
-def test_json_progress_sink_emits_tool_and_answer_records():
+def test_json_progress_sink_emits_session_loaded_record():
     stream = io.StringIO()
     sink = JsonProgressSink(stream=stream)
 
-    sink.tool_call("read_file", {"file_path": "a.py"})
-    sink.tool_result("ok")
-    sink.final_answer("done")
+    sink.on_session_loaded([object(), object()])
 
     lines = [json.loads(line) for line in stream.getvalue().splitlines()]
-    assert lines[0] == {
-        "type": "tool_call",
-        "name": "read_file",
-        "arguments": {"file_path": "a.py"},
-    }
-    assert lines[1] == {"type": "tool_result", "result": "ok"}
-    assert lines[2] == {"type": "final_answer", "text": "done"}
+    assert lines == [{"kind": "session_loaded", "payload": {"count": 2}}]

--- a/test/test_progress_event_bus_regressions.py
+++ b/test/test_progress_event_bus_regressions.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+from ouro.core.llm import ToolCall, ToolOutput
+from ouro.core.loop.agent import Agent
+from ouro.core.loop.context import RunStatistic
+from ouro.core.loop.protocols import ProgressEvent
+
+
+class _ProgressRecorder:
+    def __init__(self) -> None:
+        self.events: list[ProgressEvent] = []
+
+    def emit(self, event: ProgressEvent) -> None:
+        self.events.append(event)
+
+    @asynccontextmanager
+    async def spinner(self, label: str, title: str | None = None):
+        yield None
+
+    def on_session_loaded(self, messages):
+        return None
+
+
+class _ToolRegistryStub:
+    def get_tool_schemas(self):
+        return []
+
+    def is_tool_readonly(self, name: str) -> bool:
+        return False
+
+    def conflict_keys(self, name: str, arguments: dict[str, object]):
+        return None
+
+    async def execute_tool_call(self, name: str, arguments: dict[str, object]) -> ToolOutput:
+        return ToolOutput(content="tool content", metadata={"source": "stub"})
+
+
+@pytest.mark.asyncio
+async def test_sequential_tool_result_event_uses_tool_content() -> None:
+    progress = _ProgressRecorder()
+    agent = Agent(llm=object(), tools=_ToolRegistryStub(), progress=progress)
+
+    result = await agent._exec_sequential(
+        ctx=RunStatistic(task="demo", progress=progress),
+        tool_calls=[ToolCall(id="call-1", name="demo_tool", arguments={"value": 1})],
+    )
+
+    assert result[0].content == "tool content"
+    assert progress.events == [
+        ProgressEvent(
+            kind="tool_call",
+            payload={"name": "demo_tool", "arguments": {"value": 1}},
+        ),
+        ProgressEvent(kind="tool_result", payload={"text": "tool content"}),
+    ]

--- a/test/test_tui_progress_sink.py
+++ b/test/test_tui_progress_sink.py
@@ -1,61 +1,57 @@
 from __future__ import annotations
 
+from ouro.core.loop import ProgressEvent
 from ouro.interfaces.tui.tui_progress import TuiProgressSink
 
 
-def test_info_renders_task_list_with_summary(monkeypatch):
+def test_emit_renders_task_list_with_summary(monkeypatch):
     calls: list[tuple[list[str], str | None]] = []
-    infos: list[str] = []
 
     monkeypatch.setattr(
         "ouro.interfaces.tui.tui_progress.terminal_ui.print_task_summary",
         lambda task_lines, summary=None, title="Tasks": calls.append((task_lines, summary)),
     )
+
+    sink = TuiProgressSink()
+    sink.emit(
+        ProgressEvent(
+            kind="task_list",
+            payload={
+                "task_lines": ["[pending] #1 Task A", "[running] #2 Task B"],
+                "summary": "Summary: 0 done, 1 running, 0 blocked, 1 pending",
+            },
+        )
+    )
+
+    assert calls == [
+        (
+            ["[pending] #1 Task A", "[running] #2 Task B"],
+            "Summary: 0 done, 1 running, 0 blocked, 1 pending",
+        )
+    ]
+
+
+def test_emit_falls_back_for_invalid_task_list_payload(monkeypatch):
+    infos: list[str] = []
+    calls: list[tuple[list[str], str | None]] = []
+
     monkeypatch.setattr(
         "ouro.interfaces.tui.tui_progress.terminal_ui.print_info",
         lambda msg: infos.append(msg),
     )
-
-    sink = TuiProgressSink()
-    sink.info(
-        "Tasks:\n[pending] #1 Task A\n[running] #2 Task B\n\nSummary: 0 done, 1 running, 0 blocked, 1 pending"
-    )
-
-    assert calls == [
-        (
-            ["[pending] #1 Task A", "[running] #2 Task B"],
-            "Summary: 0 done, 1 running, 0 blocked, 1 pending",
-        )
-    ]
-    assert infos == []
-
-
-def test_event_renders_task_list_with_summary(monkeypatch):
-    calls: list[tuple[list[str], str | None]] = []
-
     monkeypatch.setattr(
         "ouro.interfaces.tui.tui_progress.terminal_ui.print_task_summary",
         lambda task_lines, summary=None, title="Tasks": calls.append((task_lines, summary)),
     )
 
     sink = TuiProgressSink()
-    sink.event(
-        "task_list",
-        {
-            "task_lines": ["[pending] #1 Task A", "[running] #2 Task B"],
-            "summary": "Summary: 0 done, 1 running, 0 blocked, 1 pending",
-        },
-    )
+    sink.emit(ProgressEvent(kind="task_list", payload={"task_lines": "oops", "summary": "bad"}))
 
-    assert calls == [
-        (
-            ["[pending] #1 Task A", "[running] #2 Task B"],
-            "Summary: 0 done, 1 running, 0 blocked, 1 pending",
-        )
-    ]
+    assert calls == []
+    assert infos == ["[task_list] {'task_lines': 'oops', 'summary': 'bad'}"]
 
 
-def test_event_renders_swarm_runtime(monkeypatch):
+def test_emit_renders_swarm_runtime(monkeypatch):
     swarm_calls: list[tuple[list[str], str]] = []
 
     monkeypatch.setattr(
@@ -68,21 +64,50 @@ def test_event_renders_swarm_runtime(monkeypatch):
     )
 
     sink = TuiProgressSink()
-    sink.event(
-        "swarm_header", {"line": "Swarm selected: complexity=0.82, subtasks=2", "title": "Swarm"}
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_header",
+            payload={"line": "Swarm selected: complexity=0.82, subtasks=2", "title": "Swarm"},
+        )
     )
-    sink.event("swarm_reset", {"keep_headers": True})
-    sink.event("swarm_plan_item", {"line": "#1 Inspect rendering", "title": "Swarm Plan"})
-    sink.event("swarm_plan_item", {"line": "#2 Update output", "title": "Swarm Plan"})
-    sink.event("swarm_header", {"line": "Starting swarm with 2 agent(s)...", "title": "Swarm"})
-    sink.event("swarm_agent", {"agent": "agent-1", "title": "Swarm"})
-    sink.event(
-        "swarm_assignment",
-        {"agent": "agent-1", "assignment": "task #1: Inspect rendering", "title": "Swarm"},
+    sink.emit(ProgressEvent(kind="swarm_reset", payload={"keep_headers": True}))
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_plan_item",
+            payload={"line": "#1 Inspect rendering", "title": "Swarm Plan"},
+        )
     )
-    sink.event(
-        "swarm_status",
-        {"line": "Swarm complete: 2/2 tasks done, 0 running, 0 blocked", "title": "Swarm Result"},
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_plan_item",
+            payload={"line": "#2 Update output", "title": "Swarm Plan"},
+        )
+    )
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_header",
+            payload={"line": "Starting swarm with 2 agent(s)...", "title": "Swarm"},
+        )
+    )
+    sink.emit(ProgressEvent(kind="swarm_agent", payload={"agent": "agent-1", "title": "Swarm"}))
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_assignment",
+            payload={
+                "agent": "agent-1",
+                "assignment": "task #1: Inspect rendering",
+                "title": "Swarm",
+            },
+        )
+    )
+    sink.emit(
+        ProgressEvent(
+            kind="swarm_status",
+            payload={
+                "line": "Swarm complete: 2/2 tasks done, 0 running, 0 blocked",
+                "title": "Swarm Result",
+            },
+        )
     )
 
     assert swarm_calls[-1] == (
@@ -105,7 +130,7 @@ def test_event_renders_swarm_runtime(monkeypatch):
     )
 
 
-def test_info_falls_back_to_plain_info(monkeypatch):
+def test_emit_info_falls_back_to_plain_info(monkeypatch):
     infos: list[str] = []
 
     monkeypatch.setattr(
@@ -114,6 +139,6 @@ def test_info_falls_back_to_plain_info(monkeypatch):
     )
 
     sink = TuiProgressSink()
-    sink.info("hello world")
+    sink.emit(ProgressEvent(kind="info", payload={"message": "hello world"}))
 
     assert infos == ["hello world"]


### PR DESCRIPTION
## Summary

- replace the multi-method `ProgressSink` API with a single `emit(ProgressEvent)` event bus
- migrate core loop, swarm/task/verification producers, and TUI/JSON sinks to the new event model
- add regression coverage for JSON/TUI event handling and sequential tool result payload parity

## Scope

- Goals:
  - make progress reporting use one structured event path end-to-end
  - remove the old per-method progress callback surface from production sinks
  - preserve current task/swarm/verification UX while simplifying the architecture
- Non-goals:
  - redesign the visible task/swarm layouts
  - change spinner or session-replay ownership beyond current special handling

## Invariants (Must Not Regress)

- [x] CLI/TUI still renders task and swarm progress updates during runs
- [x] JSON mode still emits machine-readable progress records to stdout
- [x] sequential and parallel tool execution both surface tool results consistently
- [x] verification progress still surfaces pass/fail feedback to the user
- [x] layer boundaries remain valid (`interfaces -> capabilities -> core` only)

## Acceptance Criteria

- [x] `ProgressSink` production implementations use `emit(ProgressEvent)` instead of method-per-event callbacks
- [x] agent, swarm, task, and verification progress producers emit structured `ProgressEvent`s
- [x] TUI and JSON sinks consume the new event bus correctly
- [x] regression tests cover event payload handling and sequential tool-result semantics

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_progress_event_bus_regressions.py test/test_json_progress_sink.py test/test_tui_progress_sink.py test/tasks/test_tools.py test/tasks/test_engine.py test/test_main_auth_cli.py test/test_cli_json_mode.py`
- [x] `./scripts/dev.sh test -q`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "<...>" --verify`
- not run here because the local dev workflow in this environment uses `./scripts/dev.sh` verification and this refactor did not change command discovery or CLI argument parsing behavior beyond already tested JSON wiring

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? (3–5 invariants)
  - mismatched event payloads between sequential and parallel tool paths
  - JSON consumers depending on previous record shapes
  - TUI rendering when malformed event payloads arrive
  - verification feedback visibility after replacing `info`/`unfinished_answer` calls
- Worst-case input/output size? Any truncation/limits?
  - event payload sizes remain bounded by existing model/tool output sizes; no new truncation logic added
- Any secrets/logging risks?
  - no new logging sinks; events expose the same user/tool content already surfaced in progress output
- Any async/blocking I/O added on hot paths?
  - no new blocking I/O added; event emission remains in-process and synchronous like the prior sink calls
- What error message does the user see on failure? Is it actionable?
  - malformed task-list event payloads now fall back to a plain `[kind] payload` info line instead of mis-rendering character-by-character

## Docs / Compatibility

- [x] Updated relevant docs (`README.md`, `docs/examples.md`, `docs/configuration.md`) when needed
- no doc updates needed; behavior change is internal architecture plus already-tested progress output contracts
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)

## Context Hygiene (Avoid Token/Attention Waste)

- focused file reads and targeted tests were used during the refactor
- only relevant command outputs were retained; full logs were not copied into repo files

## CI

- expected CI coverage: precommit, full tests, and strict typecheck

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)