### PR TITLE
Show sub-agent source prefixes in TUI progress output

### DIFF
--- a/ouro/interfaces/tui/tui_progress.py
+++ b/ouro/interfaces/tui/tui_progress.py
@@ -26,25 +26,34 @@ class TuiProgressSink:
         self._swarm_header_lines: list[str] = []
         self._swarm_status_line: str | None = None
 
+    def _format_source_prefix(self, event: ProgressEvent) -> str:
+        agent_id = event.source.agent_id
+        if not agent_id or agent_id == "root":
+            return ""
+        return f"[{agent_id}] "
+
     def emit(self, event: ProgressEvent) -> None:
         kind = event.kind
         payload = event.payload
+        prefix = self._format_source_prefix(event)
 
         if kind == "info":
             message = payload.get("message")
             if isinstance(message, str) and message:
-                terminal_ui.print_info(message)
+                terminal_ui.print_info(f"{prefix}{message}")
             return
 
         if kind == "thinking":
             text = payload.get("text")
             if isinstance(text, str) and text:
-                terminal_ui.print_thinking(text)
+                terminal_ui.print_thinking(f"{prefix}{text}")
             return
 
         if kind == "assistant_message":
             content = payload.get("text", payload.get("content"))
             if content is not None:
+                if isinstance(content, str):
+                    content = f"{prefix}{content}"
                 terminal_ui.print_assistant_message(content)
             return
 
@@ -52,13 +61,13 @@ class TuiProgressSink:
             name = payload.get("name")
             arguments = payload.get("arguments")
             if isinstance(name, str) and isinstance(arguments, dict):
-                terminal_ui.print_tool_call(name, arguments)
+                terminal_ui.print_tool_call(f"{prefix}{name}", arguments)
             return
 
         if kind == "tool_result":
             result = payload.get("text")
             if isinstance(result, str):
-                terminal_ui.print_tool_result(result)
+                terminal_ui.print_tool_result(f"{prefix}{result}")
             return
 
         if kind == "tool_blocked":
@@ -66,7 +75,7 @@ class TuiProgressSink:
             arguments = payload.get("arguments")
             reason = payload.get("reason")
             if isinstance(name, str) and isinstance(arguments, dict) and isinstance(reason, str):
-                terminal_ui.print_tool_blocked(name, arguments, reason)
+                terminal_ui.print_tool_blocked(f"{prefix}{name}", arguments, reason)
             return
 
         if kind == "final_answer":

--- a/test/test_tui_progress_sink.py
+++ b/test/test_tui_progress_sink.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ouro.core.loop import ProgressEvent
+from ouro.core.loop import EventSource, ProgressEvent
 from ouro.interfaces.tui.tui_progress import TuiProgressSink
 
 
@@ -128,6 +128,66 @@ def test_emit_renders_swarm_runtime(monkeypatch):
         ],
         "Swarm Result",
     )
+
+
+def test_emit_info_prefixes_subagent_source(monkeypatch):
+    infos: list[str] = []
+
+    monkeypatch.setattr(
+        "ouro.interfaces.tui.tui_progress.terminal_ui.print_info",
+        lambda msg: infos.append(msg),
+    )
+
+    sink = TuiProgressSink()
+    sink.emit(
+        ProgressEvent(
+            kind="info",
+            payload={"message": "hello world"},
+            source=EventSource(agent_id="agent-2", root_agent_id="root", depth=1),
+        )
+    )
+
+    assert infos == ["[agent-2] hello world"]
+
+
+def test_emit_tool_call_prefixes_subagent_source(monkeypatch):
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    monkeypatch.setattr(
+        "ouro.interfaces.tui.tui_progress.terminal_ui.print_tool_call",
+        lambda name, arguments: calls.append((name, arguments)),
+    )
+
+    sink = TuiProgressSink()
+    sink.emit(
+        ProgressEvent(
+            kind="tool_call",
+            payload={"name": "read_file", "arguments": {"file_path": "a.py"}},
+            source=EventSource(agent_id="agent-2", root_agent_id="root", depth=1),
+        )
+    )
+
+    assert calls == [("[agent-2] read_file", {"file_path": "a.py"})]
+
+
+def test_emit_info_keeps_root_source_unprefixed(monkeypatch):
+    infos: list[str] = []
+
+    monkeypatch.setattr(
+        "ouro.interfaces.tui.tui_progress.terminal_ui.print_info",
+        lambda msg: infos.append(msg),
+    )
+
+    sink = TuiProgressSink()
+    sink.emit(
+        ProgressEvent(
+            kind="info",
+            payload={"message": "hello world"},
+            source=EventSource(agent_id="root", root_agent_id="root", role="root"),
+        )
+    )
+
+    assert infos == ["hello world"]
 
 
 def test_emit_info_falls_back_to_plain_info(monkeypatch):


### PR DESCRIPTION
## Summary

- prefix ordinary TUI progress events with sub-agent source IDs while leaving root output unchanged
- preserve the existing task/swarm specialized views instead of turning them into a generic log stream
- add TUI sink tests covering root vs sub-agent rendering behavior for source-aware progress output

## Scope

- Goals:
  - make ordinary TUI progress output distinguish sub-agent events from root-agent events
  - keep current swarm/task summary panels intact
  - verify source-aware rendering with focused TUI tests
- Non-goals:
  - redesign task or swarm layouts
  - expose full provenance trees or verbose trace views in the TUI yet

## Invariants (Must Not Regress)

- [x] root progress output remains concise and unprefixed
- [x] sub-agent ordinary events become visibly distinguishable in the TUI
- [x] swarm/task specialized renderers keep their current aggregation behavior
- [x] progress event source metadata remains a rendering aid, not a payload rewrite
- [x] layer boundaries remain valid (`interfaces -> capabilities -> core` only)

## Acceptance Criteria

- [x] sub-agent `info` events render with a source prefix in TUI
- [x] sub-agent ordinary tool progress renders with a source prefix in TUI
- [x] root events still render without a source prefix
- [x] existing TUI task/swarm tests continue to pass alongside new source-aware cases

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_tui_progress_sink.py`
- [x] `./scripts/dev.sh test -q`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "<...>" --verify`
- not run here; this PR changes TUI rendering behavior only and is covered by focused sink tests plus the full automated suite

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? (3–5 invariants)
  - root output could accidentally gain noisy prefixes
  - task/swarm panels could be polluted by generic source prefix logic
  - tool-call or tool-result rendering could become harder to scan if prefixes are malformed
  - assistant/thinking text could be double-prefixed if future layers also add source labels
- Worst-case input/output size? Any truncation/limits?
  - output grows by a short `[agent-id] ` prefix on sub-agent ordinary events only; no new truncation logic
- Any secrets/logging risks?
  - no new secrets; the TUI only surfaces existing source IDs already present in event metadata
- Any async/blocking I/O added on hot paths?
  - no new blocking I/O; only string prefix formatting was added in the sink
- What error message does the user see on failure? Is it actionable?
  - malformed payloads continue to use existing TUI fallbacks; this PR does not add new user-facing error paths

## Docs / Compatibility

- [x] Updated relevant docs (`README.md`, `docs/examples.md`, `docs/configuration.md`) when needed
- no doc updates needed; this is an incremental TUI rendering refinement
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)

## Context Hygiene (Avoid Token/Attention Waste)

- change stayed isolated to the TUI sink and its tests
- validation used focused sink coverage first, then the full suite

## CI

- expected CI coverage: precommit, importlint, full tests, and strict typecheck

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)