### PR TITLE
Rename agent swarm config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Ouro is organized into three layers with strict downward-only imports:
 
 ## Features
 
-### 🤖 Agent Team — Multi-Agent Swarm with Persistent Tasks
+### 🤖 Agent Swarm — Multi-Agent Swarm with Persistent Tasks
 
-The flagship feature. Enable with `ENABLE_AGENT_TEAM=true` in `~/.ouro/config`.
+The flagship feature. Enable with `ENABLE_AGENT_SWARM=true` in `~/.ouro/config`.
 
 - **Persistent Task Store** — SQLite-backed tasks with dependency graphs (`task_create`, `task_claim`, `task_update`, `task_list`, `task_get`, `task_delete`)
 - **Atomic Task Claiming** — Agents race to claim available tasks; one agent, one in-progress task

--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -136,9 +136,9 @@ class AgentBuilder:
     read_before_write: bool = True
     nested_agents_md: bool = True
     extra_rules: list[Rule] = field(default_factory=list)
-    # Agent Team feature flag (off by default; Phase 1 opt-in)
+    # Agent Swarm feature flag (off by default; Phase 1 opt-in)
     # When enabled: Task V2 tools replace TodoTool/MultiTaskTool, auto-swarm is active
-    enable_agent_team: bool = False
+    enable_agent_swarm: bool = False
     task_store_path: str | None = None
     agent_id: str | None = None
     parent_agent_id: str | None = None
@@ -213,12 +213,12 @@ class AgentBuilder:
         self.verifier = verifier
         return self
 
-    # ---- Agent Team -------------------------------------------------------
+    # ---- Agent Swarm ------------------------------------------------------
 
-    def with_agent_team(
+    def with_agent_swarm(
         self, enabled: bool = True, store_path: str | None = None, agent_id: str | None = None
     ) -> AgentBuilder:
-        """Enable agent team collaboration with Task V2 and auto-swarm.
+        """Enable agent swarm collaboration with Task V2 and auto-swarm.
 
         When enabled:
         - Task V2 tools (task_create, task_update, task_list, task_get, task_delete, task_claim)
@@ -230,7 +230,7 @@ class AgentBuilder:
 
         When disabled (default): legacy TodoTool + MultiTaskTool are used.
         """
-        self.enable_agent_team = enabled
+        self.enable_agent_swarm = enabled
         self.task_store_path = store_path
         self.agent_id = agent_id
         return self
@@ -253,9 +253,9 @@ class AgentBuilder:
         self.progress_role = role
         return self
 
-    def without_agent_team(self) -> AgentBuilder:
-        """Explicitly disable agent team (default)."""
-        self.enable_agent_team = False
+    def without_agent_swarm(self) -> AgentBuilder:
+        """Explicitly disable agent swarm (default)."""
+        self.enable_agent_swarm = False
         self.task_store_path = None
         return self
 
@@ -302,14 +302,14 @@ class AgentBuilder:
             raise ValueError("AgentBuilder requires .with_llm(...) before .build()")
 
         # Determine which task management system to use.
-        # When enable_agent_team=True:
+        # When enable_agent_swarm=True:
         #   - Use Task V2 tools (task_create, task_update, task_list, task_get, task_delete, task_claim)
         #   - Skip TodoTool (replaced by Task V2)
         #   - Auto-swarm is active for complex task decomposition
-        # When enable_agent_team=False (default):
+        # When enable_agent_swarm=False (default):
         #   - Use TodoTool (legacy)
         #   - MultiTaskTool can be added manually via with_tool()
-        use_v2_mode = self.enable_agent_team
+        use_v2_mode = self.enable_agent_swarm
         progress_identity = self._progress_identity()
         progress_sink = (
             ScopedProgressSink(self.progress, progress_identity.to_event_source())
@@ -329,7 +329,7 @@ class AgentBuilder:
 
         # Task V2 store + tools
         task_store: TaskStore | None = None
-        if self.enable_agent_team:
+        if self.enable_agent_swarm:
             import os
 
             store_path = self.task_store_path or os.path.expanduser("~/.ouro/tasks/default.db")
@@ -378,8 +378,8 @@ class AgentBuilder:
                 )
             )
 
-        # Auto-swarm hook (active when agent team is enabled).
-        if self.enable_agent_team and self.llm is not None:
+        # Auto-swarm hook (active when agent swarm is enabled).
+        if self.enable_agent_swarm and self.llm is not None:
             llm = self.llm  # capture for closure
             parent_identity = progress_identity
 
@@ -387,7 +387,7 @@ class AgentBuilder:
                 builder = (
                     AgentBuilder()
                     .with_llm(llm)
-                    .with_agent_team(enabled=True, agent_id=agent_id)
+                    .with_agent_swarm(enabled=True, agent_id=agent_id)
                     .without_memory()
                     .with_max_iterations(self.max_iterations)
                     .with_progress_sink(self.progress)

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -21,10 +21,10 @@ MAX_ITERATIONS=1000
 # Ralph Loop (outer verification loop — re-checks task completion)
 # RALPH_LOOP_MAX_ITERATIONS=3
 
-# Agent Team / Task V2 (persistent task store + multi-agent coordination)
+# Agent Swarm / Task V2 (persistent task store + multi-agent coordination)
 # When enabled, replaces TodoTool and MultiTaskTool with task_create,
 # task_claim, task_update, task_list, task_get, task_delete tools.
-# ENABLE_AGENT_TEAM=false
+# ENABLE_AGENT_SWARM=false
 
 # Commit / PR attribution: append "Co-Authored-By: ouro" to commits and
 # "Generated with ouro" to PR bodies the agent authors. Set to false to disable.
@@ -104,10 +104,10 @@ class Config:
     # Ralph Loop (outer verification loop)
     RALPH_LOOP_MAX_ITERATIONS = int(_cfg.get("RALPH_LOOP_MAX_ITERATIONS", "3"))
 
-    # Agent Team / Task V2 (persistent task store + multi-agent coordination)
+    # Agent Swarm / Task V2 (persistent task store + multi-agent coordination)
     # When enabled, replaces TodoTool and MultiTaskTool with task_create,
     # task_claim, task_update, task_list, task_get, task_delete tools.
-    ENABLE_AGENT_TEAM = _cfg.get("ENABLE_AGENT_TEAM", "false").lower() == "true"
+    ENABLE_AGENT_SWARM = _cfg.get("ENABLE_AGENT_SWARM", "false").lower() == "true"
 
     # Retry Configuration
     RETRY_MAX_ATTEMPTS = int(_cfg.get("RETRY_MAX_ATTEMPTS", "3"))

--- a/ouro/interfaces/cli/factory.py
+++ b/ouro/interfaces/cli/factory.py
@@ -111,16 +111,16 @@ def create_agent(
         .with_tools(tools)
     )
 
-    # Agent Team / Task V2: persistent task store + multi-agent coordination.
+    # Agent Swarm / Task V2: persistent task store + multi-agent coordination.
     # When enabled, replaces TodoTool and MultiTaskTool with task_create,
     # task_claim, task_update, task_list, task_get, task_delete tools.
-    if Config.ENABLE_AGENT_TEAM:
-        builder = builder.with_agent_team(enabled=True)
+    if Config.ENABLE_AGENT_SWARM:
+        builder = builder.with_agent_swarm(enabled=True)
 
     agent = builder.build()
 
-    # MultiTaskTool is only added when Agent Team is disabled (legacy mode).
-    if not Config.ENABLE_AGENT_TEAM:
+    # MultiTaskTool is only added when Agent Swarm is disabled (legacy mode).
+    if not Config.ENABLE_AGENT_SWARM:
         multi = MultiTaskTool(agent)
         agent.tool_executor.add_tool(multi)
 

--- a/test/swarm/test_swarm.py
+++ b/test/swarm/test_swarm.py
@@ -61,7 +61,7 @@ def coordinator(store: TaskStore):
         return (
             AgentBuilder()
             .with_llm(fake_llm)
-            .with_agent_team(enabled=True, store_path=str(store._db_path), agent_id=agent_id)
+            .with_agent_swarm(enabled=True, store_path=str(store._db_path), agent_id=agent_id)
             .without_memory()
         )
 


### PR DESCRIPTION
## Summary
- rename the user-facing config flag from `ENABLE_AGENT_TEAM` to `ENABLE_AGENT_SWARM`
- rename related builder API and internal state from `agent_team` to `agent_swarm`
- update README and swarm test coverage to match the new naming

## Test plan
- [x] `python -m pytest -q test/swarm/test_swarm.py`

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)