### PR TITLE
Stabilize swarm worker execution and shutdown

### DIFF
--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -426,7 +426,7 @@ class AgentBuilder:
                     return (
                         AgentBuilder()
                         .with_llm(llm)
-                        .with_agent_swarm(enabled=True, store_path=store_path, agent_id=agent_id)
+                        .without_agent_swarm()
                         .without_memory()
                         .with_max_iterations(max_iterations)
                     )
@@ -572,6 +572,17 @@ class ComposedAgent:
             return await self._dispatcher.run(task)
 
         return await self._run_single_agent(task, verify=verify, images=images)
+
+    async def shutdown(self) -> None:
+        """Release any in-flight dispatcher/swarm work."""
+        dispatcher = self._dispatcher
+        if dispatcher is None:
+            return
+        runtime = getattr(dispatcher, "runtime", None)
+        shutdown = getattr(runtime, "shutdown", None)
+        if shutdown is None:
+            return
+        await shutdown()
 
     async def _run_single_agent(
         self,

--- a/ouro/capabilities/swarm/coordinator.py
+++ b/ouro/capabilities/swarm/coordinator.py
@@ -4,7 +4,7 @@ Manages a pool of agents working from a shared TaskStore. Each agent
 claims tasks atomically, works on them via the core loop, and marks
 them complete. The coordinator handles:
 
-- Agent lifecycle (spawn, health check, recovery)
+- Agent lifecycle (spawn, task reconciliation, recovery)
 - Task assignment (claim → work → complete)
 - Swarm-level queries (progress, bottlenecks, available agents)
 """
@@ -12,7 +12,7 @@ them complete. The coordinator handles:
 from __future__ import annotations
 
 import asyncio
-import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -36,7 +36,7 @@ class AgentHandle:
     agent_id: str
     agent: ComposedAgent
     task_ids: list[str] = field(default_factory=list)
-    last_heartbeat: float = field(default_factory=time.time)
+    running_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     total_tasks_completed: int = 0
     total_tasks_failed: int = 0
 
@@ -143,8 +143,8 @@ class SwarmCoordinator:
             # Try to assign available tasks to idle agents
             await self._assign_tasks()
 
-            # Health check
-            await self._health_check()
+            # Reconcile tracked worker tasks
+            await self._reconcile_running_tasks()
 
             await asyncio.sleep(min(self.heartbeat_interval, 1.0))
 
@@ -164,7 +164,6 @@ class SwarmCoordinator:
             result = self.store.claim(task.id, handle.agent_id)
             if result.success:
                 handle.task_ids.append(task.id)
-                handle.last_heartbeat = time.time()
                 self.progress.emit(
                     ProgressEvent(
                         kind="swarm_assignment",
@@ -176,10 +175,11 @@ class SwarmCoordinator:
                     )
                 )
                 # Fire-and-forget task execution
-                asyncio.create_task(
+                running = asyncio.create_task(
                     self._run_task(handle, task.id),
                     name=f"swarm-task-{task.id}",
                 )
+                handle.running_tasks[task.id] = running
 
     async def _run_task(self, handle: AgentHandle, task_id: str) -> None:
         """Execute a single task and mark it complete."""
@@ -247,8 +247,9 @@ class SwarmCoordinator:
             self.store.unassign(task_id)
 
         finally:
-            handle.task_ids.remove(task_id)
-            handle.last_heartbeat = time.time()
+            handle.running_tasks.pop(task_id, None)
+            if task_id in handle.task_ids:
+                handle.task_ids.remove(task_id)
 
     def _build_task_prompt(self, task) -> str:
         """Build a prompt for the agent to execute a task."""
@@ -264,21 +265,31 @@ class SwarmCoordinator:
         return "\n".join(lines)
 
     # ------------------------------------------------------------------
-    # Health check
+    # Running task reconciliation
     # ------------------------------------------------------------------
 
-    async def _health_check(self) -> None:
-        """Check agent health and recover stale agents."""
-        now = time.time()
-        stale_threshold = self.heartbeat_interval * 3
-
+    async def _reconcile_running_tasks(self) -> None:
+        """Recover tasks from completed, cancelled, or failed task handles."""
         for handle in list(self.agents.values()):
-            if now - handle.last_heartbeat > stale_threshold:
-                logger.warning(f"Agent {handle.agent_id} stale — recovering tasks")
-                for task_id in list(handle.task_ids):
+            for task_id, running in list(handle.running_tasks.items()):
+                if not running.done():
+                    continue
+                if running.cancelled():
+                    logger.warning(f"Agent {handle.agent_id} task {task_id} cancelled — recovering")
                     self.store.unassign(task_id)
-                    handle.task_ids.remove(task_id)
-                handle.last_heartbeat = now
+                    handle.running_tasks.pop(task_id, None)
+                    if task_id in handle.task_ids:
+                        handle.task_ids.remove(task_id)
+                    continue
+                exc = running.exception()
+                if exc is not None:
+                    logger.warning(
+                        f"Agent {handle.agent_id} task {task_id} ended with exception — recovering: {exc}"
+                    )
+                    self.store.unassign(task_id)
+                    handle.running_tasks.pop(task_id, None)
+                    if task_id in handle.task_ids:
+                        handle.task_ids.remove(task_id)
 
     # ------------------------------------------------------------------
     # Queries
@@ -308,7 +319,17 @@ class SwarmCoordinator:
             available_agents=available,
         )
 
-    def shutdown(self) -> None:
-        """Signal the swarm to shut down gracefully."""
+    async def shutdown(self) -> None:
+        """Signal the swarm to shut down gracefully and cancel worker tasks."""
         self._shutdown = True
+        to_cancel: list[asyncio.Task[None]] = []
+        for handle in self.agents.values():
+            for running in handle.running_tasks.values():
+                if not running.done():
+                    running.cancel()
+                    to_cancel.append(running)
+        for running in to_cancel:
+            with suppress(asyncio.CancelledError):
+                await running
+        await self._reconcile_running_tasks()
         logger.info("Swarm shutdown requested")

--- a/ouro/capabilities/swarm/runtime.py
+++ b/ouro/capabilities/swarm/runtime.py
@@ -32,7 +32,7 @@ class SwarmRuntime:
         idle_count = 0
         while not self.coordinator._shutdown:
             await self.coordinator._assign_tasks()
-            await self.coordinator._health_check()
+            await self.coordinator._reconcile_running_tasks()
             self._apply_followups(store)
 
             refreshed = self.coordinator.get_status()
@@ -44,6 +44,10 @@ class SwarmRuntime:
                 idle_count = 0
 
             await asyncio.sleep(min(self.coordinator.heartbeat_interval, 1.0))
+
+    async def shutdown(self) -> None:
+        """Cancel in-flight worker tasks and stop the coordinator."""
+        await self.coordinator.shutdown()
 
     def _apply_followups(self, store) -> None:
         for task in store.list_all():

--- a/ouro/interfaces/tui/interactive.py
+++ b/ouro/interfaces/tui/interactive.py
@@ -149,6 +149,16 @@ class InteractiveSession:
         """Handle Ctrl+S - show quick stats."""
         self._show_stats()
 
+    async def _shutdown_agent(self) -> None:
+        """Let the agent clean up in-flight swarm work after interruption."""
+        shutdown = getattr(self.agent, "shutdown", None)
+        if shutdown is None:
+            return
+        try:
+            await shutdown()
+        except Exception:
+            terminal_ui.print_warning("Agent shutdown cleanup encountered an error.")
+
     def _show_help(self) -> None:
         """Display help message with available commands."""
         colors = Theme.get_colors()
@@ -497,6 +507,7 @@ class InteractiveSession:
                 self.status_bar.show()
 
         except asyncio.CancelledError:
+            await self._shutdown_agent()
             terminal_ui.console.print(
                 f"\n[bold {colors.warning}]Task interrupted by user.[/bold {colors.warning}]\n"
             )
@@ -875,6 +886,7 @@ class InteractiveSession:
                         self.status_bar.show()
 
                 except asyncio.CancelledError:
+                    await self._shutdown_agent()
                     terminal_ui.console.print(
                         f"\n[bold {colors.warning}]Task interrupted by user.[/bold {colors.warning}]\n"
                     )

--- a/test/swarm/test_swarm.py
+++ b/test/swarm/test_swarm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -45,6 +46,24 @@ class FakeLLM:
     @property
     def supports_tools(self) -> bool:
         return True
+
+
+class NonSwarmingAgent:
+    def __init__(self, response: str = "Done"):
+        self.response = response
+        self.calls: list[str] = []
+
+    async def run(self, task: str) -> str:
+        self.calls.append(task)
+        return self.response
+
+
+class BuilderStub:
+    def __init__(self, agent):
+        self._agent = agent
+
+    def build(self):
+        return self._agent
 
 
 @pytest.fixture
@@ -146,16 +165,20 @@ class TestSwarmCoordinator:
         assert status.completed == 0
         assert len(status.available_agents) == 2
 
-    async def test_health_check_recovery(
+    async def test_health_check_recovers_cancelled_task(
         self, coordinator: SwarmCoordinator, store: TaskStore
     ) -> None:
         store.create(subject="Test task", description="...")
         await coordinator.spawn_agents(n=1)
         store.claim("1", "agent-1")
         coordinator.agents["agent-1"].task_ids.append("1")
-        coordinator.agents["agent-1"].last_heartbeat = 0
+        task_handle = asyncio.create_task(asyncio.sleep(1))
+        coordinator.agents["agent-1"].running_tasks["1"] = task_handle
+        task_handle.cancel()
+        with suppress(asyncio.CancelledError):
+            await task_handle
 
-        await coordinator._health_check()
+        await coordinator._reconcile_running_tasks()
 
         task = store.get("1")
         assert task is not None
@@ -178,3 +201,137 @@ class TestSwarmCoordinator:
 
         tasks = store.list_all()
         assert all(t.status == TaskStatus.COMPLETED for t in tasks)
+
+
+async def test_coordinator_cleanup_is_idempotent_after_stale_recovery(store: TaskStore) -> None:
+    agent = NonSwarmingAgent()
+
+    def builder_factory(agent_id: str):
+        return BuilderStub(agent)
+
+    coordinator = SwarmCoordinator(store, builder_factory, heartbeat_interval=0.01)
+    store.create(subject="Test task", description="...")
+    await coordinator.spawn_agents(n=1)
+    handle = coordinator.agents["agent-1"]
+    handle.task_ids.append("1")
+    task_handle = asyncio.create_task(asyncio.sleep(0))
+    await task_handle
+    handle.running_tasks["1"] = task_handle
+
+    await coordinator._reconcile_running_tasks()
+    await coordinator._run_task(handle, "1")
+
+    assert handle.task_ids == []
+
+
+async def test_worker_agent_can_run_without_recursive_swarm(store: TaskStore) -> None:
+    agent = NonSwarmingAgent(response="worker-complete")
+
+    def builder_factory(agent_id: str):
+        return BuilderStub(agent)
+
+    coordinator = SwarmCoordinator(store, builder_factory, heartbeat_interval=0.1)
+    store.create(subject="Test task", description="A simple test task")
+    await coordinator.spawn_agents(n=1)
+    await coordinator._assign_tasks()
+    await asyncio.sleep(0.1)
+
+    task = store.get("1")
+    assert task is not None
+    assert task.status == TaskStatus.COMPLETED
+    assert task.metadata["result"]["summary"] == "worker-complete"
+    assert len(agent.calls) == 1
+
+
+async def test_health_check_ignores_active_running_task(store: TaskStore) -> None:
+    agent = NonSwarmingAgent(response="worker-complete")
+
+    def builder_factory(agent_id: str):
+        return BuilderStub(agent)
+
+    coordinator = SwarmCoordinator(store, builder_factory, heartbeat_interval=0.01)
+    store.create(subject="Test task", description="...")
+    await coordinator.spawn_agents(n=1)
+    handle = coordinator.agents["agent-1"]
+    handle.task_ids.append("1")
+    active = asyncio.create_task(asyncio.sleep(0.2))
+    handle.running_tasks["1"] = active
+
+    await coordinator._reconcile_running_tasks()
+
+    task = store.get("1")
+    assert task is not None
+    assert task.status == TaskStatus.PENDING
+    assert "1" in handle.task_ids
+    active.cancel()
+    with suppress(asyncio.CancelledError):
+        await active
+
+
+async def test_shutdown_cancels_running_tasks_cleanly(store: TaskStore) -> None:
+    gate = asyncio.Event()
+
+    class BlockingAgent:
+        async def run(self, task: str) -> str:
+            await gate.wait()
+            return "done"
+
+    def builder_factory(agent_id: str):
+        return BuilderStub(BlockingAgent())
+
+    coordinator = SwarmCoordinator(store, builder_factory, heartbeat_interval=0.1)
+    store.create(subject="Test task", description="...")
+    await coordinator.spawn_agents(n=1)
+    await coordinator._assign_tasks()
+
+    handle = coordinator.agents["agent-1"]
+    assert "1" in handle.running_tasks
+
+    await coordinator.shutdown()
+
+    task = store.get("1")
+    assert task is not None
+    assert task.status == TaskStatus.PENDING
+    assert task.owner is None
+    assert handle.running_tasks == {}
+    assert handle.task_ids == []
+
+
+async def test_composed_agent_shutdown_delegates_to_dispatcher_runtime() -> None:
+    from ouro.capabilities.builder import AgentBuilder
+
+    class FakeLLMForShutdown(FakeLLM):
+        pass
+
+    class RuntimeStub:
+        def __init__(self):
+            self.calls = 0
+
+        async def shutdown(self) -> None:
+            self.calls += 1
+
+    class DispatcherStub:
+        def __init__(self, runtime):
+            self.runtime = runtime
+
+        async def run(self, task: str) -> str:
+            return task
+
+    runtime = RuntimeStub()
+
+    def dispatcher_factory(single_agent_runner):
+        del single_agent_runner
+        return DispatcherStub(runtime)
+
+    agent = (
+        AgentBuilder()
+        .with_llm(FakeLLMForShutdown())
+        .with_agent_swarm(enabled=True)
+        .without_memory()
+        .with_dispatcher_factory(dispatcher_factory)
+        .build()
+    )
+
+    await agent.shutdown()
+
+    assert runtime.calls == 1


### PR DESCRIPTION
## Summary
- stop swarm workers from recursively entering the swarm dispatcher when executing Task V2 child tasks
- replace heartbeat-style in-process worker tracking with direct asyncio task-handle reconciliation and clean shutdown
- invoke agent/swarm shutdown during interactive interruption and cover the new behavior with focused swarm tests

## Scope
- Goals:
  - Make in-process swarm worker execution deterministic and non-recursive
  - Recover cancelled/failed worker tasks from tracked asyncio task handles
  - Cleanly cancel in-flight swarm work during Ctrl-C / interactive interruption
- Non-goals:
  - Solve the remaining GUI-style “appears stuck” observability issue in this PR
  - Add distributed or cross-process swarm liveness management

## Invariants (Must Not Regress)
- [x] Simple non-swarm agent runs still use the standard single-agent loop
- [x] Task V2 remains the source of truth for swarm task state
- [x] Capabilities/core/interface layer boundaries remain intact
- [x] Structured task results and follow-up task generation still work
- [x] Interactive cancellation still interrupts the current foreground task

## Acceptance Criteria
- [x] Swarm workers do not recursively re-enter swarm execution
- [x] In-process worker tracking uses asyncio task handles instead of heartbeat-based stale detection
- [x] Cancelled swarm worker tasks are reconciled back into Task V2 safely
- [x] Interactive interruption triggers agent/swarm shutdown cleanup

## Test Plan
- [x] Targeted tests: `./scripts/dev.sh test -q test/swarm/test_swarm.py`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)
- [ ] `python -m ouro.interfaces.cli.entry --task "inspect the current swarm task-graph execution design and summarize the findings"`
  - A related real interactive repro still shows a “looks stuck” follow-up issue; this PR focuses on recursion/cancellation/shutdown stability first.

## Adversarial Review (Answer Briefly)
- What existing behavior could this break? (3–5 invariants)
  - Worker task assignment and completion bookkeeping, especially around cancellation and recovery, are the most likely risk areas.
- Worst-case input/output size? Any truncation/limits?
  - No new payload size expansion; this change primarily adjusts execution tracking and shutdown behavior.
- Any secrets/logging risks?
  - No new secret surfaces; logging remains limited to execution state transitions.
- Any async/blocking I/O added on hot paths?
  - No blocking I/O added; execution tracking now uses existing asyncio task handles directly.
- What error message does the user see on failure? Is it actionable?
  - Cancelled worker tasks are now recovered cleanly instead of leaving late shutdown exceptions; remaining stuck/visibility issues are called out separately.

## Docs / Compatibility
- [x] No public API removals or breaking config changes
- [x] No secrets committed; no generated artifacts included

## Known Follow-Up
- A real swarm interaction can still appear visually stuck after the initial agent banner. This PR addresses recursion and shutdown correctness first; the remaining progress/observability issue should be debugged in a follow-up.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)