### PR TITLE
Improve swarm observability and worker robustness

### DIFF
--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -136,6 +136,7 @@ class AgentBuilder:
     progress: ProgressSink = field(default_factory=NullProgressSink)
     extra_hooks: list[Hook] = field(default_factory=list)
     dispatcher_factory: Any | None = None
+    swarm_max_workers: int = 5
     # Deterministic per-tool-call rules. ReadBeforeWriteRule and
     # NestedAgentsMdRule are on by default; `extra_rules` run after them.
     # See `ouro.capabilities.rules`.
@@ -273,6 +274,10 @@ class AgentBuilder:
 
     def with_dispatcher_factory(self, factory) -> AgentBuilder:
         self.dispatcher_factory = factory
+        return self
+
+    def with_swarm_max_workers(self, n: int) -> AgentBuilder:
+        self.swarm_max_workers = max(1, n)
         return self
 
     def with_hook(self, hook: Hook) -> AgentBuilder:
@@ -437,7 +442,7 @@ class AgentBuilder:
                     heartbeat_interval=5.0,
                     progress=progress,
                 )
-                runtime = SwarmRuntime(coordinator)
+                runtime = SwarmRuntime(coordinator, default_agents=self.swarm_max_workers)
                 synthesizer = TaskGraphSynthesizer()
                 return SwarmExecutionDispatcher(
                     analyzer=analyzer,
@@ -446,6 +451,7 @@ class AgentBuilder:
                     runtime=runtime,
                     synthesizer=synthesizer,
                     single_agent_runner=single_agent_runner,
+                    progress=progress,
                 )
 
             dispatcher_factory = default_dispatcher_factory
@@ -591,14 +597,12 @@ class ComposedAgent:
         verify: bool = False,
         images: Sequence[ImageInput] | None = None,
     ) -> str:
-        if self.memory is None:
-            return await self._core.run(task, context=self._context)
-
-        # 1) System prompt — only on first turn.
-        if not self._context.has_system_messages:
+        # 1) System prompt — only when memory-backed conversations are enabled.
+        if self.memory is not None and not self._context.has_system_messages:
             await self._add_system_prompt()
 
-        # 2) User message (text or multimodal with images).
+        # 2) User message (text or multimodal with images) always enters the
+        # loop-owned context, even for transient no-memory runs.
         user_msg = await self._build_user_message(task, images)
         self._context.detached.append(user_msg)
 
@@ -627,8 +631,9 @@ class ComposedAgent:
                 for block in user_msg.content
             ]
 
-        # 6) Flush memory.
-        await self.memory.save_memory(context=self._context)
+        # 6) Flush memory when persistence is enabled.
+        if self.memory is not None:
+            await self.memory.save_memory(context=self._context)
         return result
 
     # ---- proxies ------------------------------------------------------------

--- a/ouro/capabilities/swarm/dispatcher.py
+++ b/ouro/capabilities/swarm/dispatcher.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from ouro.capabilities.swarm.analyzer import TaskAnalysis, TaskAnalyzer
 from ouro.capabilities.swarm.planner import TaskPlan, TaskPlanner
 from ouro.capabilities.tasks.store import TaskStore
+from ouro.core.loop import NullProgressSink, ProgressEvent
 
 
 @dataclass
@@ -30,6 +31,7 @@ class SwarmExecutionDispatcher:
         runtime,
         synthesizer,
         single_agent_runner,
+        progress=None,
     ) -> None:
         self.analyzer = analyzer
         self.planner = planner
@@ -37,6 +39,7 @@ class SwarmExecutionDispatcher:
         self.runtime = runtime
         self.synthesizer = synthesizer
         self.single_agent_runner = single_agent_runner
+        self.progress = progress or NullProgressSink()
         self.last_decision: DispatchDecision | None = None
 
     async def run(self, task: str) -> str:
@@ -46,6 +49,31 @@ class SwarmExecutionDispatcher:
             return await self.single_agent_runner(task)
 
         plan = await self.planner.plan(task)
+        self.progress.emit(
+            ProgressEvent(
+                kind="swarm_reset",
+                payload={"keep_headers": False},
+            )
+        )
+        self.progress.emit(
+            ProgressEvent(
+                kind="swarm_header",
+                payload={
+                    "line": f"Swarm selected: complexity={analysis.complexity_score:.2f}, tasks={len(plan.tasks)}",
+                    "title": "Swarm",
+                },
+            )
+        )
+        for idx, planned in enumerate(plan.tasks, start=1):
+            self.progress.emit(
+                ProgressEvent(
+                    kind="swarm_plan_item",
+                    payload={
+                        "line": f"#{idx} {planned.subject}",
+                        "title": "Swarm Plan",
+                    },
+                )
+            )
         store: TaskStore = self.store_factory()
         self._persist_plan(plan, store)
         await self.runtime.run_until_done(store=store, plan=plan, root_task=task)

--- a/ouro/capabilities/swarm/planner.py
+++ b/ouro/capabilities/swarm/planner.py
@@ -59,7 +59,9 @@ Return valid JSON matching this schema:
 ```
 
 Rules:
-- Create 1 to 6 tasks.
+- Create 3 to 6 tasks for genuinely complex requests; use 1 task only if the request is truly atomic.
+- Prefer high-level phases or responsibilities over atomic implementation steps.
+- Do not exceed 8 tasks under any circumstance.
 - Use dependencies whenever one task must wait for another.
 - Prefer partially ordered work over pretending tasks are independent.
 - Every `local_id` must be unique.
@@ -75,8 +77,9 @@ Response:"""
 class TaskPlanner:
     """Plan a complex task as a dependency graph for Task V2 execution."""
 
-    def __init__(self, llm) -> None:
+    def __init__(self, llm, max_tasks: int = 8) -> None:
         self.llm = llm
+        self.max_tasks = max_tasks
 
     async def plan(self, task: str) -> TaskPlan:
         """Return a validated task graph for the given request."""
@@ -125,6 +128,10 @@ class TaskPlanner:
     def _validate(self, plan: TaskPlan) -> None:
         if not plan.tasks:
             raise ValueError("Planner returned no tasks")
+        if len(plan.tasks) > self.max_tasks:
+            raise ValueError(
+                f"Planner returned too many tasks: {len(plan.tasks)} > {self.max_tasks}"
+            )
 
         ids = [task.local_id for task in plan.tasks]
         if len(ids) != len(set(ids)):

--- a/ouro/capabilities/swarm/runtime.py
+++ b/ouro/capabilities/swarm/runtime.py
@@ -6,17 +6,23 @@ import asyncio
 
 from ouro.capabilities.swarm.coordinator import SwarmCoordinator
 from ouro.capabilities.swarm.replanner import SwarmReplanner
+from ouro.core.loop import ProgressEvent
 
 
 class SwarmRuntime:
     """Execute a Task V2 plan using the existing scheduler implementation."""
 
     def __init__(
-        self, coordinator: SwarmCoordinator, replanner: SwarmReplanner | None = None
+        self,
+        coordinator: SwarmCoordinator,
+        replanner: SwarmReplanner | None = None,
+        default_agents: int = 5,
     ) -> None:
         self.coordinator = coordinator
         self.replanner = replanner or SwarmReplanner()
+        self.default_agents = default_agents
         self._applied_followups: set[str] = set()
+        self._last_status_line: str | None = None
 
     async def run_until_done(self, *, store, plan, root_task: str) -> None:
         # The runtime delegates scheduling to the existing coordinator and
@@ -27,10 +33,28 @@ class SwarmRuntime:
         self.coordinator.engine.store = store
 
         if not self.coordinator.agents:
-            await self.coordinator.spawn_agents(n=1)
+            await self.coordinator.spawn_agents(
+                n=min(self.default_agents, max(1, len(store.list_all())))
+            )
 
         idle_count = 0
         while not self.coordinator._shutdown:
+            status = self.coordinator.get_status()
+            status_line = (
+                "Swarm status: "
+                f"{status.completed}/{status.total_tasks} done, "
+                f"{status.in_progress} running, "
+                f"{status.blocked} blocked, "
+                f"{status.pending} pending"
+            )
+            if status_line != self._last_status_line:
+                self.coordinator.progress.emit(
+                    ProgressEvent(
+                        kind="swarm_status",
+                        payload={"line": status_line, "title": "Swarm Status"},
+                    )
+                )
+                self._last_status_line = status_line
             await self.coordinator._assign_tasks()
             await self.coordinator._reconcile_running_tasks()
             self._apply_followups(store)

--- a/test/swarm/test_builder_dispatch.py
+++ b/test/swarm/test_builder_dispatch.py
@@ -60,6 +60,12 @@ async def test_agent_team_run_uses_dispatcher_factory() -> None:
     assert holder["dispatcher"].calls == ["complex task"]
 
 
+async def test_builder_defaults_swarm_max_workers_to_five() -> None:
+    builder = AgentBuilder()
+
+    assert builder.swarm_max_workers == 5
+
+
 async def test_non_team_run_keeps_single_agent_path() -> None:
     agent = AgentBuilder().with_llm(FakeLLM()).without_memory().build()
 

--- a/test/swarm/test_dispatcher.py
+++ b/test/swarm/test_dispatcher.py
@@ -10,6 +10,15 @@ from ouro.capabilities.swarm.dispatcher import SwarmExecutionDispatcher
 from ouro.capabilities.swarm.planner import PlannedTask, TaskPlan
 from ouro.capabilities.swarm.synthesizer import TaskGraphSynthesizer
 from ouro.capabilities.tasks.store import TaskStore
+from ouro.core.loop import ProgressEvent
+
+
+class RecordingProgress:
+    def __init__(self):
+        self.events: list[ProgressEvent] = []
+
+    def emit(self, event: ProgressEvent) -> None:
+        self.events.append(event)
 
 
 class StubAnalyzer:
@@ -64,6 +73,7 @@ class StubRuntime:
 class TestSwarmExecutionDispatcher:
     async def test_simple_task_uses_single_agent_runner(self) -> None:
         runtime = StubRuntime()
+        progress = RecordingProgress()
         with tempfile.TemporaryDirectory() as tmpdir:
             store_path = Path(tmpdir) / "tasks.db"
             dispatcher = SwarmExecutionDispatcher(
@@ -73,17 +83,20 @@ class TestSwarmExecutionDispatcher:
                 runtime=runtime,
                 synthesizer=TaskGraphSynthesizer(),
                 single_agent_runner=_single_agent_runner,
+                progress=progress,
             )
 
             result = await dispatcher.run("Simple task")
 
         assert result == "single-agent: Simple task"
         assert runtime.calls == 0
+        assert progress.events == []
         assert dispatcher.last_decision is not None
         assert dispatcher.last_decision.used_swarm is False
 
-    async def test_complex_task_uses_swarm_path_and_persists_dependencies(self) -> None:
+    async def test_complex_task_emits_plan_progress_and_persists_dependencies(self) -> None:
         runtime = StubRuntime()
+        progress = RecordingProgress()
         with tempfile.TemporaryDirectory() as tmpdir:
             store_path = Path(tmpdir) / "tasks.db"
             store_ref: dict[str, TaskStore] = {}
@@ -100,12 +113,17 @@ class TestSwarmExecutionDispatcher:
                 runtime=runtime,
                 synthesizer=TaskGraphSynthesizer(),
                 single_agent_runner=_single_agent_runner,
+                progress=progress,
             )
 
             result = await dispatcher.run("Complex task")
             tasks = store_ref["store"].list_all()
 
         assert runtime.calls == 1
+        kinds = [event.kind for event in progress.events]
+        assert "swarm_reset" in kinds
+        assert "swarm_header" in kinds
+        assert kinds.count("swarm_plan_item") == 2
         assert len(tasks) == 2
         assert tasks[1].blockedBy == [tasks[0].id]
         assert tasks[0].metadata["result"] == "result-1"

--- a/test/swarm/test_planner.py
+++ b/test/swarm/test_planner.py
@@ -69,3 +69,24 @@ class TestTaskPlanner:
 
         assert len(plan.tasks) == 1
         assert plan.tasks[0].subject == "Execute the requested task"
+
+    async def test_too_many_tasks_fall_back_to_single_task(self) -> None:
+        response = """{
+          "summary": "Overplanned",
+          "tasks": [
+            {"local_id": "t1", "subject": "T1", "description": "..."},
+            {"local_id": "t2", "subject": "T2", "description": "..."},
+            {"local_id": "t3", "subject": "T3", "description": "..."},
+            {"local_id": "t4", "subject": "T4", "description": "..."},
+            {"local_id": "t5", "subject": "T5", "description": "..."},
+            {"local_id": "t6", "subject": "T6", "description": "..."},
+            {"local_id": "t7", "subject": "T7", "description": "..."},
+            {"local_id": "t8", "subject": "T8", "description": "..."},
+            {"local_id": "t9", "subject": "T9", "description": "..."}
+          ]
+        }"""
+        planner = TaskPlanner(FakeLLM(response), max_tasks=8)
+        plan = await planner.plan("Do the work")
+
+        assert len(plan.tasks) == 1
+        assert plan.tasks[0].local_id == "task-1"

--- a/test/swarm/test_runtime.py
+++ b/test/swarm/test_runtime.py
@@ -31,7 +31,9 @@ async def test_runtime_emits_status_only_on_change() -> None:
         progress = RecordingProgress()
         coordinator = SwarmCoordinator(store, lambda agent_id: BuilderStub(), progress=progress)
         runtime = SwarmRuntime(coordinator, default_agents=1)
-        coordinator.agents["agent-1"] = object()  # prevent automatic spawn for this observability test
+        coordinator.agents["agent-1"] = (
+            object()
+        )  # prevent automatic spawn for this observability test
         coordinator._shutdown = True
 
         await runtime.run_until_done(store=store, plan=None, root_task="task")

--- a/test/swarm/test_runtime.py
+++ b/test/swarm/test_runtime.py
@@ -1,0 +1,69 @@
+"""Tests for SwarmRuntime observability behavior."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from ouro.capabilities.swarm.coordinator import SwarmCoordinator
+from ouro.capabilities.swarm.runtime import SwarmRuntime
+from ouro.capabilities.tasks.store import TaskStore
+from ouro.core.loop import ProgressEvent
+
+
+class RecordingProgress:
+    def __init__(self):
+        self.events: list[ProgressEvent] = []
+
+    def emit(self, event: ProgressEvent) -> None:
+        self.events.append(event)
+
+
+class BuilderStub:
+    def build(self):
+        raise AssertionError("Worker build should not be needed in this test")
+
+
+async def test_runtime_emits_status_only_on_change() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = TaskStore(Path(tmpdir) / "tasks.db")
+        store.create(subject="Task 1", description="...")
+        progress = RecordingProgress()
+        coordinator = SwarmCoordinator(store, lambda agent_id: BuilderStub(), progress=progress)
+        runtime = SwarmRuntime(coordinator, default_agents=1)
+        coordinator.agents["agent-1"] = object()  # prevent automatic spawn for this observability test
+        coordinator._shutdown = True
+
+        await runtime.run_until_done(store=store, plan=None, root_task="task")
+
+    status_events = [event for event in progress.events if event.kind == "swarm_status"]
+    assert len(status_events) <= 1
+
+
+async def test_runtime_spawns_up_to_configured_default_agents() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = TaskStore(Path(tmpdir) / "tasks.db")
+        for i in range(7):
+            store.create(subject=f"Task {i}", description="...")
+        progress = RecordingProgress()
+        spawn_calls: list[int] = []
+
+        class BuildableStub:
+            def build(self):
+                return object()
+
+        coordinator = SwarmCoordinator(store, lambda agent_id: BuildableStub(), progress=progress)
+
+        original_spawn = coordinator.spawn_agents
+
+        async def recording_spawn(n: int = 1):
+            spawn_calls.append(n)
+            return await original_spawn(n=n)
+
+        coordinator.spawn_agents = recording_spawn  # type: ignore[method-assign]
+        runtime = SwarmRuntime(coordinator, default_agents=5)
+        coordinator._shutdown = True
+
+        await runtime.run_until_done(store=store, plan=None, root_task="task")
+
+    assert spawn_calls == [5]

--- a/test/test_composed_agent_no_memory.py
+++ b/test/test_composed_agent_no_memory.py
@@ -1,0 +1,42 @@
+"""Regression tests for no-memory ComposedAgent runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ouro.capabilities.builder import AgentBuilder
+from ouro.core.llm import LLMMessage, LLMResponse, StopReason
+
+
+@dataclass
+class RecordingLLM:
+    seen_messages: list[list[LLMMessage]] = field(default_factory=list)
+
+    async def call_async(self, messages, tools=None, max_tokens=None, **kwargs):
+        self.seen_messages.append(list(messages))
+        return LLMResponse(content="done", stop_reason=StopReason.STOP)
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse):
+        return []
+
+    def to_message(self, response: LLMResponse) -> LLMMessage:
+        return LLMMessage(role="assistant", content=response.content)
+
+    @property
+    def supports_tools(self) -> bool:
+        return True
+
+
+async def test_no_memory_run_still_includes_user_message() -> None:
+    llm = RecordingLLM()
+    agent = AgentBuilder().with_llm(llm).without_memory().build()
+
+    result = await agent.run("hello from worker")
+
+    assert result == "done"
+    assert llm.seen_messages
+    first_call = llm.seen_messages[0]
+    assert any(msg.role == "user" and msg.content == "hello from worker" for msg in first_call)


### PR DESCRIPTION
## Summary
- tighten swarm planning so complex requests produce a small high-level task graph and show planning progress in the TUI
- raise and expose the swarm worker concurrency default so wider task graphs can execute in parallel
- fix no-memory worker runs so they still send user input to the loop, avoiding provider request failures

## Scope
- Goals:
  - make swarm runs feel responsive and understandable during planning and execution
  - reduce planner over-decomposition and improve default parallelism
  - prevent no-memory swarm workers from issuing empty LLM requests
- Non-goals:
  - redesign the Task V2 swarm architecture again
  - reintroduce hook-based swarm execution or heartbeat-style stale recovery

## Invariants (Must Not Regress)
- [ ] Simple requests still bypass swarm and run through the normal single-agent path
- [ ] Swarm workers do not recursively re-enter swarm execution
- [ ] Task V2 remains the source of truth for swarm task graphs and dependencies
- [ ] Runtime status updates do not spam identical lines when nothing changes
- [ ] No-memory composed-agent runs still work without persistence enabled

## Acceptance Criteria
- [ ] Planner guidance and validation keep generated swarm plans bounded to a small high-level task set
- [ ] Dispatcher emits swarm planning events before runtime execution begins
- [ ] Swarm runtime starts up to the configured default number of workers, with the default set to 5
- [ ] No-memory worker runs include a user message in the loop context, preventing provider input errors

## Test Plan
- [x] Targeted tests: `./scripts/dev.sh test -q test/test_composed_agent_no_memory.py test/swarm/test_runtime.py test/swarm/test_builder_dispatch.py`
- [x] `./scripts/dev.sh test -q`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)
- [ ] `python main.py --task "<...>" --verify` (not rerun in this patch; behavior covered by targeted tests plus full check)

## Adversarial Review (Answer Briefly)
- What existing behavior could this break? (3–5 invariants)
  - planner caps could collapse a legitimately detailed task graph into a single fallback task
  - higher default concurrency could expose races in worker coordination for plans with more breadth
  - new planning/status events could affect progress sinks that assume a narrower event sequence
  - no-memory context changes could alter prompt ordering for transient agent runs
- Worst-case input/output size? Any truncation/limits?
  - planner output is now explicitly capped at 8 tasks by validation, with fallback to a single-task plan on overflow
- Any secrets/logging risks?
  - no new secret handling or logging surfaces were added
- Any async/blocking I/O added on hot paths?
  - no new blocking I/O; runtime only adds status deduplication and configurable worker spawn count
- What error message does the user see on failure? Is it actionable?
  - oversized plans fall back internally rather than surfacing a planner-shape failure; provider empty-input failures should now be prevented in no-memory runs

## Docs / Compatibility
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)
- [ ] Updated relevant docs (`README.md`, `docs/examples.md`, `docs/configuration.md`) when needed

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)