### PR TITLE
Retry transient LLM disconnects

### DIFF
--- a/ouro/core/llm/retry.py
+++ b/ouro/core/llm/retry.py
@@ -44,6 +44,17 @@ def is_retryable_error(error: BaseException) -> bool:
         "timeout",
         "connection",
         "server error",
+        # httpx/httpcore can surface upstream disconnects as
+        # RemoteProtocolError("Server disconnected without sending a response")
+        # without wrapping them in LiteLLM's APIConnectionError. Treat these as
+        # transient transport failures so the normal retry policy applies.
+        "server disconnected",
+        "disconnected without sending",
+        "remote protocol error",
+        "remoteprotocolerror",
+        "connection closed",
+        "connection reset",
+        "connection aborted",
         "500",
         "502",
         "503",

--- a/ouro/interfaces/tui/interactive.py
+++ b/ouro/interfaces/tui/interactive.py
@@ -1,6 +1,7 @@
 """Interactive multi-turn conversation mode for the agent."""
 
 import asyncio
+import logging
 import shlex
 import signal
 
@@ -35,6 +36,16 @@ from ouro.interfaces.tui.reasoning_ui import pick_reasoning_effort
 from ouro.interfaces.tui.skills_ui import SkillsAction, pick_skills_action
 from ouro.interfaces.tui.status_bar import StatusBar
 from ouro.interfaces.tui.theme import Theme, set_theme
+
+logger = logging.getLogger(__name__)
+
+
+def _format_exception_message(error: BaseException) -> str:
+    """Return a useful user-facing message even for exceptions with empty str()."""
+    message = str(error).strip()
+    if message:
+        return message
+    return type(error).__name__
 
 
 class InteractiveSession:
@@ -517,7 +528,8 @@ class InteractiveSession:
             if getattr(self.agent, "memory", None) is not None:
                 self.agent.rollback_incomplete_exchange()
         except Exception as e:
-            terminal_ui.print_error(str(e))
+            logger.exception("Skill invocation failed")
+            terminal_ui.print_error(_format_exception_message(e))
             if Config.TUI_STATUS_BAR:
                 self.status_bar.update(is_processing=False)
 
@@ -909,7 +921,8 @@ class InteractiveSession:
                     self.current_task = None
                     continue
                 except Exception as e:
-                    terminal_ui.print_error(str(e))
+                    logger.exception("Interactive agent run failed")
+                    terminal_ui.print_error(_format_exception_message(e))
                     if Config.TUI_STATUS_BAR:
                         self.status_bar.update(is_processing=False)
                     continue

--- a/test/test_llm_retry.py
+++ b/test/test_llm_retry.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from ouro.core.llm.retry import is_retryable_error
+
+
+class CustomError(Exception):
+    pass
+
+
+def test_server_disconnected_error_is_retryable() -> None:
+    assert is_retryable_error(CustomError("Server disconnected without sending a response."))
+
+
+def test_remote_protocol_disconnect_error_is_retryable() -> None:
+    assert is_retryable_error(
+        CustomError("httpcore.RemoteProtocolError: Server disconnected without sending a response.")
+    )
+
+
+def test_cancelled_error_is_not_retryable() -> None:
+    assert not is_retryable_error(asyncio.CancelledError())

--- a/test/test_model_setup_session.py
+++ b/test/test_model_setup_session.py
@@ -1,5 +1,7 @@
 import types
 
+from ouro.interfaces.tui.interactive import _format_exception_message
+
 
 class _FakeInputHandler:
     def __init__(self, inputs: list[str]):
@@ -7,6 +9,15 @@ class _FakeInputHandler:
 
     async def prompt_async(self, prompt_text: str = "> ") -> str:  # noqa: ARG002
         return next(self._inputs)
+
+
+def test_format_exception_message_falls_back_to_exception_type() -> None:
+    class EmptyMessageError(Exception):
+        def __str__(self) -> str:
+            return ""
+
+    assert _format_exception_message(EmptyMessageError()) == "EmptyMessageError"
+    assert _format_exception_message(RuntimeError("boom")) == "boom"
 
 
 async def _write_models_yaml(path, *, model_id: str = "openai/gpt-4o") -> None:


### PR DESCRIPTION
## Summary

Retry transient LLM transport disconnects and improve TUI error visibility.

## Scope

- Goals:
  - Treat common httpx/httpcore server disconnect messages as retryable LLM failures.
  - Avoid blank TUI error panels when an exception has an empty string representation.
  - Log interactive/skill invocation exceptions with stack traces when logging is enabled.
- Non-goals:
  - Change tool execution semantics.
  - Change provider configuration or timeout defaults.

## Invariants (Must Not Regress)

- [x] `asyncio.CancelledError` remains non-retryable.
- [x] Existing rate limit / timeout / 5xx retry behavior remains unchanged.
- [x] TUI still continues the interactive loop after recoverable display errors.
- [x] Tool-call message ordering is unchanged.

## Acceptance Criteria

- [x] `Server disconnected without sending a response` is classified as retryable.
- [x] `RemoteProtocolError` disconnect strings are classified as retryable.
- [x] Empty exception messages in TUI fall back to the exception type name.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_llm_retry.py test/test_model_setup_session.py`
- [x] Related tests: `./scripts/dev.sh test -q test/test_litellm_adapter.py test/test_slash_autocomplete_engine.py test/test_slash_command_autocomplete.py`
- [x] `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` (covered by `./scripts/dev.sh check` in this repo configuration)

## Smoke Run (Real CLI)

- [ ] Not run: change is retry/error-handling only and would require inducing an upstream transport disconnect.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Retry classification could retry a non-transient provider error if it contains the new disconnect keywords.
- Worst-case input/output size? No new large I/O; only string matching on exception text.
- Any secrets/logging risks? Stack traces are logged only when logging is enabled; no request payloads or API keys are added.
- Any async/blocking I/O added on hot paths? No.
- What error message does the user see on failure? The original exception message, or the exception type name if the message is empty.

## Docs / Compatibility

- [x] No docs needed for internal retry/error display behavior.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)