### PR TITLE
Escape TUI tool call markup

### DIFF
--- a/ouro/interfaces/tui/terminal_ui.py
+++ b/ouro/interfaces/tui/terminal_ui.py
@@ -145,19 +145,22 @@ def print_tool_call(tool_name: str, arguments: Dict[str, Any]) -> None:
     # Format arguments nicely
     args_lines = []
     for key, value in arguments.items():
+        key_str = rich_escape(str(key))
         value_str = str(value)
         if len(value_str) > 100:
             value_str = value_str[:97] + "..."
+        value_str = rich_escape(value_str)
         args_lines.append(
-            f"  [{colors.text_secondary}]{key}:[/{colors.text_secondary}] {value_str}"
+            f"  [{colors.text_secondary}]{key_str}:[/{colors.text_secondary}] {value_str}"
         )
 
     content = "\n".join(args_lines) if args_lines else ""
+    escaped_tool_name = rich_escape(tool_name)
 
     console.print(
         Panel(
             content,
-            title=f"[{colors.tool_accent}]Tool: {tool_name}[/{colors.tool_accent}]",
+            title=f"[{colors.tool_accent}]Tool: {escaped_tool_name}[/{colors.tool_accent}]",
             title_align="left",
             border_style=colors.text_muted,
             box=box.ROUNDED,
@@ -199,20 +202,23 @@ def print_tool_blocked(tool_name: str, arguments: Dict[str, Any], reason: str) -
     # Format arguments nicely (same as print_tool_call)
     args_lines = []
     for key, value in arguments.items():
+        key_str = rich_escape(str(key))
         value_str = str(value)
         if len(value_str) > 100:
             value_str = value_str[:97] + "..."
+        value_str = rich_escape(value_str)
         args_lines.append(
-            f"  [{colors.text_secondary}]{key}:[/{colors.text_secondary}] {value_str}"
+            f"  [{colors.text_secondary}]{key_str}:[/{colors.text_secondary}] {value_str}"
         )
 
-    content_parts = args_lines + ["", f"[{colors.warning}]{reason}[/{colors.warning}]"]
+    content_parts = args_lines + ["", f"[{colors.warning}]{rich_escape(reason)}[/{colors.warning}]"]
     content = "\n".join(content_parts)
+    escaped_tool_name = rich_escape(tool_name)
 
     console.print(
         Panel(
             content,
-            title=f"[{colors.warning}]Blocked: {tool_name}[/{colors.warning}]",
+            title=f"[{colors.warning}]Blocked: {escaped_tool_name}[/{colors.warning}]",
             title_align="left",
             border_style=colors.warning,
             box=box.ROUNDED,

--- a/test/test_terminal_ui_markup.py
+++ b/test/test_terminal_ui_markup.py
@@ -1,0 +1,45 @@
+from io import StringIO
+
+from rich.console import Console
+
+from ouro.interfaces.tui import terminal_ui
+
+
+def test_print_tool_call_escapes_markup_in_dynamic_fields(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(
+        terminal_ui,
+        "console",
+        Console(file=output, force_terminal=True, width=120),
+    )
+
+    terminal_ui.print_tool_call(
+        "[agent-2] shell",
+        {
+            "[bad-key]": "literal closing tag [/{colors.text_secondary}]",
+            "command": "printf '[not markup]'",
+        },
+    )
+
+    rendered = output.getvalue()
+    assert "Tool:" in rendered
+    assert "literal closing tag" in rendered
+
+
+def test_print_tool_blocked_escapes_markup_in_dynamic_fields(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(
+        terminal_ui,
+        "console",
+        Console(file=output, force_terminal=True, width=120),
+    )
+
+    terminal_ui.print_tool_blocked(
+        "[agent-2] shell",
+        {"command": "printf '[not markup]'"},
+        "blocked because [/{colors.warning}] should be literal",
+    )
+
+    rendered = output.getvalue()
+    assert "Blocked:" in rendered
+    assert "should be literal" in rendered


### PR DESCRIPTION
## Summary

What changed and why (user-facing when applicable).

## Scope

- Goals:
- Non-goals:

## Invariants (Must Not Regress)

- [ ] List 3–5 existing behaviors that must stay the same

## Acceptance Criteria

- [ ] Concrete, testable outcomes

## Test Plan

- [ ] Targeted tests:
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "<...>" --verify` (or explain why not)

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? (3–5 invariants)
- Worst-case input/output size? Any truncation/limits?
- Any secrets/logging risks?
- Any async/blocking I/O added on hot paths?
- What error message does the user see on failure? Is it actionable?

## Docs / Compatibility

- [ ] Updated relevant docs (`README.md`, `docs/examples.md`, `docs/configuration.md`) when needed
- [ ] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)

---

Note: This template is also embedded in `CLAUDE.md` so coding-agents always see it.
