### PR TITLE
Add core tracing primitives

### DIFF
--- a/ouro/core/tracing/__init__.py
+++ b/ouro/core/tracing/__init__.py
@@ -1,0 +1,29 @@
+"""Core tracing primitives for ouro runtime observability."""
+
+from .context import get_current_run_id, get_current_span_id
+from .events import TraceError, TraceEvent, TraceEventType, TraceStatus
+from .exporters import (
+    InMemoryTraceExporter,
+    JSONLTraceExporter,
+    NoOpTraceExporter,
+    TraceExporter,
+)
+from .tracer import NoOpSpan, Span, Tracer, sanitize_attributes, span
+
+__all__ = [
+    "InMemoryTraceExporter",
+    "JSONLTraceExporter",
+    "NoOpSpan",
+    "NoOpTraceExporter",
+    "Span",
+    "TraceError",
+    "TraceEvent",
+    "TraceEventType",
+    "TraceExporter",
+    "TraceStatus",
+    "Tracer",
+    "get_current_run_id",
+    "get_current_span_id",
+    "sanitize_attributes",
+    "span",
+]

--- a/ouro/core/tracing/context.py
+++ b/ouro/core/tracing/context.py
@@ -1,0 +1,16 @@
+"""Context-local trace span state."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+_current_run_id: ContextVar[str | None] = ContextVar("ouro_trace_current_run_id", default=None)
+_current_span_id: ContextVar[str | None] = ContextVar("ouro_trace_current_span_id", default=None)
+
+
+def get_current_run_id() -> str | None:
+    return _current_run_id.get()
+
+
+def get_current_span_id() -> str | None:
+    return _current_span_id.get()

--- a/ouro/core/tracing/events.py
+++ b/ouro/core/tracing/events.py
@@ -1,0 +1,86 @@
+"""Structured trace event types for ouro runtime observability."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+TraceStatus = Literal["started", "completed", "failed", "event"]
+
+
+class TraceEventType(StrEnum):
+    """High-level event categories emitted by ouro tracing."""
+
+    RUN = "run"
+    AGENT = "agent"
+    TASK = "task"
+    LLM_CALL = "llm_call"
+    TOOL_CALL = "tool_call"
+    MEMORY = "memory"
+    PLAN = "plan"
+    VERIFY = "verify"
+    ERROR = "error"
+    LOG = "log"
+
+
+@dataclass(frozen=True, slots=True)
+class TraceError:
+    """Bounded error details safe to serialize in trace events."""
+
+    type: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"type": self.type, "message": self.message}
+
+
+@dataclass(frozen=True, slots=True)
+class TraceEvent:
+    """Append-only trace event emitted by spans and tracers."""
+
+    event_id: str
+    run_id: str
+    span_id: str
+    parent_span_id: str | None
+    timestamp: datetime
+    event_type: str
+    name: str
+    status: TraceStatus
+    attributes: dict[str, Any] = field(default_factory=dict)
+    agent_id: str | None = None
+    task_id: str | None = None
+    duration_ms: int | None = None
+    error: TraceError | None = None
+    links: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary."""
+        data: dict[str, Any] = {
+            "event_id": self.event_id,
+            "run_id": self.run_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "timestamp": self.timestamp.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "event_type": self.event_type,
+            "name": self.name,
+            "status": self.status,
+            "attributes": self.attributes,
+        }
+        if self.agent_id is not None:
+            data["agent_id"] = self.agent_id
+        if self.task_id is not None:
+            data["task_id"] = self.task_id
+        if self.duration_ms is not None:
+            data["duration_ms"] = self.duration_ms
+        if self.error is not None:
+            data["error"] = self.error.to_dict()
+        if self.links:
+            data["links"] = list(self.links)
+        return data
+
+
+def utc_now() -> datetime:
+    """Return the current UTC datetime."""
+    return datetime.now(UTC)

--- a/ouro/core/tracing/exporters.py
+++ b/ouro/core/tracing/exporters.py
@@ -1,0 +1,55 @@
+"""Trace exporters for local testing and JSONL persistence."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Protocol
+
+from .events import TraceEvent
+
+
+class TraceExporter(Protocol):
+    """Receives trace events emitted by a tracer."""
+
+    async def export(self, event: TraceEvent) -> None: ...
+
+
+class NoOpTraceExporter:
+    """Exporter that intentionally drops every event."""
+
+    async def export(self, event: TraceEvent) -> None:
+        return None
+
+
+class InMemoryTraceExporter:
+    """Exporter useful for deterministic tests."""
+
+    def __init__(self) -> None:
+        self.events: list[TraceEvent] = []
+
+    async def export(self, event: TraceEvent) -> None:
+        self.events.append(event)
+
+
+class JSONLTraceExporter:
+    """Append trace events to a newline-delimited JSON file.
+
+    File writes are protected by an async lock so concurrent spans do not
+    interleave writes. The implementation performs small synchronous writes;
+    it is intended for local/debug export and should be wrapped/buffered before
+    use on high-volume hot paths.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._lock = asyncio.Lock()
+
+    async def export(self, event: TraceEvent) -> None:
+        line = json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True)
+        async with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+                handle.write("\n")

--- a/ouro/core/tracing/tracer.py
+++ b/ouro/core/tracing/tracer.py
@@ -1,0 +1,257 @@
+"""Async-safe tracer and span primitives."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from time import perf_counter
+from types import TracebackType
+from typing import Any, Self
+
+from . import context
+from .events import TraceError, TraceEvent, TraceStatus, utc_now
+from .exporters import NoOpTraceExporter, TraceExporter
+
+_SECRET_MARKERS = ("key", "token", "secret", "password", "authorization", "auth")
+_DEFAULT_MAX_STRING_LENGTH = 2048
+_DEFAULT_MAX_ATTRIBUTES = 64
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _is_secret_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(marker in lowered for marker in _SECRET_MARKERS)
+
+
+def _sanitize_value(value: Any, *, max_string_length: int) -> Any:
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        if len(value) <= max_string_length:
+            return value
+        return value[:max_string_length] + "…[truncated]"
+    if isinstance(value, Mapping):
+        return sanitize_attributes(value, max_string_length=max_string_length)
+    if isinstance(value, list | tuple):
+        return [_sanitize_value(item, max_string_length=max_string_length) for item in value]
+    return repr(value)
+
+
+def sanitize_attributes(
+    attributes: Mapping[str, Any] | None,
+    *,
+    max_string_length: int = _DEFAULT_MAX_STRING_LENGTH,
+    max_attributes: int = _DEFAULT_MAX_ATTRIBUTES,
+) -> dict[str, Any]:
+    """Return redacted and bounded trace attributes."""
+    if not attributes:
+        return {}
+
+    sanitized: dict[str, Any] = {}
+    for index, (key, value) in enumerate(attributes.items()):
+        if index >= max_attributes:
+            sanitized["trace.attributes.truncated"] = True
+            break
+        string_key = str(key)
+        if _is_secret_key(string_key):
+            sanitized[string_key] = "[redacted]"
+        else:
+            sanitized[string_key] = _sanitize_value(value, max_string_length=max_string_length)
+    return sanitized
+
+
+class Tracer:
+    """Create trace spans and emit structured events."""
+
+    def __init__(
+        self,
+        exporter: TraceExporter | None = None,
+        *,
+        enabled: bool = True,
+        run_id: str | None = None,
+        max_string_length: int = _DEFAULT_MAX_STRING_LENGTH,
+    ) -> None:
+        self.exporter = exporter or NoOpTraceExporter()
+        self.enabled = enabled
+        self.run_id = run_id or _new_id("run")
+        self.max_string_length = max_string_length
+
+    def span(
+        self,
+        event_type: str,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+        agent_id: str | None = None,
+        task_id: str | None = None,
+        links: tuple[str, ...] = (),
+    ) -> Span | NoOpSpan:
+        """Create a span context manager."""
+        if not self.enabled:
+            return NoOpSpan()
+        return Span(
+            tracer=self,
+            event_type=event_type,
+            name=name,
+            attributes=attributes,
+            agent_id=agent_id,
+            task_id=task_id,
+            links=links,
+        )
+
+    async def emit_event(
+        self,
+        event_type: str,
+        name: str,
+        *,
+        attributes: Mapping[str, Any] | None = None,
+        status: TraceStatus = "event",
+        agent_id: str | None = None,
+        task_id: str | None = None,
+        links: tuple[str, ...] = (),
+    ) -> None:
+        """Emit a standalone trace event under the current span context."""
+        if not self.enabled:
+            return
+        run_id = context.get_current_run_id() or self.run_id
+        span_id = context.get_current_span_id() or _new_id("span")
+        event = TraceEvent(
+            event_id=_new_id("evt"),
+            run_id=run_id,
+            span_id=span_id,
+            parent_span_id=context.get_current_span_id(),
+            timestamp=utc_now(),
+            event_type=event_type,
+            name=name,
+            status=status,
+            attributes=sanitize_attributes(attributes, max_string_length=self.max_string_length),
+            agent_id=agent_id,
+            task_id=task_id,
+            links=links,
+        )
+        await self._export(event)
+
+    async def _export(self, event: TraceEvent) -> None:
+        try:
+            await self.exporter.export(event)
+        except Exception:
+            # Tracing is best-effort by default and must not fail user work.
+            return
+
+
+class Span:
+    """Async context manager representing a traced operation."""
+
+    def __init__(
+        self,
+        *,
+        tracer: Tracer,
+        event_type: str,
+        name: str,
+        attributes: Mapping[str, Any] | None,
+        agent_id: str | None,
+        task_id: str | None,
+        links: tuple[str, ...],
+    ) -> None:
+        self.tracer = tracer
+        self.event_type = event_type
+        self.name = name
+        self.attributes = sanitize_attributes(
+            attributes, max_string_length=tracer.max_string_length
+        )
+        self.agent_id = agent_id
+        self.task_id = task_id
+        self.links = links
+        self.span_id = _new_id("span")
+        self.parent_span_id: str | None = None
+        self.run_id = tracer.run_id
+        self._start = 0.0
+        self._run_token: Any = None
+        self._span_token: Any = None
+
+    async def __aenter__(self) -> Self:
+        self.parent_span_id = context.get_current_span_id()
+        self.run_id = context.get_current_run_id() or self.tracer.run_id
+        self._run_token = context._current_run_id.set(self.run_id)
+        self._span_token = context._current_span_id.set(self.span_id)
+        self._start = perf_counter()
+        await self._emit("started")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        duration_ms = int((perf_counter() - self._start) * 1000)
+        if exc is None:
+            await self._emit("completed", duration_ms=duration_ms)
+        else:
+            await self._emit(
+                "failed",
+                duration_ms=duration_ms,
+                error=TraceError(type=type(exc).__name__, message=str(exc)),
+            )
+        if self._span_token is not None:
+            context._current_span_id.reset(self._span_token)
+        if self._run_token is not None:
+            context._current_run_id.reset(self._run_token)
+        return False
+
+    async def _emit(
+        self,
+        status: TraceStatus,
+        *,
+        duration_ms: int | None = None,
+        error: TraceError | None = None,
+    ) -> None:
+        await self.tracer._export(
+            TraceEvent(
+                event_id=_new_id("evt"),
+                run_id=self.run_id,
+                span_id=self.span_id,
+                parent_span_id=self.parent_span_id,
+                timestamp=utc_now(),
+                event_type=self.event_type,
+                name=self.name,
+                status=status,
+                attributes=self.attributes,
+                agent_id=self.agent_id,
+                task_id=self.task_id,
+                duration_ms=duration_ms,
+                error=error,
+                links=self.links,
+            )
+        )
+
+
+class NoOpSpan:
+    """Span context manager used when tracing is disabled."""
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        return False
+
+
+@asynccontextmanager
+async def span(
+    tracer: Tracer,
+    event_type: str,
+    name: str,
+    **kwargs: Any,
+) -> AsyncIterator[Span | NoOpSpan]:
+    """Convenience async context manager around ``Tracer.span``."""
+    async with tracer.span(event_type, name, **kwargs) as active_span:
+        yield active_span

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ packages = [
     "ouro.core",
     "ouro.core.llm",
     "ouro.core.loop",
+    "ouro.core.tracing",
     "ouro.capabilities",
     "ouro.capabilities.compaction",
     "ouro.capabilities.context",

--- a/test/core/test_tracing.py
+++ b/test/core/test_tracing.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from ouro.core.tracing import (
+    InMemoryTraceExporter,
+    JSONLTraceExporter,
+    TraceEventType,
+    Tracer,
+    get_current_span_id,
+    sanitize_attributes,
+)
+
+
+async def test_nested_spans_preserve_parent_child_relationships() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter, run_id="run-test")
+
+    async with tracer.span(TraceEventType.RUN, "run") as parent:
+        assert get_current_span_id() == parent.span_id
+        async with tracer.span(TraceEventType.TOOL_CALL, "tool") as child:
+            assert get_current_span_id() == child.span_id
+
+    assert [event.status for event in exporter.events] == [
+        "started",
+        "started",
+        "completed",
+        "completed",
+    ]
+    parent_started, child_started, child_completed, parent_completed = exporter.events
+    assert parent_started.run_id == "run-test"
+    assert parent_started.parent_span_id is None
+    assert child_started.parent_span_id == parent.span_id
+    assert child_completed.parent_span_id == parent.span_id
+    assert parent_completed.duration_ms is not None
+
+
+async def test_failed_span_records_bounded_error_and_reraises() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter)
+
+    with pytest.raises(ValueError, match="bad input"):
+        async with tracer.span(TraceEventType.LLM_CALL, "llm"):
+            raise ValueError("bad input")
+
+    failed = exporter.events[-1]
+    assert failed.status == "failed"
+    assert failed.error is not None
+    assert failed.error.type == "ValueError"
+    assert failed.error.message == "bad input"
+    assert failed.duration_ms is not None
+
+
+async def test_disabled_tracer_does_not_export_events() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter, enabled=False)
+
+    async with tracer.span(TraceEventType.RUN, "run"):
+        await tracer.emit_event(TraceEventType.LOG, "ignored")
+
+    assert exporter.events == []
+
+
+async def test_contextvars_isolate_concurrent_child_spans() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter, run_id="run-concurrent")
+
+    async def child(name: str) -> None:
+        async with tracer.span(TraceEventType.TASK, name):
+            await asyncio.sleep(0)
+
+    async with tracer.span(TraceEventType.RUN, "run") as parent:
+        await asyncio.gather(child("a"), child("b"))
+
+    task_started = [
+        event
+        for event in exporter.events
+        if event.event_type == TraceEventType.TASK and event.status == "started"
+    ]
+    assert len(task_started) == 2
+    assert {event.parent_span_id for event in task_started} == {parent.span_id}
+    assert {event.run_id for event in task_started} == {"run-concurrent"}
+
+
+async def test_jsonl_exporter_writes_newline_delimited_json(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    tracer = Tracer(exporter=JSONLTraceExporter(trace_path), run_id="run-jsonl")
+
+    async with tracer.span(TraceEventType.TOOL_CALL, "grep", attributes={"tool.name": "grep"}):
+        pass
+
+    lines = trace_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    payloads = [json.loads(line) for line in lines]
+    assert payloads[0]["status"] == "started"
+    assert payloads[1]["status"] == "completed"
+    assert payloads[0]["run_id"] == "run-jsonl"
+    assert payloads[0]["attributes"] == {"tool.name": "grep"}
+
+
+def test_sanitize_attributes_redacts_and_truncates() -> None:
+    sanitized = sanitize_attributes(
+        {
+            "api_key": "secret-value",
+            "nested": {"Authorization": "Bearer abc", "safe": "ok"},
+            "long": "x" * 8,
+        },
+        max_string_length=4,
+    )
+
+    assert sanitized["api_key"] == "[redacted]"
+    assert sanitized["nested"]["Authorization"] == "[redacted]"
+    assert sanitized["nested"]["safe"] == "ok"
+    assert sanitized["long"] == "xxxx…[truncated]"
+
+
+async def test_exporter_failures_do_not_fail_user_work() -> None:
+    class FailingExporter:
+        async def export(self, event):  # type: ignore[no-untyped-def]
+            raise RuntimeError("export failed")
+
+    tracer = Tracer(exporter=FailingExporter())
+
+    async with tracer.span(TraceEventType.RUN, "run"):
+        pass


### PR DESCRIPTION
## Summary

Adds the first implementation slice from the Agent Tracing Monitor RFC: core tracing primitives, context propagation, exporters, and tests.

## Scope

- Goals:
  - Add `ouro.core.tracing` with trace events, spans, contextvars, and exporter protocol.
  - Include no-op, in-memory, and JSONL exporters.
  - Add safe default attribute redaction/truncation and exporter failure isolation.
- Non-goals:
  - No CLI flags or monitor UI yet.
  - No runtime instrumentation of agent/tool/LLM/swarm paths yet.
  - No OpenTelemetry exporter yet.

## Invariants (Must Not Regress)

- [x] Existing runs remain unchanged; no code paths use tracing yet.
- [x] Core layer does not import capabilities or interfaces.
- [x] Tracing exporter failures are best-effort and do not fail user work.
- [x] Disabled tracing is no-op.
- [x] No secrets or generated artifacts committed.

## Acceptance Criteria

- [x] `TraceEvent` serializes to JSON-compatible dictionaries.
- [x] Nested spans preserve parent-child relationships.
- [x] Failed spans record bounded error metadata and re-raise.
- [x] Concurrent async tasks preserve trace context via `contextvars`.
- [x] JSONL exporter writes newline-delimited JSON.
- [x] Attribute sanitization redacts secret-looking keys and truncates long strings.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/core/test_tracing.py`
- [x] `./scripts/dev.sh importlint`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh precommit`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] Not run; this PR only adds unused core primitives and does not change CLI/runtime behavior.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Packaging/imports if the new package is not listed; covered by pyproject update and check.
- Worst-case input/output size? Trace attributes are bounded/truncated; JSONL writes one line per event when explicitly used.
- Any secrets/logging risks? Secret-looking attribute keys are redacted and prompt/output capture is not implemented.
- Any async/blocking I/O added on hot paths? No existing hot path uses this yet; JSONL exporter does small local file writes when explicitly used.
- What error message does the user see on failure? Exporter failures are swallowed by default, so user tasks are not failed by tracing.

## Docs / Compatibility

- [x] Implements first slice from `rfc/agent-tracing-monitor.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
