### PR TITLE
[codex] Retry Codex transport failures

### DIFF
--- a/ouro/core/llm/openai_codex_adapter.py
+++ b/ouro/core/llm/openai_codex_adapter.py
@@ -50,7 +50,12 @@ class OpenAICodexAdapter:
         token = await self._ensure_access_token()
         account_id = _extract_account_id(token)
         body = self._build_request_body(messages, tools, max_tokens, **kwargs)
-        events = await self._request_events(token=token, account_id=account_id, body=body)
+        try:
+            events = await self._request_events(token=token, account_id=account_id, body=body)
+        except httpx.RequestError as e:
+            raise RuntimeError(
+                _format_request_error(e, url=_resolve_codex_url(self.api_base))
+            ) from e
         return _convert_response_events(events)
 
     async def _ensure_access_token(self) -> str:
@@ -341,6 +346,15 @@ async def _format_error_response(response: httpx.Response) -> str:
         return f"Codex request failed with HTTP {response.status_code}: {text.decode('utf-8')}"
     message = payload.get("detail") or payload.get("message") or payload.get("error") or payload
     return f"Codex request failed with HTTP {response.status_code}: {message}"
+
+
+def _format_request_error(error: httpx.RequestError, *, url: str) -> str:
+    detail = str(error).strip() or type(error).__name__
+    return (
+        f"Unable to connect to the ChatGPT Codex endpoint ({url}): {detail}. "
+        "Check your network connection and proxy/VPN settings. If you use a proxy, "
+        "verify HTTP_PROXY, HTTPS_PROXY, or ALL_PROXY can reach chatgpt.com."
+    )
 
 
 def _convert_response_events(events: list[dict[str, Any]]) -> LLMResponse:

--- a/ouro/core/llm/retry.py
+++ b/ouro/core/llm/retry.py
@@ -3,6 +3,7 @@
 import asyncio
 from typing import Callable, TypeVar
 
+import httpx
 from tenacity import retry, retry_if_exception, stop_after_attempt
 from tenacity.wait import wait_base
 
@@ -30,6 +31,13 @@ def is_retryable_error(error: BaseException) -> bool:
     """Check if an error is retryable."""
     if isinstance(error, asyncio.CancelledError):
         return False
+
+    if isinstance(error, httpx.TimeoutException | httpx.NetworkError | httpx.RemoteProtocolError):
+        return True
+
+    if isinstance(error, httpx.HTTPStatusError):
+        status_code = error.response.status_code
+        return status_code in {408, 409, 425, 429, 500, 502, 503, 504}
 
     if is_rate_limit_error(error):
         return True

--- a/test/test_llm_retry.py
+++ b/test/test_llm_retry.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import httpx
+
 from ouro.core.llm.retry import is_retryable_error
 
 
@@ -19,3 +21,31 @@ def test_remote_protocol_disconnect_error_is_retryable() -> None:
 
 def test_cancelled_error_is_not_retryable() -> None:
     assert not is_retryable_error(asyncio.CancelledError())
+
+
+def test_httpx_connect_error_is_retryable_even_without_message() -> None:
+    assert is_retryable_error(httpx.ConnectError(""))
+
+
+def test_retryable_http_statuses_are_retryable() -> None:
+    for status_code in (408, 409, 425, 429, 500, 502, 503, 504):
+        response = httpx.Response(
+            status_code, request=httpx.Request("POST", "https://example.test")
+        )
+        assert is_retryable_error(
+            httpx.HTTPStatusError("failed", request=response.request, response=response)
+        )
+
+
+def test_non_retryable_http_statuses_are_not_retryable() -> None:
+    for status_code in (400, 401, 403, 404, 422):
+        response = httpx.Response(
+            status_code, request=httpx.Request("POST", "https://example.test")
+        )
+        assert not is_retryable_error(
+            httpx.HTTPStatusError("failed", request=response.request, response=response)
+        )
+
+
+def test_unknown_exception_is_not_retryable_by_default() -> None:
+    assert not is_retryable_error(ValueError("bad request body"))

--- a/test/test_openai_codex_adapter.py
+++ b/test/test_openai_codex_adapter.py
@@ -1,6 +1,9 @@
 import base64
 import json
 
+import httpx
+import pytest
+
 from ouro.core.llm.message_types import LLMMessage, StopReason
 from ouro.core.llm.model_manager import ModelManager, ModelProfile
 from ouro.core.llm.openai_codex_adapter import (
@@ -178,3 +181,26 @@ def test_openai_codex_model_does_not_require_api_key(tmp_path) -> None:
 
     assert valid is True
     assert message == ""
+
+
+async def test_call_async_formats_codex_request_errors(monkeypatch) -> None:
+    adapter = OpenAICodexAdapter("openai-codex/gpt-5.5")
+    token = _jwt({"https://api.openai.com/auth": {"chatgpt_account_id": "acct_123"}})
+
+    async def fake_access_token() -> str:
+        return token
+
+    async def fake_request_events(**_kwargs):
+        raise httpx.ConnectError("")
+
+    monkeypatch.setattr(adapter, "_ensure_access_token", fake_access_token)
+    monkeypatch.setattr(adapter, "_request_events", fake_request_events)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await adapter.call_async([LLMMessage(role="user", content="hello")])
+
+    message = str(exc_info.value)
+    assert "Unable to connect to the ChatGPT Codex endpoint" in message
+    assert "https://chatgpt.com/backend-api/codex/responses" in message
+    assert "proxy/VPN" in message
+    assert isinstance(exc_info.value.__cause__, httpx.ConnectError)


### PR DESCRIPTION
Retry structured httpx transport failures for Codex requests and show actionable proxy/network guidance after retries are exhausted.\n\nValidation:\n- ./scripts/dev.sh test -q test/test_llm_retry.py test/test_openai_codex_adapter.py\n- ./scripts/dev.sh check