### PR TITLE
Colorize TUI status bar metrics

### DIFF
--- a/ouro/interfaces/tui/status_bar.py
+++ b/ouro/interfaces/tui/status_bar.py
@@ -84,7 +84,9 @@ class StatusBar:
         total_in = self._format_tokens(self.state.input_tokens)
         total_out = self._format_tokens(self.state.output_tokens)
         items.append(
-            f"[{colors.text_secondary}]Total:[/{colors.text_secondary}] {total_in}↑ {total_out}↓"
+            f"[{colors.text_secondary}]Total:[/{colors.text_secondary}] "
+            f"[{colors.success}]{total_in}↑[/{colors.success}] "
+            f"[{colors.warning}]{total_out}↓[/{colors.warning}]"
         )
 
         # Cache info
@@ -99,11 +101,15 @@ class StatusBar:
 
         # Context Tokens
         ctx_tokens = self._format_tokens(self.state.context_tokens)
-        items.append(f"[{colors.text_secondary}]Context:[/{colors.text_secondary}] {ctx_tokens}")
+        items.append(
+            f"[{colors.text_secondary}]Context:[/{colors.text_secondary}] "
+            f"[{colors.primary}]{ctx_tokens}[/{colors.primary}]"
+        )
 
         # Cost
         items.append(
-            f"[{colors.text_secondary}]Cost:[/{colors.text_secondary}] ${self.state.cost:.4f}"
+            f"[{colors.text_secondary}]Cost:[/{colors.text_secondary}] "
+            f"[{colors.primary}]${self.state.cost:.4f}[/{colors.primary}]"
         )
 
         # Compression count


### PR DESCRIPTION
## Summary

Colorizes the TUI status bar metric values so Total, Context, and Cost match the existing colored Cache display.

## Scope

- Goals:
  - Colorize Total input/output token values.
  - Colorize Context and Cost values.
- Non-goals:
  - No changes to token accounting or cost calculation.
  - No changes to status bar layout or labels.

## Invariants (Must Not Regress)

- [x] Existing status bar labels remain unchanged.
- [x] Cache read/write colors remain unchanged.
- [x] Token formatting remains unchanged.
- [x] Cost precision remains four decimal places.

## Acceptance Criteria

- [x] Total input token value is colorized.
- [x] Total output token value is colorized.
- [x] Context value is colorized.
- [x] Cost value is colorized.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_loop_usage_callback.py`
- [ ] `./scripts/dev.sh test -q`
- [ ] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] Not run; visual-only TUI rendering change.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Status bar markup rendering if malformed; cache colors; token/cost display formatting.
- Worst-case input/output size? Unchanged; values are still formatted through existing formatter.
- Any secrets/logging risks? None.
- Any async/blocking I/O added on hot paths? None.
- What error message does the user see on failure? N/A; Rich markup rendering should continue normally.

## Docs / Compatibility

- [x] No docs needed for visual-only status bar styling change.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)