### PR TITLE
Prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-21
+
+### Added
+
+- **OpenAI Codex subscription adapter**: added subscription-based Codex support, model catalog updates, and retry handling for transient Codex transport failures (#229, #227, #242).
+- **Agent Tracing Monitor foundation**: added an RFC and first core tracing primitives, including trace events/spans, context propagation, in-memory and JSONL exporters, redaction, truncation, and package registration (#239, #241).
+- **Progress event bus and sinks**: refactored progress reporting into a shared event bus with source metadata, JSON progress output, and clearer CLI/TUI task and swarm rendering (#231, #232, #228).
+
+### Changed
+
+- **Swarm robustness and observability**: redesigned swarm execution around Task V2, improved worker shutdown/coordination, surfaced sub-agent source prefixes, and renamed the swarm config flag (#234, #236, #237, #233, #235).
+- **LLM reliability**: retry transient LLM disconnects and upgrade LiteLLM to `1.87.0` (#238, #226).
+- **GitHub Copilot model catalog**: updated OAuth model discovery/catalog entries (#225).
+- **Documentation**: restructured README Features and Architecture sections (#222).
+
+### Fixed
+
+- **TUI rendering**: escape tool-call markup and colorize status bar metrics for clearer, safer terminal output (#240, #243).
+- **Session persistence**: incrementally persist sessions and print the session ID on interactive exit (#223, #224).
+
 ## [0.5.0] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ouro-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "General AI Agent System"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2452,7 +2452,7 @@ wheels = [
 
 [[package]]
 name = "ouro-ai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Prepare the v0.5.1 release by bumping package metadata and documenting changes since v0.5.0.

## Scope

- Goals: update release version metadata and changelog for v0.5.1.
- Non-goals: no runtime behavior changes beyond release metadata/docs.

## Invariants (Must Not Regress)

- [x] Existing package dependencies and entry points remain unchanged
- [x] Existing three-layer import boundaries remain unchanged
- [x] Existing tests continue to pass

## Acceptance Criteria

- [x] `pyproject.toml` reports version `0.5.1`
- [x] `uv.lock` local package metadata reports version `0.5.1`
- [x] `CHANGELOG.md` includes a dated `0.5.1` entry

## Test Plan

- [x] Targeted tests: release metadata diff reviewed
- [x] `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`

## Smoke Run (Real CLI)

- [ ] Not run; release metadata/changelog-only change

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Package version resolution only; no runtime code changed.
- Worst-case input/output size? N/A; metadata/docs-only.
- Any secrets/logging risks? No secrets touched.
- Any async/blocking I/O added on hot paths? No code paths changed.
- What error message does the user see on failure? N/A for runtime; CI/publish would report packaging errors.

## Docs / Compatibility

- [x] Updated relevant docs (`CHANGELOG.md`)
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`)

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)