### PR TITLE
Add SQLite trace exporter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,16 @@ agent = (
 )
 ```
 
+### Agent Tracing
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `TRACE_STORAGE_DIALECT` | `sqlite` | Trace storage backend. `sqlite` is supported now; MySQL-compatible backends such as MySQL/StarRocks are planned. |
+| `TRACE_DB_PATH` | `~/.ouro/trace.db` | Local SQLite trace database path. Used when `TRACE_STORAGE_DIALECT=sqlite` and no `TRACE_DATABASE_URL` is set. |
+| `TRACE_DATABASE_URL` | `""` | Optional database URL for future remote trace backends. SQLite URLs such as `sqlite:///tmp/ouro-trace.db` can also be resolved to local paths. |
+
+Tracing is opt-in until CLI/runtime wiring lands. Core tracing exporters do not read config directly; CLI/capability layers should resolve these settings and inject the selected exporter.
+
 ### Retry
 
 | Setting | Default | Description |

--- a/ouro/config.py
+++ b/ouro/config.py
@@ -34,6 +34,12 @@ MAX_ITERATIONS=1000
 # enabled, discovery failures fail login model sync instead of using stale data.
 # OAUTH_MODEL_DYNAMIC_REFRESH=true
 # OAUTH_MODEL_REFRESH_TIMEOUT_SECONDS=10
+
+# Agent tracing monitor. SQLite is the default local durable store; future
+# storage dialects can use TRACE_DATABASE_URL for MySQL-compatible backends.
+# TRACE_STORAGE_DIALECT=sqlite
+# TRACE_DB_PATH=~/.ouro/trace.db
+# TRACE_DATABASE_URL=
 """
 
 
@@ -108,6 +114,11 @@ class Config:
     # When enabled, replaces TodoTool and MultiTaskTool with task_create,
     # task_claim, task_update, task_list, task_get, task_delete tools.
     ENABLE_AGENT_SWARM = _cfg.get("ENABLE_AGENT_SWARM", "false").lower() == "true"
+
+    # Agent Tracing Monitor
+    TRACE_STORAGE_DIALECT = _cfg.get("TRACE_STORAGE_DIALECT", "sqlite").lower()
+    TRACE_DB_PATH = _cfg.get("TRACE_DB_PATH", "~/.ouro/trace.db")
+    TRACE_DATABASE_URL = _cfg.get("TRACE_DATABASE_URL", "")
 
     # Retry Configuration
     RETRY_MAX_ATTEMPTS = int(_cfg.get("RETRY_MAX_ATTEMPTS", "3"))

--- a/ouro/core/tracing/__init__.py
+++ b/ouro/core/tracing/__init__.py
@@ -6,7 +6,10 @@ from .exporters import (
     InMemoryTraceExporter,
     JSONLTraceExporter,
     NoOpTraceExporter,
+    SQLiteTraceExporter,
     TraceExporter,
+    default_trace_db_path,
+    resolve_sqlite_trace_db_path,
 )
 from .tracer import NoOpSpan, Span, Tracer, sanitize_attributes, span
 
@@ -15,6 +18,7 @@ __all__ = [
     "JSONLTraceExporter",
     "NoOpSpan",
     "NoOpTraceExporter",
+    "SQLiteTraceExporter",
     "Span",
     "TraceError",
     "TraceEvent",
@@ -22,8 +26,10 @@ __all__ = [
     "TraceExporter",
     "TraceStatus",
     "Tracer",
+    "default_trace_db_path",
     "get_current_run_id",
     "get_current_span_id",
+    "resolve_sqlite_trace_db_path",
     "sanitize_attributes",
     "span",
 ]

--- a/ouro/core/tracing/exporters.py
+++ b/ouro/core/tracing/exporters.py
@@ -1,13 +1,41 @@
-"""Trace exporters for local testing and JSONL persistence."""
+"""Trace exporters for local testing, database persistence, and JSONL export."""
 
 from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 from typing import Protocol
+from urllib.parse import unquote, urlparse
 
 from .events import TraceEvent
+
+_TRACE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS trace_events (
+    event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    parent_span_id TEXT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    duration_ms INTEGER,
+    agent_id TEXT,
+    task_id TEXT,
+    attributes_json TEXT NOT NULL DEFAULT '{}',
+    error_json TEXT,
+    links_json TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_events_run_id ON trace_events(run_id);
+CREATE INDEX IF NOT EXISTS idx_trace_events_span_id ON trace_events(span_id);
+CREATE INDEX IF NOT EXISTS idx_trace_events_parent_span_id ON trace_events(parent_span_id);
+CREATE INDEX IF NOT EXISTS idx_trace_events_timestamp ON trace_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_trace_events_type_status ON trace_events(event_type, status);
+CREATE INDEX IF NOT EXISTS idx_trace_events_agent_task ON trace_events(agent_id, task_id);
+"""
 
 
 class TraceExporter(Protocol):
@@ -33,13 +61,58 @@ class InMemoryTraceExporter:
         self.events.append(event)
 
 
+class SQLiteTraceExporter:
+    """Persist trace events to a local SQLite database.
+
+    This is the default durable trace store target for local ouro runs. Writes
+    are serialized with an async lock and executed in a worker thread to avoid
+    blocking the event loop with filesystem I/O.
+    """
+
+    def __init__(self, path: str | Path | None = None, *, database_url: str | None = None) -> None:
+        self.path = resolve_sqlite_trace_db_path(db_path=path, database_url=database_url)
+        self._lock = asyncio.Lock()
+        self._initialized = False
+
+    async def export(self, event: TraceEvent) -> None:
+        async with self._lock:
+            await asyncio.to_thread(self._export_sync, event)
+
+    def _export_sync(self, event: TraceEvent) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.path) as connection:
+            if not self._initialized:
+                connection.executescript(_TRACE_SCHEMA)
+                self._initialized = True
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO trace_events (
+                    event_id,
+                    run_id,
+                    span_id,
+                    parent_span_id,
+                    timestamp,
+                    event_type,
+                    name,
+                    status,
+                    duration_ms,
+                    agent_id,
+                    task_id,
+                    attributes_json,
+                    error_json,
+                    links_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                trace_event_row(event),
+            )
+            connection.commit()
+
+
 class JSONLTraceExporter:
     """Append trace events to a newline-delimited JSON file.
 
-    File writes are protected by an async lock so concurrent spans do not
-    interleave writes. The implementation performs small synchronous writes;
-    it is intended for local/debug export and should be wrapped/buffered before
-    use on high-volume hot paths.
+    JSONL is intended for local debugging, interchange, and monitor replay.
+    Durable analysis should prefer the database exporter.
     """
 
     def __init__(self, path: str | Path) -> None:
@@ -53,3 +126,58 @@ class JSONLTraceExporter:
             with self.path.open("a", encoding="utf-8") as handle:
                 handle.write(line)
                 handle.write("\n")
+
+
+def default_trace_db_path() -> Path:
+    """Return the default local trace database path."""
+    return Path.home() / ".ouro" / "trace.db"
+
+
+def resolve_sqlite_trace_db_path(
+    *, db_path: str | Path | None = None, database_url: str | None = None
+) -> Path:
+    """Resolve configured SQLite trace storage into a local database path.
+
+    Higher layers own configuration loading and should pass `TRACE_DB_PATH` as
+    ``db_path`` or a SQLite ``TRACE_DATABASE_URL`` as ``database_url``. Core
+    tracing intentionally does not import ``ouro.config``.
+    """
+    if database_url:
+        parsed = urlparse(database_url)
+        if parsed.scheme != "sqlite":
+            raise ValueError(f"Unsupported SQLite trace database URL scheme: {parsed.scheme}")
+        if parsed.netloc and parsed.netloc != "localhost":
+            raise ValueError("SQLite trace database URLs must be local paths")
+        if parsed.path in {"", "/"}:
+            raise ValueError("SQLite trace database URL must include a database path")
+        return Path(unquote(parsed.path)).expanduser()
+
+    if db_path is not None:
+        return Path(db_path).expanduser()
+
+    return default_trace_db_path()
+
+
+def trace_event_row(event: TraceEvent) -> tuple[object, ...]:
+    """Return the SQLite row representation for a trace event."""
+    timestamp = event.timestamp.astimezone().isoformat()
+    return (
+        event.event_id,
+        event.run_id,
+        event.span_id,
+        event.parent_span_id,
+        timestamp,
+        event.event_type,
+        event.name,
+        event.status,
+        event.duration_ms,
+        event.agent_id,
+        event.task_id,
+        json.dumps(event.attributes, ensure_ascii=False, sort_keys=True),
+        (
+            json.dumps(event.error.to_dict(), ensure_ascii=False, sort_keys=True)
+            if event.error is not None
+            else None
+        ),
+        json.dumps(list(event.links), ensure_ascii=False, sort_keys=True),
+    )

--- a/rfc/agent-tracing-monitor.md
+++ b/rfc/agent-tracing-monitor.md
@@ -27,7 +27,7 @@ Without a first-class trace model, every monitor UI would need to reconstruct ex
 
 - Provide a shared trace event/span model for agent execution.
 - Preserve parent-child relationships across runs, agents, tasks, tool calls, LLM calls, memory operations, and swarm workers.
-- Support realtime event streaming and durable JSONL export in the first implementation slice.
+- Support realtime event streaming and durable database-backed trace storage in the first implementation slice.
 - Make tracing opt-in or explicitly configurable, with minimal overhead when disabled.
 - Keep tracing safe by default: redact secrets, avoid storing full prompts/tool outputs unless explicitly configured, and bound payload sizes.
 - Support concurrent tasks and agent swarm execution without losing context propagation.
@@ -51,21 +51,28 @@ Tracing can be enabled for a run and observed in realtime or saved for later ins
 - CLI / UX changes:
   - Add an opt-in trace mode, for example:
     - `python main.py --task "..." --trace`
-    - `python main.py --task "..." --trace-file .ouro/traces/<run_id>.jsonl`
+    - `python main.py --task "..." --trace-db ~/.ouro/trace.db`
+    - `python main.py --task "..." --trace-file .ouro/traces/<run_id>.jsonl` for debug/export workflows.
   - Add follow-up monitor commands in a later slice, for example:
+    - `ouro trace list` to list recent runs from the trace database.
     - `ouro trace watch <run_id>` to stream active spans/events.
-    - `ouro trace view <trace.jsonl>` to inspect a saved trace.
+    - `ouro trace view <run_id>` to inspect a saved trace tree/timeline from the database.
+    - `ouro trace export <run_id> --format jsonl` to produce a portable JSONL artifact.
     - `ouro trace serve` to start a local monitor UI.
 - Config changes:
   - Add optional tracing configuration only after the core event model lands, for example:
     - `tracing.enabled`
-    - `tracing.exporters`
+    - `TRACE_STORAGE_DIALECT` defaulting to `sqlite`
+    - `TRACE_DB_PATH` defaulting to `~/.ouro/trace.db` for local SQLite
+    - `TRACE_DATABASE_URL` for future MySQL-compatible backends such as MySQL and StarRocks
+    - `tracing.exporters` for optional JSONL/debug/OpenTelemetry export
     - `tracing.max_payload_bytes`
     - `tracing.capture_prompts` / `tracing.capture_tool_outputs` defaulting to false.
+  - `ouro.config.Config` owns these settings and higher layers inject the resolved path/URL into core exporters. `ouro.core.tracing` must not import config directly. Future storage dialects can use the same relational schema through MySQL-compatible targets, including MySQL and StarRocks.
 - Output / logging changes:
   - Normal runs remain unchanged when tracing is disabled.
   - When tracing is enabled, ouro emits structured trace events such as `run.started`, `task.completed`, `tool.failed`, and `llm.completed`.
-  - Saved traces are newline-delimited JSON for easy inspection and test assertions.
+  - Saved traces are written to the configured relational trace store by default; JSONL remains available as a debug/export format.
 
 Example saved event shape:
 
@@ -124,9 +131,11 @@ async with tracer.span("tool_call", name="grep_content", attributes={"tool.name"
    - Initial exporters:
      - no-op exporter for disabled tracing.
      - in-memory exporter for tests.
-     - JSONL file exporter for local debugging and later monitor replay.
+     - SQLite database exporter for the default durable store at `~/.ouro/trace.db`.
+     - JSONL file exporter for local debugging, interchange, and monitor replay.
      - stdout/debug exporter only for development.
    - Exporters should be async-compatible and failure-isolated.
+   - Future database exporters should share the same relational schema for MySQL-compatible targets such as MySQL and StarRocks.
 
 4. Instrumentation points
    - Initial slice should instrument high-value boundaries only:
@@ -151,12 +160,50 @@ ouro/core/tracing/
 
 Capabilities and interfaces import those core primitives to instrument their own execution paths. This keeps monitor data production separate from monitor display.
 
-### Realtime Monitoring Path
+### Database Storage Path
 
-The first implementation should write JSONL as events arrive. A later CLI monitor can follow that file or subscribe to an in-process stream:
+The default durable trace store should be a relational database. The local zero-config default is configured through `TRACE_DB_PATH` in `~/.ouro/config` and resolves to SQLite at:
 
 ```text
-runtime spans -> TraceExporter -> JSONL / event bus -> trace watch/view/serve
+~/.ouro/trace.db
+```
+
+The first schema can be intentionally small:
+
+```sql
+CREATE TABLE trace_events (
+    event_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    span_id TEXT NOT NULL,
+    parent_span_id TEXT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    duration_ms INTEGER,
+    agent_id TEXT,
+    task_id TEXT,
+    attributes_json TEXT NOT NULL DEFAULT '{}',
+    error_json TEXT,
+    links_json TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX idx_trace_events_run_id ON trace_events(run_id);
+CREATE INDEX idx_trace_events_span_id ON trace_events(span_id);
+CREATE INDEX idx_trace_events_parent_span_id ON trace_events(parent_span_id);
+CREATE INDEX idx_trace_events_timestamp ON trace_events(timestamp);
+CREATE INDEX idx_trace_events_type_status ON trace_events(event_type, status);
+CREATE INDEX idx_trace_events_agent_task ON trace_events(agent_id, task_id);
+```
+
+A later schema can add a `trace_runs` summary table for faster run listing and aggregate status queries. External backends such as MySQL and StarRocks should use the same logical columns, with backend-specific DDL handled by the exporter/migration layer.
+
+### Realtime Monitoring Path
+
+The first implementation should write events to the configured trace database as they arrive. A later CLI monitor can query the database, follow an in-process stream, or consume an optional JSONL export:
+
+```text
+runtime spans -> TraceExporter -> SQLite trace_events / event bus / JSONL export -> trace list/watch/view/serve
 ```
 
 A web monitor is intentionally a later slice. It can reconstruct a tree/timeline from `run_id`, `span_id`, and `parent_span_id` without changing the event schema.
@@ -190,7 +237,8 @@ Trace attributes are metadata, not arbitrary dumps. Defaults should:
   - exception handling marks spans failed and records bounded error data.
   - disabled/no-op tracer has near-zero behavior impact and does not call exporters.
   - `contextvars` preserve span context across concurrent async tasks.
-  - JSONL exporter writes valid newline-delimited JSON and survives exporter errors according to policy.
+  - database exporter initializes schema, writes queryable trace rows, and survives exporter errors according to policy.
+  - JSONL exporter writes valid newline-delimited JSON for debug/export workflows.
   - redaction/truncation removes known secret keys and bounds payload sizes.
 - Targeted tests to run locally:
   - `./scripts/dev.sh test -q test/core/` after core tracing lands.
@@ -198,8 +246,8 @@ Trace attributes are metadata, not arbitrary dumps. Defaults should:
   - `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`.
   - `./scripts/dev.sh importlint`.
 - Smoke run (one real CLI run):
-  - `python main.py --task "explain what ouro is" --trace --trace-file /tmp/ouro-trace.jsonl`
-  - Verify the JSONL file contains a run span plus LLM/tool/task spans when applicable.
+  - `python main.py --task "explain what ouro is" --trace --trace-db ~/.ouro/trace.db`
+  - Verify the trace database contains a run span plus LLM/tool/task spans when applicable.
 
 ## Rollout / Migration
 
@@ -209,11 +257,12 @@ Trace attributes are metadata, not arbitrary dumps. Defaults should:
   - Existing progress/log behavior remains unchanged.
 - Incremental rollout:
   1. Add core tracing primitives, no-op tracer, in-memory exporter, JSONL exporter, and tests.
-  2. Wire opt-in CLI/config plumbing for trace file output.
-  3. Instrument run, tool, and LLM boundaries.
-  4. Instrument Task V2 and swarm execution boundaries.
-  5. Add `trace view/watch` CLI or TUI inspection.
-  6. Add optional OpenTelemetry exporter and local web monitor if demand justifies it.
+  2. Add database trace exporter and make SQLite `~/.ouro/trace.db` the default durable store.
+  3. Wire opt-in CLI/config plumbing for trace database output.
+  4. Instrument run, tool, and LLM boundaries.
+  5. Instrument Task V2 and swarm execution boundaries.
+  6. Add `trace list/view/watch` CLI or TUI inspection.
+  7. Add optional MySQL/StarRocks/OpenTelemetry exporters and local web monitor if demand justifies it.
 - Rollback:
   - Disable tracing via config/flag to return to current behavior.
   - Remove instrumentation calls independently because they should target no-op-safe APIs.
@@ -238,6 +287,6 @@ Trace attributes are metadata, not arbitrary dumps. Defaults should:
 - Should tracing be disabled by default, enabled by a CLI flag, or enabled for debug/development profiles?
 - What event names should be considered stable public schema in the first accepted version?
 - Should prompt/tool-output capture ever be allowed, or should ouro only support metadata-level traces?
-- How should trace files be retained and cleaned up under `~/.ouro/traces/`?
-- Should the first realtime monitor follow JSONL files, subscribe to an in-process event bus, or support both?
-- What is the right compatibility layer for OpenTelemetry: direct span mapping, JSONL conversion, or an exporter plugin?
+- How should trace rows be retained, compacted, and cleaned up under `~/.ouro/trace.db`?
+- Should the first realtime monitor query SQLite, subscribe to an in-process event bus, consume JSONL export, or support multiple modes?
+- What is the right compatibility layer for OpenTelemetry: direct span mapping, database conversion, JSONL conversion, or an exporter plugin?

--- a/test/core/test_tracing.py
+++ b/test/core/test_tracing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -9,9 +10,11 @@ import pytest
 from ouro.core.tracing import (
     InMemoryTraceExporter,
     JSONLTraceExporter,
+    SQLiteTraceExporter,
     TraceEventType,
     Tracer,
     get_current_span_id,
+    resolve_sqlite_trace_db_path,
     sanitize_attributes,
 )
 
@@ -100,6 +103,61 @@ async def test_jsonl_exporter_writes_newline_delimited_json(tmp_path: Path) -> N
     assert payloads[1]["status"] == "completed"
     assert payloads[0]["run_id"] == "run-jsonl"
     assert payloads[0]["attributes"] == {"tool.name": "grep"}
+
+
+def test_resolve_sqlite_trace_db_path_prefers_configured_path(tmp_path: Path) -> None:
+    configured = tmp_path / "configured.db"
+
+    assert resolve_sqlite_trace_db_path(db_path=configured) == configured
+
+
+def test_resolve_sqlite_trace_db_path_supports_sqlite_urls(tmp_path: Path) -> None:
+    configured = tmp_path / "from-url.db"
+
+    assert resolve_sqlite_trace_db_path(database_url="sqlite://" + str(configured)) == configured
+
+
+def test_resolve_sqlite_trace_db_path_rejects_remote_urls() -> None:
+    with pytest.raises(ValueError, match="Unsupported SQLite trace database URL scheme"):
+        resolve_sqlite_trace_db_path(database_url="mysql://localhost/ouro_trace")
+
+
+async def test_sqlite_exporter_writes_queryable_trace_events(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.db"
+    tracer = Tracer(exporter=SQLiteTraceExporter(trace_path), run_id="run-sqlite")
+
+    async with tracer.span(
+        TraceEventType.TOOL_CALL,
+        "grep",
+        attributes={"tool.name": "grep", "api_key": "secret"},
+        agent_id="agent-1",
+        task_id="task-1",
+    ):
+        pass
+
+    with sqlite3.connect(trace_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT run_id, event_type, name, status, agent_id, task_id,
+                   attributes_json, duration_ms
+            FROM trace_events
+            ORDER BY rowid
+            """
+        ).fetchall()
+
+    assert len(rows) == 2
+    started, completed = rows
+    assert started[:6] == (
+        "run-sqlite",
+        TraceEventType.TOOL_CALL,
+        "grep",
+        "started",
+        "agent-1",
+        "task-1",
+    )
+    assert json.loads(started[6]) == {"api_key": "[redacted]", "tool.name": "grep"}
+    assert completed[3] == "completed"
+    assert completed[7] is not None
 
 
 def test_sanitize_attributes_redacts_and_truncates() -> None:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -13,6 +13,14 @@ async def test_imports():
     from ouro.core import Agent, Hook, ToolRegistry  # noqa: F401
 
 
+async def test_trace_config_defaults_are_available():
+    from ouro.config import Config
+
+    assert Config.TRACE_STORAGE_DIALECT == "sqlite"
+    assert Config.TRACE_DB_PATH == "~/.ouro/trace.db"
+    assert Config.TRACE_DATABASE_URL == ""
+
+
 async def test_tools_execute_and_cleanup(tmp_path):
     from ouro.capabilities.tools.builtins.file_ops import FileReadTool, FileWriteTool
 


### PR DESCRIPTION
## Summary

Adds SQLite-backed trace persistence, exposes trace storage settings in config, and updates the Agent Tracing Monitor RFC to make configurable relational database storage the default durable trace store.

## Scope

- Goals:
  - Add `SQLiteTraceExporter` for queryable trace storage in SQLite.
  - Default local durable trace DB path to `~/.ouro/trace.db`.
  - Expose `TRACE_STORAGE_DIALECT`, `TRACE_DB_PATH`, and `TRACE_DATABASE_URL` config values.
  - Keep `ouro.core.tracing` config-free by resolving paths/URLs from injected values.
  - Keep JSONL as a debug/export/interchange format.
  - Update docs/RFC for relational trace storage and future MySQL/StarRocks-compatible backends.
- Non-goals:
  - No CLI runtime flag wiring in this PR.
  - No MySQL or StarRocks implementation yet.
  - No runtime instrumentation of agent/tool/LLM/swarm paths yet.

## Invariants (Must Not Regress)

- [x] Existing runs remain unchanged; no runtime path uses tracing yet.
- [x] Existing JSONL exporter remains available.
- [x] Core layer does not import config, capabilities, or interfaces.
- [x] Exporter failures remain isolated by `Tracer` best-effort behavior.
- [x] No secrets or generated artifacts committed.

## Acceptance Criteria

- [x] SQLite exporter creates the trace schema automatically.
- [x] SQLite exporter writes queryable `trace_events` rows.
- [x] Trace attributes remain JSON encoded and redacted before persistence.
- [x] Config exposes trace storage settings for future CLI/capabilities wiring.
- [x] RFC/docs document SQLite `~/.ouro/trace.db` as the default durable store.
- [x] RFC/docs document JSONL as debug/export and mention future MySQL/StarRocks-compatible storage.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/core/test_tracing.py test/test_basic.py`
- [x] `./scripts/dev.sh precommit`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh importlint`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] Not run; this PR adds unused exporter/config primitives and docs only, with no CLI/runtime behavior changes.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Config/import/export surface only; covered by tests and full check.
- Worst-case input/output size? One SQLite row per trace event; attributes/errors/links stored as JSON text after existing sanitization.
- Any secrets/logging risks? Attributes are sanitized before events reach exporters; RFC reinforces metadata-only defaults.
- Any async/blocking I/O added on hot paths? No current hot path uses it; exporter uses `asyncio.to_thread` and an async lock for SQLite writes.
- What error message does the user see on failure? None by default; `Tracer` treats exporter failures as best-effort and does not fail user work.

## Docs / Compatibility

- [x] Updated `rfc/agent-tracing-monitor.md` and `docs/configuration.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
