### PR TITLE
Add CLI resume regression test

### DIFF
--- a/test/test_main_auth_cli.py
+++ b/test/test_main_auth_cli.py
@@ -260,6 +260,45 @@ def test_main_does_not_print_session_id_after_task_run(monkeypatch):
     assert "Session ID: 12345678-1234-1234-1234-123456789abc" not in calls["info"]
 
 
+def test_main_resume_with_session_id_loads_session_before_interactive_mode(monkeypatch):
+    calls, _ = _setup_common(monkeypatch, ["--resume", "abcdef12"])
+    state = {"loaded": None, "interactive_started": False}
+    agent = SimpleNamespace(
+        session_id=None,
+        set_reasoning_effort=lambda effort: None,
+        load_session=None,
+    )
+
+    async def fake_resolve_session_id(resume_arg: str):
+        assert resume_arg == "abcdef12"
+        return "abcdef12-3456-7890-abcd-ef1234567890"
+
+    async def fake_load_session(session_id: str):
+        state["loaded"] = session_id
+        agent.session_id = session_id
+
+    async def fake_interactive_mode(passed_agent):
+        assert passed_agent is agent
+        assert state["loaded"] == "abcdef12-3456-7890-abcd-ef1234567890"
+        state["interactive_started"] = True
+        return None
+
+    agent.load_session = fake_load_session
+
+    monkeypatch.setattr(ouro_main.Config, "validate", staticmethod(lambda: None))
+    monkeypatch.setattr(ouro_main, "_resolve_session_id", fake_resolve_session_id)
+    monkeypatch.setattr(ouro_main, "create_agent", lambda model_id=None, **kwargs: agent)
+    monkeypatch.setattr(ouro_main, "run_interactive_mode", fake_interactive_mode)
+
+    ouro_main.main()
+
+    assert calls["info"][0] == "Resuming session: abcdef12-3456-7890-abcd-ef1234567890"
+    assert state == {
+        "loaded": "abcdef12-3456-7890-abcd-ef1234567890",
+        "interactive_started": True,
+    }
+
+
 def test_main_prints_session_id_after_interactive_mode(monkeypatch):
     calls, _ = _setup_common(monkeypatch, [])
     agent = SimpleNamespace(


### PR DESCRIPTION
## Summary

Adds a regression test covering `ouro-cli --resume <session id/prefix>` so the CLI resolves the session, loads it into the agent, and enters interactive mode with the restored session.

## Scope

- Goals: lock in existing CLI resume behavior for explicit session IDs/prefixes.
- Non-goals: no user-facing behavior or session persistence format changes.

## Invariants (Must Not Regress)

- [x] `ouro-cli --resume <prefix>` resolves a saved session before agent startup proceeds.
- [x] Interactive mode receives the same agent after `load_session` completes.
- [x] One-shot `--task` behavior remains unchanged.
- [x] Login/logout CLI flows remain unchanged.

## Acceptance Criteria

- [x] CLI resume path has deterministic unit-test coverage.
- [x] Existing CLI JSON/auth tests continue to pass.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_main_auth_cli.py test/test_cli_json_mode.py`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] `python -m ouro.interfaces.cli.main -h` confirmed `--resume [RESUME], -r [RESUME]` is advertised. No live LLM task needed because this PR is test-only.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Test-only change; no runtime behavior changed.
- Worst-case input/output size? N/A.
- Any secrets/logging risks? No secrets touched.
- Any async/blocking I/O added on hot paths? No runtime I/O added.
- What error message does the user see on failure? Existing `Resume Error` path unchanged.

## Docs / Compatibility

- [x] No docs update needed; behavior already existed and CLI help advertises it.
- [x] No secrets committed; no generated artifacts committed.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)