### PR TITLE
Instrument run, LLM, and tool tracing

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -77,6 +77,7 @@ ouro --resume a1b2c3d4
 | `--logout` | - | Open OAuth provider selector and logout |
 | `--verify` | | Enable self-verification (Ralph Loop) in `--task` mode |
 | `--reasoning-effort LEVEL` | - | Set run-scoped reasoning effort (`default|none|minimal|low|medium|high|xhigh|off`) |
+| `--trace` | - | Enable agent/LLM/tool tracing to the configured SQLite trace DB |
 | `--verbose` | `-v` | Enable verbose logging to `~/.ouro/logs/` |
 
 ## Interactive Commands

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,6 +27,10 @@ ouro --task "Summarize this README" --model openai/gpt-4o
 
 # Set reasoning effort (LiteLLM/OpenAI-style). Use `off` as alias for `none`.
 ouro --task "Solve this logic puzzle" --reasoning-effort high
+
+# Enable tracing to the configured SQLite trace DB (`TRACE_DB_PATH`, default `~/.ouro/trace.db`)
+ouro --task "Summarize this README" --trace
+
 ```
 
 From source (without install):

--- a/ouro/capabilities/builder.py
+++ b/ouro/capabilities/builder.py
@@ -36,6 +36,7 @@ from ouro.core.loop import (
     Rule,
     ScopedProgressSink,
 )
+from ouro.core.tracing import Tracer
 
 from .compaction.hook import CompactionHook
 from .context.agents_md import load_agents_md
@@ -134,6 +135,7 @@ class AgentBuilder:
     verifier: Verifier | None = None
     verification_max_iterations: int = 0  # 0 disables verification
     progress: ProgressSink = field(default_factory=NullProgressSink)
+    tracer: Tracer | None = None
     extra_hooks: list[Hook] = field(default_factory=list)
     dispatcher_factory: Any | None = None
     swarm_max_workers: int = 5
@@ -270,6 +272,10 @@ class AgentBuilder:
 
     def with_progress_sink(self, progress: ProgressSink) -> AgentBuilder:
         self.progress = progress
+        return self
+
+    def with_tracer(self, tracer: Tracer | None) -> AgentBuilder:
+        self.tracer = tracer
         return self
 
     def with_dispatcher_factory(self, factory) -> AgentBuilder:
@@ -414,6 +420,7 @@ class AgentBuilder:
             progress=progress_sink,
             usage_callback=(memory.token_tracker.record_usage if memory is not None else None),
             rules=rules,
+            tracer=self.tracer,
         )
 
         dispatcher_factory = self.dispatcher_factory

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Sequence
 from ouro.core.llm import LLMMessage, LLMResponse, StopReason, ToolCall, ToolOutput, ToolResult
 from ouro.core.llm.reasoning import normalize_reasoning_effort
 from ouro.core.log import get_logger
+from ouro.core.tracing import TraceEventType, Tracer
 
 from .context import MessageListContext, RunStatistic
 from .message_list import MessageList
@@ -46,6 +47,7 @@ class Agent:
         usage_callback: Callable[[dict[str, int]], None] | None = None,
         repeat_tool_call_threshold: int = 3,
         rules: Sequence[Rule] = (),
+        tracer: Tracer | None = None,
     ) -> None:
         self.llm = llm
         self.tools = tools
@@ -53,6 +55,7 @@ class Agent:
         self.max_iterations = max_iterations
         self.max_tokens_per_call = max_tokens_per_call
         self.progress: ProgressSink = progress or NullProgressSink()
+        self.tracer = tracer or Tracer(enabled=False)
         self._reasoning_effort: str | None = None
         self._usage_callback = usage_callback
         # Warn the model after `repeat_tool_call_threshold` consecutive identical
@@ -76,6 +79,26 @@ class Agent:
         self.rules.append(rule)
 
     async def run(
+        self,
+        task: str,
+        *,
+        context: MessageListContext | None = None,
+    ) -> str:
+        async with self.tracer.span(
+            TraceEventType.RUN,
+            "agent.run",
+            attributes={
+                "task.preview": task[:200],
+                "task.length": len(task),
+                "agent.max_iterations": self.max_iterations,
+            },
+        ) as span:
+            result = await self._run_impl(task, context=context)
+            span.set_attributes({"result.length": len(result)})
+            return result
+        raise AssertionError("unreachable: tracer span exited without returning")
+
+    async def _run_impl(
         self,
         task: str,
         *,
@@ -116,7 +139,27 @@ class Agent:
                     call_kwargs["max_tokens"] = self.max_tokens_per_call
                 if os.environ.get("OURO_DEBUG_LLM_HISTORY"):
                     _log_outgoing_messages(ctx.iteration, outgoing)
-                response = await self.llm.call_async(**call_kwargs)
+                async with self.tracer.span(
+                    TraceEventType.LLM_CALL,
+                    "llm.call",
+                    attributes={
+                        "llm.model": getattr(self.llm, "model", "unknown"),
+                        "llm.provider": getattr(self.llm, "provider_name", "unknown"),
+                        "llm.message_count": len(outgoing),
+                        "llm.tool_schema_count": len(tool_schemas),
+                        "agent.iteration": ctx.iteration,
+                    },
+                ) as llm_span:
+                    response = await self.llm.call_async(**call_kwargs)
+                    usage = getattr(response, "usage", None) or {}
+                    llm_span.set_attributes(
+                        {
+                            "llm.stop_reason": response.stop_reason,
+                            "llm.input_tokens": usage.get("input_tokens", 0),
+                            "llm.output_tokens": usage.get("output_tokens", 0),
+                            "llm.total_tokens": usage.get("total_tokens", 0),
+                        }
+                    )
             ctx.stop_reason_last = response.stop_reason
             ctx.add_usage(getattr(response, "usage", None))
 
@@ -375,7 +418,7 @@ class Agent:
                 )
             )
             async with self.progress.spinner(f"Executing {tc.name}...", title="Working"):
-                output = await self.tools.execute_tool_call(tc.name, tc.arguments)
+                output = await self._execute_traced_tool_call(tc)
             self.progress.emit(ProgressEvent(kind="tool_result", payload={"text": output.content}))
             results.append(
                 ToolResult(
@@ -386,6 +429,26 @@ class Agent:
                 )
             )
         return results
+
+    async def _execute_traced_tool_call(self, tool_call: ToolCall) -> ToolOutput:
+        async with self.tracer.span(
+            TraceEventType.TOOL_CALL,
+            tool_call.name,
+            attributes={
+                "tool.name": tool_call.name,
+                "tool.call_id": tool_call.id,
+                "tool.argument_keys": sorted(tool_call.arguments.keys()),
+            },
+        ) as tool_span:
+            output = await self.tools.execute_tool_call(tool_call.name, tool_call.arguments)
+            tool_span.set_attributes(
+                {
+                    "tool.result_length": len(output.content),
+                    "tool.metadata_keys": sorted((output.metadata or {}).keys()),
+                }
+            )
+            return output
+        raise AssertionError("unreachable: tool trace span exited without returning")
 
     async def _exec_parallel(
         self, ctx: RunStatistic, tool_calls: list[ToolCall]
@@ -401,7 +464,7 @@ class Agent:
         outputs: list[ToolOutput | None] = [None] * len(tool_calls)
 
         async def _run(i: int, tc: ToolCall) -> None:
-            outputs[i] = await self.tools.execute_tool_call(tc.name, tc.arguments)
+            outputs[i] = await self._execute_traced_tool_call(tc)
 
         names = ", ".join(tc.name for tc in tool_calls)
         async with self.progress.spinner(

--- a/ouro/core/tracing/tracer.py
+++ b/ouro/core/tracing/tracer.py
@@ -13,7 +13,18 @@ from . import context
 from .events import TraceError, TraceEvent, TraceStatus, utc_now
 from .exporters import NoOpTraceExporter, TraceExporter
 
-_SECRET_MARKERS = ("key", "token", "secret", "password", "authorization", "auth")
+_SECRET_KEYS = {
+    "api_key",
+    "apikey",
+    "authorization",
+    "auth_header",
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "secret",
+    "password",
+}
+_SECRET_SUFFIXES = ("_api_key", "_secret", "_password", "_access_token", "_refresh_token")
 _DEFAULT_MAX_STRING_LENGTH = 2048
 _DEFAULT_MAX_ATTRIBUTES = 64
 
@@ -24,7 +35,7 @@ def _new_id(prefix: str) -> str:
 
 def _is_secret_key(key: str) -> bool:
     lowered = key.lower()
-    return any(marker in lowered for marker in _SECRET_MARKERS)
+    return lowered in _SECRET_KEYS or any(lowered.endswith(suffix) for suffix in _SECRET_SUFFIXES)
 
 
 def _sanitize_value(value: Any, *, max_string_length: int) -> Any:
@@ -173,6 +184,16 @@ class Span:
         self._run_token: Any = None
         self._span_token: Any = None
 
+    def set_attributes(self, attributes: Mapping[str, Any] | None = None, **kwargs: Any) -> None:
+        """Merge additional sanitized attributes into future span events."""
+        merged: dict[str, Any] = {}
+        if attributes:
+            merged.update(attributes)
+        merged.update(kwargs)
+        self.attributes.update(
+            sanitize_attributes(merged, max_string_length=self.tracer.max_string_length)
+        )
+
     async def __aenter__(self) -> Self:
         self.parent_span_id = context.get_current_span_id()
         self.run_id = context.get_current_run_id() or self.tracer.run_id
@@ -232,6 +253,9 @@ class Span:
 
 class NoOpSpan:
     """Span context manager used when tracing is disabled."""
+
+    def set_attributes(self, attributes: Mapping[str, Any] | None = None, **kwargs: Any) -> None:
+        return None
 
     async def __aenter__(self) -> Self:
         return self

--- a/ouro/interfaces/cli/factory.py
+++ b/ouro/interfaces/cli/factory.py
@@ -21,6 +21,7 @@ from ouro.capabilities.tools.builtins.web_fetch import WebFetchTool
 from ouro.capabilities.tools.builtins.web_search import WebSearchTool
 from ouro.config import Config
 from ouro.core.llm import ModelManager, create_llm_adapter
+from ouro.core.tracing import Tracer
 from ouro.interfaces.tui import terminal_ui
 from ouro.interfaces.tui.json_progress import JsonProgressSink
 from ouro.interfaces.tui.tui_progress import TuiProgressSink
@@ -32,6 +33,7 @@ def create_agent(
     memory_dir: str | None = None,
     progress_format: str = "tui",
     progress_stream=None,
+    tracer: Tracer | None = None,
 ) -> ComposedAgent:
     """Factory function to create a fully wired ComposedAgent.
 
@@ -39,6 +41,7 @@ def create_agent(
         model_id: Optional LiteLLM model ID (defaults to current/default).
         sessions_dir: Optional custom sessions directory (bot-mode isolation).
         memory_dir: Optional custom long-term memory directory (bot-mode isolation).
+        tracer: Optional tracer for run/LLM/tool instrumentation.
 
     Returns:
         A ComposedAgent with the standard builtin toolset, memory, and a
@@ -102,6 +105,7 @@ def create_agent(
         .with_llm(llm, model_manager=model_manager)
         .with_max_iterations(Config.MAX_ITERATIONS)
         .with_progress_sink(progress_sink)
+        .with_tracer(tracer)
         .with_progress_identity(
             agent_id="root",
             root_agent_id="root",

--- a/ouro/interfaces/cli/main.py
+++ b/ouro/interfaces/cli/main.py
@@ -23,6 +23,7 @@ from ouro.core.llm.oauth_model_sync import remove_oauth_models, sync_oauth_model
 from ouro.core.llm.reasoning import REASONING_EFFORT_CHOICES
 from ouro.core.log import setup_logger
 from ouro.core.runtime import ensure_runtime_dirs
+from ouro.core.tracing import SQLiteTraceExporter, Tracer, resolve_sqlite_trace_db_path
 from ouro.interfaces.cli.factory import create_agent
 from ouro.interfaces.tui import terminal_ui
 from ouro.interfaces.tui.interactive import run_interactive_mode, run_model_setup_mode
@@ -83,6 +84,22 @@ async def _pick_auth_provider_cli(mode: str) -> str | None:
     return await pick_oauth_provider(providers=providers, title=title, hint=hint)
 
 
+def _create_tracer(*, enabled: bool) -> Tracer | None:
+    """Create an opt-in CLI tracer from config."""
+    if not enabled:
+        return None
+    if Config.TRACE_STORAGE_DIALECT != "sqlite":
+        raise ValueError(
+            "Only TRACE_STORAGE_DIALECT=sqlite is supported for tracing right now. "
+            "MySQL/StarRocks backends are planned but not implemented."
+        )
+    db_path = resolve_sqlite_trace_db_path(
+        db_path=Config.TRACE_DB_PATH,
+        database_url=Config.TRACE_DATABASE_URL or None,
+    )
+    return Tracer(exporter=SQLiteTraceExporter(db_path))
+
+
 def main():
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(description="Run an AI agent with tool-calling capabilities")
@@ -139,6 +156,11 @@ def main():
         choices=REASONING_EFFORT_CHOICES,
         default="default",
         help="Run-scoped reasoning level (LiteLLM/OpenAI-style). Use 'default' to omit the parameter, or 'off' as an alias for 'none'.",
+    )
+    parser.add_argument(
+        "--trace",
+        action="store_true",
+        help="Enable agent tracing and write events to the configured SQLite trace database.",
     )
     parser.add_argument(
         "--json",
@@ -236,6 +258,12 @@ def main():
             terminal_ui.print_error(str(e), title="Resume Error")
             return
 
+    try:
+        tracer = _create_tracer(enabled=args.trace)
+    except ValueError as e:
+        terminal_ui.print_error(str(e), title="Tracing Configuration Error")
+        return
+
     # Create agent with optional model selection. If we're going into interactive mode and
     # models aren't configured yet, enter a setup session first.
     progress_format = "json" if args.json else "tui"
@@ -245,6 +273,7 @@ def main():
             model_id=args.model,
             progress_format=progress_format,
             progress_stream=progress_stream,
+            tracer=tracer,
         )
     except ValueError as e:
         if args.task:
@@ -265,6 +294,7 @@ def main():
             model_id=args.model,
             progress_format=progress_format,
             progress_stream=progress_stream,
+            tracer=tracer,
         )
 
     async def _run() -> None:

--- a/test/core/test_agent_tracing.py
+++ b/test/core/test_agent_tracing.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ouro.core.llm import LLMResponse, StopReason, ToolCall, ToolOutput
+from ouro.core.loop import Agent, NullProgressSink
+from ouro.core.tracing import InMemoryTraceExporter, TraceEventType, Tracer
+
+
+class _ToolRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def get_tool_schemas(self) -> list[dict]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "echo",
+                    "description": "Echo input",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+    def is_tool_readonly(self, name: str) -> bool:
+        return True
+
+    def conflict_keys(self, name: str, arguments: dict) -> set[str]:
+        return set()
+
+    async def execute_tool_call(self, name: str, arguments: dict) -> ToolOutput:
+        self.calls.append((name, arguments))
+        return ToolOutput(content="tool output", metadata={"source": "test"})
+
+
+class _LLM:
+    model = "test/model"
+    provider_name = "test"
+
+    def __init__(self, responses: Sequence[LLMResponse]) -> None:
+        self._responses = list(responses)
+
+    async def call_async(self, **kwargs) -> LLMResponse:  # type: ignore[no-untyped-def]
+        return self._responses.pop(0)
+
+    def extract_text(self, response: LLMResponse) -> str:
+        return response.content or ""
+
+    def extract_tool_calls(self, response: LLMResponse) -> list[ToolCall]:
+        return [
+            ToolCall(
+                id=tc["id"],
+                name=tc["function"]["name"],
+                arguments={"text": "hello"},
+            )
+            for tc in response.tool_calls or []
+        ]
+
+    def extract_thinking(self, response: LLMResponse) -> str | None:
+        return None
+
+
+async def test_agent_traces_run_and_llm_spans() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter, run_id="run-agent")
+    llm = _LLM(
+        [
+            LLMResponse(
+                content="done",
+                stop_reason=StopReason.STOP,
+                usage={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5},
+            )
+        ]
+    )
+    agent = Agent(llm=llm, tools=_ToolRegistry(), progress=NullProgressSink(), tracer=tracer)
+
+    result = await agent.run("say done")
+
+    assert result == "done"
+    completed = {(event.event_type, event.name, event.status): event for event in exporter.events}
+    run = completed[(TraceEventType.RUN, "agent.run", "completed")]
+    llm_event = completed[(TraceEventType.LLM_CALL, "llm.call", "completed")]
+    assert llm_event.parent_span_id == run.span_id
+    assert llm_event.attributes["llm.model"] == "test/model"
+    assert llm_event.attributes["llm.total_tokens"] == 5
+    assert run.attributes["result.length"] == 4
+
+
+async def test_agent_traces_tool_call_spans() -> None:
+    exporter = InMemoryTraceExporter()
+    tracer = Tracer(exporter=exporter, run_id="run-tool")
+    llm = _LLM(
+        [
+            LLMResponse(
+                tool_calls=[
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "echo", "arguments": "{}"},
+                    }
+                ],
+                stop_reason=StopReason.TOOL_CALLS,
+                usage={},
+            ),
+            LLMResponse(content="done", stop_reason=StopReason.STOP, usage={}),
+        ]
+    )
+    agent = Agent(llm=llm, tools=_ToolRegistry(), progress=NullProgressSink(), tracer=tracer)
+
+    result = await agent.run("use tool")
+
+    assert result == "done"
+    tool_events = [
+        event
+        for event in exporter.events
+        if event.event_type == TraceEventType.TOOL_CALL and event.name == "echo"
+    ]
+    assert [event.status for event in tool_events] == ["started", "completed"]
+    completed = tool_events[-1]
+    assert completed.attributes["tool.name"] == "echo"
+    assert completed.attributes["tool.argument_keys"] == ["text"]
+    assert completed.attributes["tool.result_length"] == len("tool output")
+    assert completed.attributes["tool.metadata_keys"] == ["source"]


### PR DESCRIPTION
## Summary

Adds end-to-end trace instrumentation for one-shot/interactive agents: a CLI opt-in flag, tracer injection through `AgentBuilder`, and core spans for agent runs, LLM calls, and tool calls.

## Scope

- Goals:
  - Add `--trace` as the CLI switch for tracing.
  - Build `Tracer(SQLiteTraceExporter)` from config in the interface layer.
  - Use `TRACE_DB_PATH` / `TRACE_DATABASE_URL` from `~/.ouro/config` for trace storage location.
  - Inject tracer via `AgentBuilder` into `core.Agent` without core reading config.
  - Emit `run`, `llm_call`, and `tool_call` spans.
  - Store safe metadata only: model/provider/token counts/tool arg keys/result lengths, not full prompts or tool outputs.
  - Document CLI tracing examples.
- Non-goals:
  - No per-run trace DB CLI override; configure paths in `~/.ouro/config`.
  - No trace query/view CLI yet.
  - No Task V2/swarm-specific tracing yet.
  - No MySQL/StarRocks exporter implementation yet.

## Invariants (Must Not Regress)

- [x] Tracing remains opt-in and disabled by default.
- [x] Core layer does not import config, capabilities, or interfaces.
- [x] Existing logs/progress events continue to work.
- [x] Tool arguments and outputs are not fully persisted by default.
- [x] Exporter failures remain best-effort and do not fail user work.

## Acceptance Criteria

- [x] `ouro --task "..." --trace` creates a tracer using configured SQLite trace storage.
- [x] Trace DB location is controlled by config, not a per-run CLI path flag.
- [x] Agent runs emit `run` spans with duration and bounded task metadata.
- [x] LLM calls emit `llm_call` spans with model/provider/iteration/token metadata.
- [x] Tool calls emit `tool_call` spans with tool name, argument keys, result length, and metadata keys.
- [x] Redaction does not over-redact analysis fields such as token counts or argument key lists.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/core/test_agent_tracing.py test/core/test_tracing.py test/test_basic.py`
- [x] CLI flag check: `python -m ouro.interfaces.cli.entry -h` confirms `--trace` exists and `--trace-db` does not.
- [x] `./scripts/dev.sh precommit`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh importlint`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] Not run; real LLM smoke would incur provider cost. CLI help verification was run instead.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Agent loop call flow; covered by full suite and targeted core loop tests.
- Worst-case input/output size? One span start/end event per run, LLM call, and tool call. Attributes are bounded/sanitized and do not include full prompts/tool outputs.
- Any secrets/logging risks? Redaction still covers API keys/tokens/secrets/passwords; tool args/outputs are summarized only.
- Any async/blocking I/O added on hot paths? Only when tracing is enabled; SQLite exporter writes via `asyncio.to_thread` and an async lock.
- What error message does the user see on failure? Bad trace config reports `Tracing Configuration Error`; exporter failures remain best-effort.

## Docs / Compatibility

- [x] Updated `docs/cli-guide.md` and `docs/examples.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
