### PR TITLE
Quiet noisy retry and stale-file warnings

### DIFF
--- a/ouro/capabilities/rules/read_before_write.py
+++ b/ouro/capabilities/rules/read_before_write.py
@@ -161,11 +161,6 @@ class ReadBeforeWriteRule:
             read_mtime, read_hash = snapshot
             stale_msg = _check_stale(path, read_mtime, read_hash)
             if stale_msg:
-                logger.warning(
-                    "ReadBeforeWriteRule: blocked %s on stale file %r",
-                    tool_call.name,
-                    tool_call.arguments.get("file_path"),
-                )
                 return stale_msg
 
         return None

--- a/ouro/core/llm/retry.py
+++ b/ouro/core/llm/retry.py
@@ -77,18 +77,40 @@ class _ConfigBackoff(wait_base):
         return Config.get_retry_delay(attempt)
 
 
+def _boxed_retry_message(
+    *, error_type: str, error: BaseException, delay: float, attempt: int
+) -> str:
+    """Format retry notices as a compact terminal-friendly box."""
+    lines = [
+        f"{error_type} error: {error}",
+        f"Retrying in {delay:.1f}s... (attempt {attempt}/{Config.RETRY_MAX_ATTEMPTS + 1})",
+    ]
+    width = max(len(line) for line in lines)
+    top = f"┌─ Retry ─{'─' * max(width - 7, 0)}┐"
+    body = [f"│ {line.ljust(width)} │" for line in lines]
+    bottom = f"└{'─' * (width + 2)}┘"
+    return "\n".join([top, *body, bottom])
+
+
 def _log_before_sleep(retry_state) -> None:
     error = retry_state.outcome.exception() if retry_state.outcome else None
     if not error:
         return
+
+    # The first transient failure is common and usually self-heals; keep the CLI
+    # quiet unless a second (or later) retry is needed.
+    if retry_state.attempt_number <= 1:
+        return
+
     error_type = "Rate limit" if is_rate_limit_error(error) else "Retryable"
     delay = _ConfigBackoff()(retry_state)
-    logger.warning(f"{error_type} error: {error}")
     logger.warning(
-        "Retrying in %.1fs... (attempt %s/%s)",
-        delay,
-        retry_state.attempt_number,
-        Config.RETRY_MAX_ATTEMPTS + 1,
+        _boxed_retry_message(
+            error_type=error_type,
+            error=error,
+            delay=delay,
+            attempt=retry_state.attempt_number,
+        )
     )
 
 

--- a/test/test_llm_retry.py
+++ b/test/test_llm_retry.py
@@ -1,12 +1,26 @@
 import asyncio
+import logging
+from types import SimpleNamespace
 
 import httpx
 
-from ouro.core.llm.retry import is_retryable_error
+from ouro.core.llm.retry import _boxed_retry_message, _log_before_sleep, is_retryable_error
 
 
 class CustomError(Exception):
     pass
+
+
+class _Outcome:
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+
+    def exception(self) -> BaseException:
+        return self._error
+
+
+def _retry_state(attempt_number: int, error: BaseException) -> SimpleNamespace:
+    return SimpleNamespace(attempt_number=attempt_number, outcome=_Outcome(error))
 
 
 def test_server_disconnected_error_is_retryable() -> None:
@@ -49,3 +63,38 @@ def test_non_retryable_http_statuses_are_not_retryable() -> None:
 
 def test_unknown_exception_is_not_retryable_by_default() -> None:
     assert not is_retryable_error(ValueError("bad request body"))
+
+
+def test_log_before_sleep_suppresses_first_retry(caplog):
+    with caplog.at_level(logging.WARNING, logger="ouro.core.llm.retry"):
+        _log_before_sleep(_retry_state(1, RuntimeError("Server disconnected")))
+
+    assert caplog.text == ""
+
+
+def test_log_before_sleep_boxes_second_and_later_retries(caplog):
+    error = RuntimeError("Server disconnected without sending a response.")
+
+    with caplog.at_level(logging.WARNING, logger="ouro.core.llm.retry"):
+        _log_before_sleep(_retry_state(2, error))
+
+    assert "┌─ Retry" in caplog.text
+    assert "│ Retryable error: Server disconnected without sending a response." in caplog.text
+    assert "│ Retrying in" in caplog.text
+    assert "(attempt 2/" in caplog.text
+    assert "└" in caplog.text
+
+
+def test_boxed_retry_message_contains_single_boxed_notice():
+    message = _boxed_retry_message(
+        error_type="Retryable",
+        error=RuntimeError("Server disconnected without sending a response."),
+        delay=1.0,
+        attempt=2,
+    )
+
+    lines = message.splitlines()
+    assert lines[0].startswith("┌─ Retry ─")
+    assert lines[1].startswith("│ Retryable error: Server disconnected")
+    assert lines[2].startswith("│ Retrying in 1.0s... (attempt 2/")
+    assert lines[3].startswith("└")

--- a/test/test_smart_edit_stale_detection.py
+++ b/test/test_smart_edit_stale_detection.py
@@ -10,6 +10,7 @@ The rule stores this snapshot and checks it before allowing any
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from ouro.capabilities.rules.read_before_write import (
     ReadBeforeWriteRule,
@@ -115,8 +116,8 @@ class FakeToolCall:
         self.id = "tc-1"
 
 
-def test_rule_blocks_stale_edit(tmp_path):
-    """If the file changed after read, before_toolcall blocks the edit."""
+def test_rule_blocks_stale_edit_without_warning_log(tmp_path, caplog):
+    """If the file changed after read, before_toolcall blocks the edit quietly."""
     rule = ReadBeforeWriteRule()
     ctx = FakeLoopContext()
 
@@ -141,11 +142,13 @@ def test_rule_blocks_stale_edit(tmp_path):
     # Modify file behind the rule's back
     f.write_text("x = 2\n", encoding="utf-8")
 
-    # Now try to smart_edit — should be blocked as stale
+    # Now try to smart_edit — should be blocked as stale, but not logged as a warning.
     edit_tc = FakeToolCall("smart_edit", f)
-    msg = rule.before_toolcall(ctx, edit_tc)
+    with caplog.at_level(logging.WARNING):
+        msg = rule.before_toolcall(ctx, edit_tc)
     assert msg is not None
     assert "modified on disk" in msg
+    assert "blocked smart_edit on stale file" not in caplog.text
 
 
 def test_rule_allows_fresh_edit(tmp_path):


### PR DESCRIPTION
## Summary

Reduces noisy CLI/log output around recoverable guardrails and retries:
- Suppress the `ReadBeforeWriteRule` stale-file warning log while keeping the blocking message returned to the agent.
- Suppress first retry warning for transient LLM failures.
- Render second-and-later retry notices as a boxed warning.

## Scope

- Goals:
  - Avoid printing unnecessary stale-file rule warnings.
  - Keep first transient retry quiet.
  - Make repeated retry notices easier to visually parse.
- Non-goals:
  - Change retry eligibility or retry counts.
  - Change read-before-write blocking semantics.

## Invariants (Must Not Regress)

- [x] Stale file edits are still blocked.
- [x] Unread existing file writes are still blocked.
- [x] Retryable error classification remains unchanged.
- [x] Total retry attempts remain unchanged.

## Acceptance Criteria

- [x] Stale-file rule blocks without logging `ReadBeforeWriteRule: blocked ... stale file`.
- [x] First retry attempt logs nothing.
- [x] Second-and-later retry attempts log boxed retry text.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_llm_retry.py test/test_smart_edit_stale_detection.py test/test_read_before_write_rule.py`
- [x] `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` covered by `./scripts/dev.sh check` strict typecheck path where configured.

## Smoke Run (Real CLI)

- [ ] Not run; behavior is internal retry/log formatting and would require inducing live provider/network retries.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Retry/stale warning visibility; stale blocking and retry behavior are covered by tests.
- Worst-case input/output size? Retry box width scales with exception string, same payload as prior warning.
- Any secrets/logging risks? No new secrets; logs still contain only existing exception text.
- Any async/blocking I/O added on hot paths? No.
- What error message does the user see on failure? Same final retry failure exception; only intermediate retry display changes.

## Docs / Compatibility

- [x] No docs needed for internal logging formatting.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)