### PR TITLE
Add local web trace monitor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ agent = (
 | `TRACE_DB_PATH` | `~/.ouro/trace.db` | Local SQLite trace database path. Used when `TRACE_STORAGE_DIALECT=sqlite` and no `TRACE_DATABASE_URL` is set. |
 | `TRACE_DATABASE_URL` | `""` | Optional database URL for future remote trace backends. SQLite URLs such as `sqlite:///tmp/ouro-trace.db` can also be resolved to local paths. |
 
-Tracing is opt-in until CLI/runtime wiring lands. Core tracing exporters do not read config directly; CLI/capability layers should resolve these settings and inject the selected exporter.
+Tracing is opt-in via `ouro --task "..." --trace`. Core tracing exporters do not read config directly; CLI/capability layers resolve these settings and inject the selected exporter. See `docs/trace-monitor.md` for the local web monitor.
 
 ### Retry
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -31,6 +31,10 @@ ouro --task "Solve this logic puzzle" --reasoning-effort high
 # Enable tracing to the configured SQLite trace DB (`TRACE_DB_PATH`, default `~/.ouro/trace.db`)
 ouro --task "Summarize this README" --trace
 
+# View captured traces in the local web monitor
+ouro-trace-monitor
+# then open http://127.0.0.1:8765
+
 ```
 
 From source (without install):

--- a/docs/trace-monitor.md
+++ b/docs/trace-monitor.md
@@ -1,0 +1,54 @@
+# Trace Monitor
+
+ouro can write opt-in agent traces to the configured SQLite trace database and show them in a local web monitor.
+
+## Capture traces
+
+Tracing is disabled by default. Enable it per run:
+
+```bash
+ouro --task "Summarize this README" --trace
+```
+
+By default, trace events are written to:
+
+```text
+~/.ouro/trace.db
+```
+
+Configure the location in `~/.ouro/config`:
+
+```ini
+TRACE_STORAGE_DIALECT=sqlite
+TRACE_DB_PATH=~/.ouro/trace.db
+TRACE_DATABASE_URL=
+```
+
+## Start the local monitor
+
+```bash
+ouro-trace-monitor
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8765
+```
+
+Useful options:
+
+```bash
+ouro-trace-monitor --host 127.0.0.1 --port 8765
+ouro-trace-monitor --db /path/to/trace.db
+```
+
+The web UI shows:
+
+- recent runs
+- run status and duration
+- LLM/tool call counts
+- trace tree for the selected run
+- raw event metadata for selected spans
+
+The first version polls the SQLite database every few seconds. WebSocket live streaming and swarm/task graph visualizations are planned future improvements.

--- a/ouro/interfaces/trace_web/__init__.py
+++ b/ouro/interfaces/trace_web/__init__.py
@@ -1,0 +1,5 @@
+"""Local web monitor for ouro trace databases."""
+
+from .server import create_app
+
+__all__ = ["create_app"]

--- a/ouro/interfaces/trace_web/server.py
+++ b/ouro/interfaces/trace_web/server.py
@@ -1,0 +1,246 @@
+"""Local aiohttp web monitor for ouro trace databases."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sqlite3
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+from ouro.config import Config
+from ouro.core.tracing import resolve_sqlite_trace_db_path
+
+
+@dataclass(frozen=True)
+class TraceRunSummary:
+    run_id: str
+    started_at: str
+    last_event_at: str
+    status: str
+    duration_ms: int | None
+    llm_calls: int
+    tool_calls: int
+    event_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at,
+            "last_event_at": self.last_event_at,
+            "status": self.status,
+            "duration_ms": self.duration_ms,
+            "llm_calls": self.llm_calls,
+            "tool_calls": self.tool_calls,
+            "event_count": self.event_count,
+        }
+
+
+def configured_trace_db_path() -> Path:
+    """Resolve the configured SQLite trace DB path for the web monitor."""
+    if Config.TRACE_STORAGE_DIALECT != "sqlite":
+        raise ValueError(
+            "Only TRACE_STORAGE_DIALECT=sqlite is supported by the local trace monitor."
+        )
+    return resolve_sqlite_trace_db_path(
+        db_path=Config.TRACE_DB_PATH,
+        database_url=Config.TRACE_DATABASE_URL or None,
+    )
+
+
+def create_app(db_path: str | Path | None = None) -> web.Application:
+    """Create the trace monitor aiohttp app."""
+    app = web.Application()
+    app["trace_db_path"] = (
+        Path(db_path).expanduser() if db_path is not None else configured_trace_db_path()
+    )
+    app.router.add_get("/", handle_index)
+    app.router.add_get("/api/runs", handle_runs)
+    app.router.add_get("/api/runs/latest", handle_latest_run)
+    app.router.add_get("/api/runs/{run_id}", handle_run_detail)
+    app.router.add_get("/static/{name}", handle_static)
+    return app
+
+
+async def handle_index(request: web.Request) -> web.Response:
+    return web.Response(text=_read_static_text("index.html"), content_type="text/html")
+
+
+async def handle_static(request: web.Request) -> web.Response:
+    name = request.match_info["name"]
+    if name not in {"app.js", "style.css"}:
+        raise web.HTTPNotFound(text="static asset not found")
+    content_type = "application/javascript" if name.endswith(".js") else "text/css"
+    return web.Response(text=_read_static_text(name), content_type=content_type)
+
+
+async def handle_runs(request: web.Request) -> web.Response:
+    limit = _parse_limit(request.query.get("limit"))
+    db_path = request.app["trace_db_path"]
+    runs = await asyncio.to_thread(list_runs, db_path, limit)
+    return web.json_response({"runs": [run.to_dict() for run in runs]})
+
+
+async def handle_latest_run(request: web.Request) -> web.Response:
+    db_path = request.app["trace_db_path"]
+    run_id = await asyncio.to_thread(get_latest_run_id, db_path)
+    if run_id is None:
+        return web.json_response({"run": None, "events": []})
+    events = await asyncio.to_thread(get_run_events, db_path, run_id)
+    return web.json_response({"run_id": run_id, "events": events})
+
+
+async def handle_run_detail(request: web.Request) -> web.Response:
+    db_path = request.app["trace_db_path"]
+    run_id = request.match_info["run_id"]
+    events = await asyncio.to_thread(get_run_events, db_path, run_id)
+    if not events:
+        raise web.HTTPNotFound(text=f"run not found: {run_id}")
+    return web.json_response({"run_id": run_id, "events": events})
+
+
+def list_runs(db_path: str | Path, limit: int = 50) -> list[TraceRunSummary]:
+    """Return recent trace run summaries from a SQLite trace DB."""
+    path = Path(db_path).expanduser()
+    if not path.exists():
+        return []
+    with sqlite3.connect(path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT
+                run_id,
+                MIN(timestamp) AS started_at,
+                MAX(timestamp) AS last_event_at,
+                COUNT(*) AS event_count,
+                SUM(CASE WHEN event_type = 'llm_call' AND status = 'completed' THEN 1 ELSE 0 END) AS llm_calls,
+                SUM(CASE WHEN event_type = 'tool_call' AND status = 'completed' THEN 1 ELSE 0 END) AS tool_calls,
+                MAX(CASE WHEN event_type = 'run' AND status IN ('completed', 'failed') THEN status END) AS terminal_status,
+                MAX(CASE WHEN event_type = 'run' AND status IN ('completed', 'failed') THEN duration_ms END) AS duration_ms
+            FROM trace_events
+            GROUP BY run_id
+            ORDER BY last_event_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+    return [
+        TraceRunSummary(
+            run_id=row["run_id"],
+            started_at=row["started_at"],
+            last_event_at=row["last_event_at"],
+            status=row["terminal_status"] or "running",
+            duration_ms=row["duration_ms"],
+            llm_calls=row["llm_calls"] or 0,
+            tool_calls=row["tool_calls"] or 0,
+            event_count=row["event_count"],
+        )
+        for row in rows
+    ]
+
+
+def get_latest_run_id(db_path: str | Path) -> str | None:
+    """Return the most recently updated run ID, if any."""
+    path = Path(db_path).expanduser()
+    if not path.exists():
+        return None
+    with sqlite3.connect(path) as connection:
+        row = connection.execute(
+            """
+            SELECT run_id
+            FROM trace_events
+            GROUP BY run_id
+            ORDER BY MAX(timestamp) DESC
+            LIMIT 1
+            """
+        ).fetchone()
+    return row[0] if row else None
+
+
+def get_run_events(db_path: str | Path, run_id: str) -> list[dict[str, Any]]:
+    """Return all trace events for a run as JSON-ready dictionaries."""
+    path = Path(db_path).expanduser()
+    if not path.exists():
+        return []
+    with sqlite3.connect(path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT
+                event_id,
+                run_id,
+                span_id,
+                parent_span_id,
+                timestamp,
+                event_type,
+                name,
+                status,
+                duration_ms,
+                agent_id,
+                task_id,
+                attributes_json,
+                error_json,
+                links_json
+            FROM trace_events
+            WHERE run_id = ?
+            ORDER BY timestamp, rowid
+            """,
+            (run_id,),
+        ).fetchall()
+    return [_event_row_to_dict(row) for row in rows]
+
+
+def _event_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    columns = row.keys()
+    event = {key: row[key] for key in columns if key not in _JSON_COLUMNS}
+    event["attributes"] = _loads_json(row["attributes_json"], {})
+    event["error"] = _loads_json(row["error_json"], None)
+    event["links"] = _loads_json(row["links_json"], [])
+    return event
+
+
+def _loads_json(raw: str | None, default: Any) -> Any:
+    if raw is None or raw == "":
+        return default
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return default
+
+
+def _parse_limit(raw: str | None) -> int:
+    if raw is None:
+        return 50
+    try:
+        return min(max(int(raw), 1), 200)
+    except ValueError:
+        return 50
+
+
+def _read_static_text(name: str) -> str:
+    return resources.files(__package__).joinpath("static", name).read_text(encoding="utf-8")
+
+
+_JSON_COLUMNS = {"attributes_json", "error_json", "links_json"}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Start the local ouro trace web monitor")
+    parser.add_argument("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=8765, help="Port to bind (default: 8765)")
+    parser.add_argument("--db", type=str, help="SQLite trace DB path (defaults to TRACE_DB_PATH)")
+    args = parser.parse_args()
+
+    app = create_app(args.db)
+    print(f"Starting ouro trace monitor on http://{args.host}:{args.port}")
+    print(f"Trace DB: {app['trace_db_path']}")
+    web.run_app(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/ouro/interfaces/trace_web/static/app.js
+++ b/ouro/interfaces/trace_web/static/app.js
@@ -1,0 +1,93 @@
+let selectedRunId = null;
+let selectedEvent = null;
+
+const runsEl = document.getElementById('runs');
+const treeEl = document.getElementById('tree');
+const rawEl = document.getElementById('raw');
+const titleEl = document.getElementById('detail-title');
+const autoRefreshEl = document.getElementById('auto-refresh');
+
+document.getElementById('refresh').addEventListener('click', () => loadRuns());
+setInterval(() => {
+  if (autoRefreshEl.checked) {
+    loadRuns(false);
+    if (selectedRunId) loadRun(selectedRunId, false);
+  }
+}, 2000);
+
+function duration(ms) {
+  if (ms === null || ms === undefined) return 'running';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+async function loadRuns(selectLatest = true) {
+  const res = await fetch('/api/runs');
+  const data = await res.json();
+  runsEl.innerHTML = '';
+  if (!data.runs.length) {
+    runsEl.innerHTML = '<p class="muted">No traces found. Run `ouro --task "..." --trace` first.</p>';
+    return;
+  }
+  for (const run of data.runs) {
+    const row = document.createElement('div');
+    row.className = `run-row ${run.run_id === selectedRunId ? 'active' : ''}`;
+    row.innerHTML = `
+      <div class="run-id">${run.run_id}</div>
+      <div class="meta"><span class="status-${run.status}">${run.status}</span> · ${duration(run.duration_ms)}</div>
+      <div class="meta">LLM ${run.llm_calls} · Tools ${run.tool_calls} · Events ${run.event_count}</div>
+      <div class="meta">${run.started_at}</div>
+    `;
+    row.addEventListener('click', () => loadRun(run.run_id));
+    runsEl.appendChild(row);
+  }
+  if (selectLatest && !selectedRunId) loadRun(data.runs[0].run_id);
+}
+
+async function loadRun(runId, updateRaw = true) {
+  selectedRunId = runId;
+  const res = await fetch(`/api/runs/${encodeURIComponent(runId)}`);
+  if (!res.ok) return;
+  const data = await res.json();
+  titleEl.textContent = `Trace ${runId}`;
+  renderTree(data.events);
+  if (updateRaw) rawEl.textContent = selectedEvent ? JSON.stringify(selectedEvent, null, 2) : 'Click a trace node to inspect raw event metadata.';
+  loadRuns(false);
+}
+
+function renderTree(events) {
+  treeEl.innerHTML = '';
+  const terminal = events.filter(e => ['completed', 'failed'].includes(e.status));
+  const bySpan = new Map(terminal.map(e => [e.span_id, e]));
+  const children = new Map();
+  for (const event of terminal) {
+    const parent = event.parent_span_id || '__root__';
+    if (!children.has(parent)) children.set(parent, []);
+    children.get(parent).push(event);
+  }
+  const roots = children.get('__root__') || terminal.filter(e => !bySpan.has(e.parent_span_id));
+  if (!roots.length) {
+    treeEl.innerHTML = '<p class="muted">No completed spans yet.</p>';
+    return;
+  }
+  for (const root of roots) renderNode(root, children, 0);
+}
+
+function renderNode(event, children, depth) {
+  const node = document.createElement('div');
+  node.className = `node ${event.status}`;
+  node.style.setProperty('--depth', `${depth * 18}px`);
+  node.innerHTML = `
+    <span class="node-title">${event.event_type} ${event.name}</span>
+    <span class="badge">${event.status} · ${duration(event.duration_ms)}</span>
+  `;
+  node.addEventListener('click', (e) => {
+    e.stopPropagation();
+    selectedEvent = event;
+    rawEl.textContent = JSON.stringify(event, null, 2);
+  });
+  treeEl.appendChild(node);
+  for (const child of children.get(event.span_id) || []) renderNode(child, children, depth + 1);
+}
+
+loadRuns();

--- a/ouro/interfaces/trace_web/static/index.html
+++ b/ouro/interfaces/trace_web/static/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ouro Trace Monitor</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>ouro Trace Monitor</h1>
+      <p>Local view of agent run, LLM call, and tool call traces.</p>
+    </header>
+    <main>
+      <section class="panel runs-panel">
+        <div class="panel-title">
+          <h2>Runs</h2>
+          <button id="refresh">Refresh</button>
+        </div>
+        <div id="runs" class="runs"></div>
+      </section>
+      <section class="panel detail-panel">
+        <div class="panel-title">
+          <h2 id="detail-title">Trace</h2>
+          <label><input id="auto-refresh" type="checkbox" checked /> auto refresh</label>
+        </div>
+        <div id="tree" class="tree muted">Select a run to view its trace.</div>
+      </section>
+      <section class="panel raw-panel">
+        <div class="panel-title"><h2>Selected Event</h2></div>
+        <pre id="raw" class="raw muted">Click a trace node to inspect raw event metadata.</pre>
+      </section>
+    </main>
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/ouro/interfaces/trace_web/static/style.css
+++ b/ouro/interfaces/trace_web/static/style.css
@@ -1,0 +1,84 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --panel: #111827;
+  --panel-2: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #38bdf8;
+  --failed: #fb7185;
+  --ok: #34d399;
+  --border: #374151;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+header { padding: 24px 32px 12px; }
+h1 { margin: 0 0 4px; }
+p { color: var(--muted); margin: 0; }
+main {
+  display: grid;
+  grid-template-columns: 360px minmax(420px, 1fr);
+  grid-template-rows: minmax(360px, 1fr) 280px;
+  gap: 16px;
+  padding: 16px 32px 32px;
+  min-height: calc(100vh - 96px);
+}
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.runs-panel { grid-row: 1 / span 2; }
+.raw-panel { grid-column: 2; }
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel-2);
+}
+h2 { font-size: 16px; margin: 0; }
+button {
+  background: var(--accent);
+  border: 0;
+  border-radius: 8px;
+  color: #082f49;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 6px 10px;
+}
+.runs, .tree, .raw { padding: 12px 16px; overflow: auto; height: calc(100% - 49px); }
+.run-row {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+.run-row:hover, .run-row.active { border-color: var(--accent); }
+.run-id { color: var(--accent); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; overflow-wrap: anywhere; }
+.meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
+.status-completed { color: var(--ok); }
+.status-failed { color: var(--failed); }
+.node {
+  border-left: 2px solid var(--border);
+  cursor: pointer;
+  margin: 4px 0 4px var(--depth, 0px);
+  padding: 6px 8px;
+}
+.node:hover { background: var(--panel-2); }
+.node.failed { border-left-color: var(--failed); }
+.node.completed { border-left-color: var(--ok); }
+.node-title { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.badge { color: var(--muted); font-size: 12px; margin-left: 8px; }
+.raw { white-space: pre-wrap; font-size: 12px; }
+.muted { color: var(--muted); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ Issues = "https://github.com/ouro-ai-labs/ouro/issues"
 [project.scripts]
 ouro-cli = "ouro.interfaces.cli.entry:main"
 ouro-bot = "ouro.interfaces.bot.entry:main"
+ouro-trace-monitor = "ouro.interfaces.trace_web.server:main"
 
 [tool.setuptools]
 packages = [
@@ -111,6 +112,7 @@ packages = [
     "ouro.interfaces.bot",
     "ouro.interfaces.bot.channel",
     "ouro.interfaces.cli",
+    "ouro.interfaces.trace_web",
     "ouro.interfaces.tui",
     "ouro_harbor",
 ]
@@ -119,6 +121,7 @@ packages = [
 "*" = ["py.typed"]
 "ouro_harbor" = ["*.j2"]
 "ouro.capabilities.skills" = ["system/**"]
+"ouro.interfaces.trace_web" = ["static/*"]
 
 [tool.black]
 line-length = 100

--- a/test/test_trace_web_monitor.py
+++ b/test/test_trace_web_monitor.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ouro.core.tracing import SQLiteTraceExporter, TraceEventType, Tracer
+from ouro.interfaces.trace_web.server import get_latest_run_id, get_run_events, list_runs
+
+
+async def _write_sample_trace(db_path: Path) -> None:
+    tracer = Tracer(exporter=SQLiteTraceExporter(db_path), run_id="run-web")
+    async with tracer.span(TraceEventType.RUN, "agent.run"):
+        async with tracer.span(TraceEventType.LLM_CALL, "llm.call") as llm_span:
+            llm_span.set_attributes({"llm.model": "test/model", "llm.total_tokens": 7})
+        async with tracer.span(TraceEventType.TOOL_CALL, "grep_content") as tool_span:
+            tool_span.set_attributes({"tool.result_length": 42})
+
+
+async def test_list_runs_summarizes_trace_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "trace.db"
+    await _write_sample_trace(db_path)
+
+    runs = list_runs(db_path)
+
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.run_id == "run-web"
+    assert run.status == "completed"
+    assert run.duration_ms is not None
+    assert run.llm_calls == 1
+    assert run.tool_calls == 1
+    assert run.event_count == 6
+
+
+async def test_get_latest_run_and_events(tmp_path: Path) -> None:
+    db_path = tmp_path / "trace.db"
+    await _write_sample_trace(db_path)
+
+    assert get_latest_run_id(db_path) == "run-web"
+    events = get_run_events(db_path, "run-web")
+
+    assert {event["event_type"] for event in events} == {"run", "llm_call", "tool_call"}
+    completed_llm = next(
+        event
+        for event in events
+        if event["event_type"] == "llm_call" and event["status"] == "completed"
+    )
+    assert completed_llm["attributes"]["llm.total_tokens"] == 7
+    assert completed_llm["parent_span_id"] is not None
+
+
+def test_missing_trace_database_returns_empty_results(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.db"
+
+    assert list_runs(missing) == []
+    assert get_latest_run_id(missing) is None
+    assert get_run_events(missing, "missing") == []


### PR DESCRIPTION
## Summary

Adds a local web monitor for SQLite-backed agent traces. Users can run `ouro-trace-monitor` and open `http://127.0.0.1:8765` to inspect captured runs, trace trees, and raw event metadata.

## Scope

- Goals:
  - Add `ouro.interfaces.trace_web` with an aiohttp server and static UI.
  - Add `ouro-trace-monitor` script.
  - Query configured SQLite trace DB and expose `/api/runs`, `/api/runs/latest`, and `/api/runs/{run_id}`.
  - Show recent runs, status/duration/counts, trace tree, and selected raw event metadata.
  - Document trace capture and web monitor usage.
- Non-goals:
  - No text-mode `trace list/view` CLI.
  - No WebSocket push yet; the first UI polls periodically.
  - No Task V2/swarm graph visualization yet.
  - No MySQL/StarRocks backend implementation yet.

## Invariants (Must Not Regress)

- [x] Existing CLI/TUI/bot behavior remains unchanged.
- [x] Trace monitor lives in `ouro.interfaces` and does not change core/capabilities import direction.
- [x] Missing trace DB returns empty run results instead of crashing.
- [x] Static assets are included in package data.
- [x] No secrets or generated artifacts committed.

## Acceptance Criteria

- [x] `ouro-trace-monitor -h` shows host/port/db options.
- [x] `GET /api/runs` returns recent run summaries from `trace_events`.
- [x] `GET /api/runs/{run_id}` returns JSON-ready event details.
- [x] Local web page renders run list, trace tree, and raw event panel.
- [x] Docs explain `ouro --task "..." --trace` plus `ouro-trace-monitor`.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_trace_web_monitor.py`
- [x] `ouro-trace-monitor -h`
- [x] Web smoke: start `ouro-trace-monitor --port 8766 --db /tmp/ouro-trace-monitor-smoke.db`, then `curl http://127.0.0.1:8766/api/runs`
- [x] `./scripts/dev.sh precommit`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh importlint`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] Local web smoke used an empty temp SQLite DB and `/api/runs`; no live LLM call required.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Packaging/script registration; covered by install, help, and full check.
- Worst-case input/output size? `/api/runs/{run_id}` returns all events for a run; future pagination may be needed for very large traces.
- Any secrets/logging risks? UI shows persisted trace metadata only; trace instrumentation already avoids full prompts/tool outputs.
- Any async/blocking I/O added on hot paths? None in agent hot path; web monitor queries SQLite via `asyncio.to_thread`.
- What error message does the user see on failure? Missing runs show empty UI/API; unknown run returns HTTP 404.

## Docs / Compatibility

- [x] Added `docs/trace-monitor.md` and updated examples/configuration docs.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
