### PR TITLE
Style retry notices like tool call panels

### DIFF
--- a/ouro/core/llm/retry.py
+++ b/ouro/core/llm/retry.py
@@ -80,15 +80,22 @@ class _ConfigBackoff(wait_base):
 def _boxed_retry_message(
     *, error_type: str, error: BaseException, delay: float, attempt: int
 ) -> str:
-    """Format retry notices as a compact terminal-friendly box."""
+    """Format retry notices as a compact terminal-friendly box.
+
+    Keep this in core without importing the TUI layer, but mirror the visual
+    structure used by terminal_ui.print_tool_call(): rounded corners, a
+    left-aligned title, and indented key/value rows.
+    """
     lines = [
-        f"{error_type} error: {error}",
-        f"Retrying in {delay:.1f}s... (attempt {attempt}/{Config.RETRY_MAX_ATTEMPTS + 1})",
+        f"  error: {error}",
+        f"  retryIn: {delay:.1f}s",
+        f"  attempt: {attempt}/{Config.RETRY_MAX_ATTEMPTS + 1}",
     ]
     width = max(len(line) for line in lines)
-    top = f"┌─ Retry ─{'─' * max(width - 7, 0)}┐"
+    title = f" Retry: {error_type} "
+    top = f"╭─{title}{'─' * max(width - len(title), 0)}╮"
     body = [f"│ {line.ljust(width)} │" for line in lines]
-    bottom = f"└{'─' * (width + 2)}┘"
+    bottom = f"╰{'─' * (width + 2)}╯"
     return "\n".join([top, *body, bottom])
 
 

--- a/test/test_llm_retry.py
+++ b/test/test_llm_retry.py
@@ -78,11 +78,11 @@ def test_log_before_sleep_boxes_second_and_later_retries(caplog):
     with caplog.at_level(logging.WARNING, logger="ouro.core.llm.retry"):
         _log_before_sleep(_retry_state(2, error))
 
-    assert "┌─ Retry" in caplog.text
-    assert "│ Retryable error: Server disconnected without sending a response." in caplog.text
-    assert "│ Retrying in" in caplog.text
-    assert "(attempt 2/" in caplog.text
-    assert "└" in caplog.text
+    assert "╭─ Retry: Retryable" in caplog.text
+    assert "│   error: Server disconnected without sending a response." in caplog.text
+    assert "│   retryIn:" in caplog.text
+    assert "│   attempt: 2/" in caplog.text
+    assert "╰" in caplog.text
 
 
 def test_boxed_retry_message_contains_single_boxed_notice():
@@ -94,7 +94,8 @@ def test_boxed_retry_message_contains_single_boxed_notice():
     )
 
     lines = message.splitlines()
-    assert lines[0].startswith("┌─ Retry ─")
-    assert lines[1].startswith("│ Retryable error: Server disconnected")
-    assert lines[2].startswith("│ Retrying in 1.0s... (attempt 2/")
-    assert lines[3].startswith("└")
+    assert lines[0].startswith("╭─ Retry: Retryable ")
+    assert lines[1].startswith("│   error: Server disconnected")
+    assert lines[2].startswith("│   retryIn: 1.0s")
+    assert lines[3].startswith("│   attempt: 2/")
+    assert lines[4].startswith("╰")


### PR DESCRIPTION
## Summary

Render retry notices with a rounded, tool-call-like panel layout so CLI retry output matches existing tool call styling.

## Scope

- Goals: update retry notice box characters/layout and tests.
- Non-goals: change retry policy, retry timing, or logging frequency.

## Invariants (Must Not Regress)

- [x] First transient retry remains suppressed.
- [x] Second and later retry notices are still logged as warnings.
- [x] Retry max attempt display remains based on configured retry count.
- [x] Core layer does not import TUI/interfaces code.

## Acceptance Criteria

- [x] Retry notices use rounded `╭/╰` style similar to tool call panels.
- [x] Retry notice content is displayed as indented key/value rows.
- [x] Existing retryability behavior is unchanged.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_llm_retry.py`
- [x] `./scripts/dev.sh test -q` via `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] Not run; formatting-only change for retry log output, covered by unit tests.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Retry log formatting consumers that assert exact old box characters.
- Worst-case input/output size? Same as before; error string is still included in one line.
- Any secrets/logging risks? No new fields; does not add prompt/tool output logging.
- Any async/blocking I/O added on hot paths? No.
- What error message does the user see on failure? Same retryable error text, now under `error:` in the panel.

## Docs / Compatibility

- [x] No docs needed for internal CLI formatting change.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)