### PR TITLE
Improve trace web event details and ordering

### DIFF
--- a/docs/trace-monitor.md
+++ b/docs/trace-monitor.md
@@ -49,6 +49,6 @@ The web UI shows:
 - run status and duration
 - LLM/tool call counts
 - trace tree for the selected run
-- raw event metadata for selected spans
+- structured selected-event details with attributes, errors, links, and collapsible raw JSON
 
-The first version polls the SQLite database every few seconds. WebSocket live streaming and swarm/task graph visualizations are planned future improvements.
+The monitor polls the SQLite database every few seconds and shows running spans before their completion events arrive. WebSocket live streaming and swarm/task graph visualizations are planned future improvements.

--- a/ouro/interfaces/trace_web/server.py
+++ b/ouro/interfaces/trace_web/server.py
@@ -118,13 +118,14 @@ def list_runs(db_path: str | Path, limit: int = 50) -> list[TraceRunSummary]:
                 MIN(timestamp) AS started_at,
                 MAX(timestamp) AS last_event_at,
                 COUNT(*) AS event_count,
-                SUM(CASE WHEN event_type = 'llm_call' AND status = 'completed' THEN 1 ELSE 0 END) AS llm_calls,
-                SUM(CASE WHEN event_type = 'tool_call' AND status = 'completed' THEN 1 ELSE 0 END) AS tool_calls,
+                COUNT(DISTINCT CASE WHEN event_type = 'llm_call' THEN span_id END) AS llm_calls,
+                COUNT(DISTINCT CASE WHEN event_type = 'tool_call' THEN span_id END) AS tool_calls,
                 MAX(CASE WHEN event_type = 'run' AND status IN ('completed', 'failed') THEN status END) AS terminal_status,
-                MAX(CASE WHEN event_type = 'run' AND status IN ('completed', 'failed') THEN duration_ms END) AS duration_ms
+                MAX(CASE WHEN event_type = 'run' AND status IN ('completed', 'failed') THEN duration_ms END) AS duration_ms,
+                MAX(rowid) AS last_sequence
             FROM trace_events
             GROUP BY run_id
-            ORDER BY last_event_at DESC
+            ORDER BY last_sequence DESC
             LIMIT ?
             """,
             (limit,),
@@ -155,7 +156,7 @@ def get_latest_run_id(db_path: str | Path) -> str | None:
             SELECT run_id
             FROM trace_events
             GROUP BY run_id
-            ORDER BY MAX(timestamp) DESC
+            ORDER BY MAX(rowid) DESC
             LIMIT 1
             """
         ).fetchone()
@@ -172,6 +173,7 @@ def get_run_events(db_path: str | Path, run_id: str) -> list[dict[str, Any]]:
         rows = connection.execute(
             """
             SELECT
+                rowid AS sequence,
                 event_id,
                 run_id,
                 span_id,
@@ -188,7 +190,7 @@ def get_run_events(db_path: str | Path, run_id: str) -> list[dict[str, Any]]:
                 links_json
             FROM trace_events
             WHERE run_id = ?
-            ORDER BY timestamp, rowid
+            ORDER BY rowid
             """,
             (run_id,),
         ).fetchall()

--- a/ouro/interfaces/trace_web/static/app.js
+++ b/ouro/interfaces/trace_web/static/app.js
@@ -1,5 +1,7 @@
 let selectedRunId = null;
+let selectedSpanId = null;
 let selectedEvent = null;
+let currentSpans = new Map();
 
 const runsEl = document.getElementById('runs');
 const treeEl = document.getElementById('tree');
@@ -21,6 +23,21 @@ function duration(ms) {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function formatValue(value) {
+  if (value === null || value === undefined) return '<span class="muted">None</span>';
+  if (typeof value === 'object') return `<code>${escapeHtml(JSON.stringify(value))}</code>`;
+  return `<code>${escapeHtml(value)}</code>`;
+}
+
 async function loadRuns(selectLatest = true) {
   const res = await fetch('/api/runs');
   const data = await res.json();
@@ -33,61 +50,207 @@ async function loadRuns(selectLatest = true) {
     const row = document.createElement('div');
     row.className = `run-row ${run.run_id === selectedRunId ? 'active' : ''}`;
     row.innerHTML = `
-      <div class="run-id">${run.run_id}</div>
-      <div class="meta"><span class="status-${run.status}">${run.status}</span> · ${duration(run.duration_ms)}</div>
+      <div class="run-id">${escapeHtml(run.run_id)}</div>
+      <div class="meta"><span class="status-${escapeHtml(run.status)}">${escapeHtml(run.status)}</span> · ${duration(run.duration_ms)}</div>
       <div class="meta">LLM ${run.llm_calls} · Tools ${run.tool_calls} · Events ${run.event_count}</div>
-      <div class="meta">${run.started_at}</div>
+      <div class="meta">${escapeHtml(run.started_at)}</div>
     `;
-    row.addEventListener('click', () => loadRun(run.run_id));
+    row.addEventListener('click', () => {
+      selectedSpanId = null;
+      selectedEvent = null;
+      loadRun(run.run_id);
+    });
     runsEl.appendChild(row);
   }
   if (selectLatest && !selectedRunId) loadRun(data.runs[0].run_id);
 }
 
-async function loadRun(runId, updateRaw = true) {
+async function loadRun(runId, resetDetail = true) {
   selectedRunId = runId;
   const res = await fetch(`/api/runs/${encodeURIComponent(runId)}`);
   if (!res.ok) return;
   const data = await res.json();
   titleEl.textContent = `Trace ${runId}`;
-  renderTree(data.events);
-  if (updateRaw) rawEl.textContent = selectedEvent ? JSON.stringify(selectedEvent, null, 2) : 'Click a trace node to inspect raw event metadata.';
+  currentSpans = buildSpanModels(data.events);
+  renderTree(currentSpans);
+
+  if (selectedSpanId && currentSpans.has(selectedSpanId)) {
+    selectedEvent = currentSpans.get(selectedSpanId);
+    renderEventDetail(selectedEvent);
+  } else if (resetDetail) {
+    selectedEvent = null;
+    renderEventDetail(null);
+  }
   loadRuns(false);
 }
 
-function renderTree(events) {
-  treeEl.innerHTML = '';
-  const terminal = events.filter(e => ['completed', 'failed'].includes(e.status));
-  const bySpan = new Map(terminal.map(e => [e.span_id, e]));
-  const children = new Map();
-  for (const event of terminal) {
-    const parent = event.parent_span_id || '__root__';
-    if (!children.has(parent)) children.set(parent, []);
-    children.get(parent).push(event);
+function buildSpanModels(events) {
+  const grouped = new Map();
+  for (const event of events) {
+    if (!grouped.has(event.span_id)) grouped.set(event.span_id, []);
+    grouped.get(event.span_id).push(event);
   }
-  const roots = children.get('__root__') || terminal.filter(e => !bySpan.has(e.parent_span_id));
+
+  const spans = new Map();
+  for (const [spanId, spanEvents] of grouped) {
+    spanEvents.sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    const started = spanEvents.find(e => e.status === 'started') || spanEvents[0];
+    const failed = spanEvents.find(e => e.status === 'failed');
+    const completed = spanEvents.find(e => e.status === 'completed');
+    const terminal = failed || completed || null;
+    const display = terminal || started;
+    spans.set(spanId, {
+      ...display,
+      status: terminal ? terminal.status : 'running',
+      duration_ms: terminal ? terminal.duration_ms : null,
+      parent_span_id: started.parent_span_id || display.parent_span_id,
+      timestamp: started.timestamp,
+      sequence: started.sequence ?? display.sequence ?? 0,
+      attributes: {
+        ...(started.attributes || {}),
+        ...(terminal?.attributes || {}),
+      },
+      lifecycle_events: spanEvents,
+    });
+  }
+  return spans;
+}
+
+function renderTree(spans) {
+  treeEl.innerHTML = '';
+  const children = new Map();
+  const roots = [];
+  for (const span of spans.values()) {
+    const parent = span.parent_span_id;
+    if (parent && spans.has(parent)) {
+      if (!children.has(parent)) children.set(parent, []);
+      children.get(parent).push(span);
+    } else {
+      roots.push(span);
+    }
+  }
+  for (const group of children.values()) group.sort(compareSpanOrder);
+  roots.sort(compareSpanOrder);
+
   if (!roots.length) {
-    treeEl.innerHTML = '<p class="muted">No completed spans yet.</p>';
+    treeEl.innerHTML = '<p class="muted">No trace spans yet.</p>';
     return;
   }
   for (const root of roots) renderNode(root, children, 0);
 }
 
+function compareSpanOrder(a, b) {
+  return (a.sequence ?? 0) - (b.sequence ?? 0);
+}
+
 function renderNode(event, children, depth) {
   const node = document.createElement('div');
-  node.className = `node ${event.status}`;
+  node.className = `node ${event.status} ${event.span_id === selectedSpanId ? 'selected' : ''}`;
   node.style.setProperty('--depth', `${depth * 18}px`);
   node.innerHTML = `
-    <span class="node-title">${event.event_type} ${event.name}</span>
-    <span class="badge">${event.status} · ${duration(event.duration_ms)}</span>
+    <span class="node-title">${escapeHtml(event.event_type)} ${escapeHtml(event.name)}</span>
+    <span class="badge">${escapeHtml(event.status)} · ${duration(event.duration_ms)}</span>
   `;
   node.addEventListener('click', (e) => {
     e.stopPropagation();
+    selectedSpanId = event.span_id;
     selectedEvent = event;
-    rawEl.textContent = JSON.stringify(event, null, 2);
+    renderEventDetail(event);
+    renderTree(currentSpans);
   });
   treeEl.appendChild(node);
   for (const child of children.get(event.span_id) || []) renderNode(child, children, depth + 1);
+}
+
+function renderEventDetail(event) {
+  if (!event) {
+    rawEl.innerHTML = '<p class="muted">Click a trace node to inspect event details.</p>';
+    return;
+  }
+
+  rawEl.innerHTML = `
+    <div class="event-summary">
+      ${summaryCard('Status', `<span class="status-${escapeHtml(event.status)}">${escapeHtml(event.status)}</span>`)}
+      ${summaryCard('Type', escapeHtml(event.event_type))}
+      ${summaryCard('Name', escapeHtml(event.name))}
+      ${summaryCard('Duration', duration(event.duration_ms))}
+    </div>
+
+    <section class="detail-section">
+      <h3>Span</h3>
+      ${keyValueTable({
+        'Run ID': event.run_id,
+        'Event ID': event.event_id,
+        'Span ID': event.span_id,
+        'Parent Span': event.parent_span_id,
+        'Timestamp': event.timestamp,
+        'Sequence': event.sequence,
+        'Agent ID': event.agent_id,
+        'Task ID': event.task_id,
+      })}
+    </section>
+
+    <section class="detail-section">
+      <h3>Attributes</h3>
+      ${keyValueTable(event.attributes || {}, 'No attributes recorded.')}
+    </section>
+
+    <section class="detail-section">
+      <h3>Error</h3>
+      ${renderError(event.error)}
+    </section>
+
+    <section class="detail-section">
+      <h3>Links</h3>
+      ${renderLinks(event.links)}
+    </section>
+
+    <details class="raw-json">
+      <summary>Raw JSON</summary>
+      <pre>${escapeHtml(JSON.stringify(event, null, 2))}</pre>
+    </details>
+  `;
+}
+
+function summaryCard(label, value) {
+  return `
+    <div class="summary-card">
+      <div class="summary-label">${escapeHtml(label)}</div>
+      <div class="summary-value">${value}</div>
+    </div>
+  `;
+}
+
+function keyValueTable(values, emptyText = 'None') {
+  const entries = Object.entries(values).filter(([, value]) => value !== undefined && value !== null && value !== '');
+  if (!entries.length) return `<p class="muted">${escapeHtml(emptyText)}</p>`;
+  return `
+    <table class="kv-table">
+      <tbody>
+        ${entries.map(([key, value]) => `
+          <tr>
+            <th>${escapeHtml(key)}</th>
+            <td>${formatValue(value)}</td>
+          </tr>
+        `).join('')}
+      </tbody>
+    </table>
+  `;
+}
+
+function renderError(error) {
+  if (!error) return '<p class="muted">None</p>';
+  return `
+    <div class="error-block">
+      <strong>${escapeHtml(error.type || 'Error')}</strong>
+      <div>${escapeHtml(error.message || JSON.stringify(error))}</div>
+    </div>
+  `;
+}
+
+function renderLinks(links) {
+  if (!links || !links.length) return '<p class="muted">None</p>';
+  return `<ul class="links">${links.map(link => `<li><code>${escapeHtml(link)}</code></li>`).join('')}</ul>`;
 }
 
 loadRuns();

--- a/ouro/interfaces/trace_web/static/style.css
+++ b/ouro/interfaces/trace_web/static/style.css
@@ -24,7 +24,7 @@ p { color: var(--muted); margin: 0; }
 main {
   display: grid;
   grid-template-columns: 360px minmax(420px, 1fr);
-  grid-template-rows: minmax(360px, 1fr) 280px;
+  grid-template-rows: minmax(360px, 1fr) 320px;
   gap: 16px;
   padding: 16px 32px 32px;
   min-height: calc(100vh - 96px);
@@ -47,6 +47,7 @@ main {
   background: var(--panel-2);
 }
 h2 { font-size: 16px; margin: 0; }
+h3 { font-size: 13px; margin: 0 0 8px; color: var(--text); }
 button {
   background: var(--accent);
   border: 0;
@@ -56,6 +57,7 @@ button {
   font-weight: 700;
   padding: 6px 10px;
 }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .runs, .tree, .raw { padding: 12px 16px; overflow: auto; height: calc(100% - 49px); }
 .run-row {
   border: 1px solid var(--border);
@@ -69,16 +71,93 @@ button {
 .meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
 .status-completed { color: var(--ok); }
 .status-failed { color: var(--failed); }
+.status-running { color: var(--accent); }
 .node {
   border-left: 2px solid var(--border);
   cursor: pointer;
   margin: 4px 0 4px var(--depth, 0px);
   padding: 6px 8px;
 }
-.node:hover { background: var(--panel-2); }
+.node:hover, .node.selected { background: var(--panel-2); }
+.node.selected { outline: 1px solid var(--accent); }
 .node.failed { border-left-color: var(--failed); }
 .node.completed { border-left-color: var(--ok); }
+.node.running { border-left-color: var(--accent); }
 .node-title { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .badge { color: var(--muted); font-size: 12px; margin-left: 8px; }
-.raw { white-space: pre-wrap; font-size: 12px; }
+.raw { font-size: 12px; }
 .muted { color: var(--muted); }
+.event-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.summary-card {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+}
+.summary-label {
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+}
+.summary-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+.detail-section {
+  border-top: 1px solid var(--border);
+  padding: 10px 0;
+}
+.kv-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.kv-table th,
+.kv-table td {
+  border-top: 1px solid rgba(55, 65, 81, 0.6);
+  padding: 6px 4px;
+  text-align: left;
+  vertical-align: top;
+}
+.kv-table th {
+  color: var(--muted);
+  font-weight: 600;
+  width: 180px;
+}
+.kv-table td {
+  overflow-wrap: anywhere;
+}
+.error-block {
+  background: rgba(251, 113, 133, 0.12);
+  border: 1px solid rgba(251, 113, 133, 0.5);
+  border-radius: 8px;
+  color: #fecdd3;
+  padding: 10px;
+}
+.links {
+  margin: 0;
+  padding-left: 18px;
+}
+.raw-json {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+.raw-json summary {
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 700;
+}
+.raw-json pre {
+  background: #020617;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 10px 0 0;
+  overflow: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+}

--- a/test/test_trace_web_monitor.py
+++ b/test/test_trace_web_monitor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from ouro.core.tracing import SQLiteTraceExporter, TraceEventType, Tracer
@@ -46,6 +47,33 @@ async def test_get_latest_run_and_events(tmp_path: Path) -> None:
     )
     assert completed_llm["attributes"]["llm.total_tokens"] == 7
     assert completed_llm["parent_span_id"] is not None
+
+
+async def test_events_include_stable_write_sequence(tmp_path: Path) -> None:
+    db_path = tmp_path / "trace.db"
+    await _write_sample_trace(db_path)
+
+    events = get_run_events(db_path, "run-web")
+
+    assert [event["sequence"] for event in events] == sorted(event["sequence"] for event in events)
+    assert events[0]["status"] == "started"
+
+
+async def test_latest_run_uses_write_order_not_timestamp_only(tmp_path: Path) -> None:
+    db_path = tmp_path / "trace.db"
+    await _write_sample_trace(db_path)
+    tracer = Tracer(exporter=SQLiteTraceExporter(db_path), run_id="run-newer")
+    async with tracer.span(TraceEventType.RUN, "agent.run"):
+        pass
+
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "UPDATE trace_events SET timestamp = '1900-01-01T00:00:00Z' WHERE run_id = 'run-newer'"
+        )
+        connection.commit()
+
+    assert get_latest_run_id(db_path) == "run-newer"
+    assert list_runs(db_path)[0].run_id == "run-newer"
 
 
 def test_missing_trace_database_returns_empty_results(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Improves the local trace web monitor by replacing raw-only selected event output with a structured detail panel and fixing live trace ordering/refresh behavior.

## Scope

- Goals:
  - Show selected event details as summary cards, span metadata, attributes table, error block, links, and collapsible raw JSON.
  - Display running spans as soon as their `started` event appears.
  - Use SQLite write order (`rowid` as `sequence`) for stable event/span ordering.
  - Keep selected event details synchronized during auto-refresh.
- Non-goals:
  - No polling interval change.
  - No backend schema migration.
  - No WebSocket streaming yet.
  - No swarm/task graph visualization yet.

## Invariants (Must Not Regress)

- [x] Existing trace API routes remain compatible.
- [x] Missing trace DB still returns empty run results.
- [x] Raw JSON remains available via collapsible section.
- [x] Event values are HTML-escaped before rendering.
- [x] Core/capabilities behavior is unchanged.

## Acceptance Criteria

- [x] Clicking a trace node shows structured event detail instead of only raw JSON.
- [x] Attributes render as key/value table.
- [x] Errors render in a highlighted error block.
- [x] Running spans appear before completion.
- [x] Tree order follows span start/write sequence.
- [x] Auto-refresh updates the selected event detail.

## Test Plan

- [x] `node --check ouro/interfaces/trace_web/static/app.js`
- [x] Targeted tests: `./scripts/dev.sh test -q test/test_trace_web_monitor.py`
- [x] Web smoke: start `ouro-trace-monitor --port 8767 --db /tmp/ouro-trace-detail-smoke.db`, then `curl http://127.0.0.1:8767/api/runs`
- [x] `./scripts/dev.sh precommit`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] Local web smoke used an empty temp SQLite DB and `/api/runs`; no live LLM call required.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Trace monitor frontend ordering/detail rendering; targeted tests cover backend sequence and latest-run behavior.
- Worst-case input/output size? Detail panel can still show large attribute values; existing trace sanitization bounds attributes, and raw JSON is collapsed.
- Any secrets/logging risks? UI only shows persisted trace metadata; values are HTML-escaped before rendering.
- Any async/blocking I/O added on hot paths? None in agent hot path; monitor still polls SQLite via existing API path.
- What error message does the user see on failure? Missing DB/run behavior unchanged; UI shows empty/no span messages.

## Docs / Compatibility

- [x] Updated `docs/trace-monitor.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
