### PR TITLE
Rename trace monitor command

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -32,7 +32,7 @@ ouro --task "Solve this logic puzzle" --reasoning-effort high
 ouro --task "Summarize this README" --trace
 
 # View captured traces in the local web monitor
-ouro-trace-monitor
+ouro-trace
 # then open http://127.0.0.1:8765
 
 ```

--- a/docs/trace-monitor.md
+++ b/docs/trace-monitor.md
@@ -27,7 +27,7 @@ TRACE_DATABASE_URL=
 ## Start the local monitor
 
 ```bash
-ouro-trace-monitor
+ouro-trace
 ```
 
 Then open:
@@ -39,8 +39,8 @@ http://127.0.0.1:8765
 Useful options:
 
 ```bash
-ouro-trace-monitor --host 127.0.0.1 --port 8765
-ouro-trace-monitor --db /path/to/trace.db
+ouro-trace --host 127.0.0.1 --port 8765
+ouro-trace --db /path/to/trace.db
 ```
 
 The web UI shows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ Issues = "https://github.com/ouro-ai-labs/ouro/issues"
 [project.scripts]
 ouro-cli = "ouro.interfaces.cli.entry:main"
 ouro-bot = "ouro.interfaces.bot.entry:main"
-ouro-trace-monitor = "ouro.interfaces.trace_web.server:main"
+ouro-trace = "ouro.interfaces.trace_web.server:main"
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
## Summary

Renames the local trace monitor console script from `ouro-trace-monitor` to `ouro-trace` and updates docs/examples accordingly.

## Scope

- Goals:
  - Rename the installed command to `ouro-trace`.
  - Update trace monitor docs and examples.
- Non-goals:
  - No behavior changes to the web monitor server or UI.
  - No trace schema/API changes.

## Invariants (Must Not Regress)

- [x] Trace monitor still starts through `ouro.interfaces.trace_web.server:main`.
- [x] Web monitor options remain unchanged (`--host`, `--port`, `--db`).
- [x] Existing trace capture via `ouro --task "..." --trace` remains unchanged.

## Acceptance Criteria

- [x] `ouro-trace -h` works.
- [x] Docs no longer mention `ouro-trace-monitor`.
- [x] `./scripts/dev.sh check` passes.

## Test Plan

- [x] `ouro-trace -h`
- [x] `./scripts/dev.sh test -q test/test_trace_web_monitor.py`
- [x] `./scripts/dev.sh precommit`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] `ouro-trace -h`

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Installed command name changes; docs updated to the new name.
- Worst-case input/output size? Not applicable.
- Any secrets/logging risks? None.
- Any async/blocking I/O added on hot paths? None.
- What error message does the user see on failure? Existing argparse help/error behavior.

## Docs / Compatibility

- [x] Updated `docs/trace-monitor.md` and `docs/examples.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
