### PR TITLE
Capture detailed trace payloads by default

### DIFF
--- a/docs/trace-monitor.md
+++ b/docs/trace-monitor.md
@@ -50,5 +50,6 @@ The web UI shows:
 - LLM/tool call counts
 - trace tree for the selected run
 - structured selected-event details with attributes, errors, links, and collapsible raw JSON
+- captured run task/final answer, LLM messages/responses, and tool arguments/results (with secret redaction and binary/blob omission)
 
 The monitor polls the SQLite database every few seconds and shows running spans before their completion events arrive. WebSocket live streaming and swarm/task graph visualizations are planned future improvements.

--- a/ouro/core/loop/agent.py
+++ b/ouro/core/loop/agent.py
@@ -88,13 +88,14 @@ class Agent:
             TraceEventType.RUN,
             "agent.run",
             attributes={
+                "run.task": task,
                 "task.preview": task[:200],
                 "task.length": len(task),
                 "agent.max_iterations": self.max_iterations,
             },
         ) as span:
             result = await self._run_impl(task, context=context)
-            span.set_attributes({"result.length": len(result)})
+            span.set_attributes({"run.final_answer": result, "result.length": len(result)})
             return result
         raise AssertionError("unreachable: tracer span exited without returning")
 
@@ -146,7 +147,10 @@ class Agent:
                         "llm.model": getattr(self.llm, "model", "unknown"),
                         "llm.provider": getattr(self.llm, "provider_name", "unknown"),
                         "llm.message_count": len(outgoing),
+                        "llm.messages": [_trace_message(message) for message in outgoing],
                         "llm.tool_schema_count": len(tool_schemas),
+                        "llm.tool_schemas": tool_schemas,
+                        "llm.request_params": _trace_request_params(call_kwargs),
                         "agent.iteration": ctx.iteration,
                     },
                 ) as llm_span:
@@ -158,6 +162,9 @@ class Agent:
                             "llm.input_tokens": usage.get("input_tokens", 0),
                             "llm.output_tokens": usage.get("output_tokens", 0),
                             "llm.total_tokens": usage.get("total_tokens", 0),
+                            "llm.response.content": response.content,
+                            "llm.response.tool_calls": response.tool_calls or [],
+                            "llm.response.thinking": getattr(response, "thinking", None),
                         }
                     )
             ctx.stop_reason_last = response.stop_reason
@@ -438,12 +445,15 @@ class Agent:
                 "tool.name": tool_call.name,
                 "tool.call_id": tool_call.id,
                 "tool.argument_keys": sorted(tool_call.arguments.keys()),
+                "tool.arguments": tool_call.arguments,
             },
         ) as tool_span:
             output = await self.tools.execute_tool_call(tool_call.name, tool_call.arguments)
             tool_span.set_attributes(
                 {
+                    "tool.result": output.content,
                     "tool.result_length": len(output.content),
+                    "tool.metadata": output.metadata or {},
                     "tool.metadata_keys": sorted((output.metadata or {}).keys()),
                 }
             )
@@ -523,6 +533,14 @@ class Agent:
         if retries:
             return ContinueDecision.retry_with_feedback(*retries)
         return decision
+
+
+def _trace_message(message: LLMMessage) -> dict[str, Any]:
+    return message.to_dict()
+
+
+def _trace_request_params(call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in call_kwargs.items() if key not in {"messages", "tools"}}
 
 
 def _log_outgoing_messages(iteration: int, messages: list[LLMMessage]) -> None:

--- a/ouro/core/tracing/tracer.py
+++ b/ouro/core/tracing/tracer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import traceback
 import uuid
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
@@ -25,12 +26,18 @@ _SECRET_KEYS = {
     "password",
 }
 _SECRET_SUFFIXES = ("_api_key", "_secret", "_password", "_access_token", "_refresh_token")
-_DEFAULT_MAX_STRING_LENGTH = 2048
+_BLOB_KEYS = {"image", "image_url", "base64", "b64_json", "audio", "video"}
+_DEFAULT_MAX_STRING_LENGTH = 65536
 _DEFAULT_MAX_ATTRIBUTES = 64
 
 
 def _new_id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex}"
+
+
+def _is_blob_key(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in _BLOB_KEYS or lowered.endswith(("_base64", "_b64", "_blob"))
 
 
 def _is_secret_key(key: str) -> bool:
@@ -70,6 +77,8 @@ def sanitize_attributes(
         string_key = str(key)
         if _is_secret_key(string_key):
             sanitized[string_key] = "[redacted]"
+        elif _is_blob_key(string_key):
+            sanitized[string_key] = "[omitted binary/blob]"
         else:
             sanitized[string_key] = _sanitize_value(value, max_string_length=max_string_length)
     return sanitized
@@ -213,6 +222,9 @@ class Span:
         if exc is None:
             await self._emit("completed", duration_ms=duration_ms)
         else:
+            self.set_attributes(
+                {"error.traceback": "".join(traceback.format_exception(exc_type, exc, tb))}
+            )
             await self._emit(
                 "failed",
                 duration_ms=duration_ms,

--- a/test/core/test_agent_tracing.py
+++ b/test/core/test_agent_tracing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from ouro.core.llm import LLMResponse, StopReason, ToolCall, ToolOutput
+from ouro.core.llm import LLMMessage, LLMResponse, StopReason, ToolCall, ToolOutput
 from ouro.core.loop import Agent, NullProgressSink
 from ouro.core.tracing import InMemoryTraceExporter, TraceEventType, Tracer
 
@@ -32,6 +32,11 @@ class _ToolRegistry:
     async def execute_tool_call(self, name: str, arguments: dict) -> ToolOutput:
         self.calls.append((name, arguments))
         return ToolOutput(content="tool output", metadata={"source": "test"})
+
+
+class _BootstrapHook:
+    async def on_run_start(self, ctx, messages):  # type: ignore[no-untyped-def]
+        messages.append(LLMMessage(role="user", content=ctx.task))
 
 
 class _LLM:
@@ -73,7 +78,13 @@ async def test_agent_traces_run_and_llm_spans() -> None:
             )
         ]
     )
-    agent = Agent(llm=llm, tools=_ToolRegistry(), progress=NullProgressSink(), tracer=tracer)
+    agent = Agent(
+        llm=llm,
+        tools=_ToolRegistry(),
+        hooks=(_BootstrapHook(),),
+        progress=NullProgressSink(),
+        tracer=tracer,
+    )
 
     result = await agent.run("say done")
 
@@ -84,6 +95,11 @@ async def test_agent_traces_run_and_llm_spans() -> None:
     assert llm_event.parent_span_id == run.span_id
     assert llm_event.attributes["llm.model"] == "test/model"
     assert llm_event.attributes["llm.total_tokens"] == 5
+    assert run.attributes["run.task"] == "say done"
+    assert run.attributes["run.final_answer"] == "done"
+    assert llm_event.attributes["llm.messages"][-1]["content"] == "say done"
+    assert llm_event.attributes["llm.tool_schemas"][0]["function"]["name"] == "echo"
+    assert llm_event.attributes["llm.response.content"] == "done"
     assert run.attributes["result.length"] == 4
 
 
@@ -106,7 +122,13 @@ async def test_agent_traces_tool_call_spans() -> None:
             LLMResponse(content="done", stop_reason=StopReason.STOP, usage={}),
         ]
     )
-    agent = Agent(llm=llm, tools=_ToolRegistry(), progress=NullProgressSink(), tracer=tracer)
+    agent = Agent(
+        llm=llm,
+        tools=_ToolRegistry(),
+        hooks=(_BootstrapHook(),),
+        progress=NullProgressSink(),
+        tracer=tracer,
+    )
 
     result = await agent.run("use tool")
 
@@ -120,5 +142,8 @@ async def test_agent_traces_tool_call_spans() -> None:
     completed = tool_events[-1]
     assert completed.attributes["tool.name"] == "echo"
     assert completed.attributes["tool.argument_keys"] == ["text"]
+    assert completed.attributes["tool.arguments"] == {"text": "hello"}
+    assert completed.attributes["tool.result"] == "tool output"
+    assert completed.attributes["tool.metadata"] == {"source": "test"}
     assert completed.attributes["tool.result_length"] == len("tool output")
     assert completed.attributes["tool.metadata_keys"] == ["source"]

--- a/test/core/test_tracing.py
+++ b/test/core/test_tracing.py
@@ -56,6 +56,7 @@ async def test_failed_span_records_bounded_error_and_reraises() -> None:
     assert failed.error.type == "ValueError"
     assert failed.error.message == "bad input"
     assert failed.duration_ms is not None
+    assert "ValueError: bad input" in failed.attributes["error.traceback"]
 
 
 async def test_disabled_tracer_does_not_export_events() -> None:
@@ -174,6 +175,10 @@ def test_sanitize_attributes_redacts_and_truncates() -> None:
     assert sanitized["nested"]["Authorization"] == "[redacted]"
     assert sanitized["nested"]["safe"] == "ok"
     assert sanitized["long"] == "xxxx…[truncated]"
+    assert (
+        sanitize_attributes({"image_url": {"url": "data:image/png;base64,abc"}})["image_url"]
+        == "[omitted binary/blob]"
+    )
 
 
 async def test_exporter_failures_do_not_fail_user_work() -> None:


### PR DESCRIPTION
## Summary

Captures richer run, LLM, and tool execution details in trace spans by default so the web monitor can show actual task/final-answer, LLM messages/responses, and tool arguments/results.

## Scope

- Goals:
  - Record full `run.task` and `run.final_answer` attributes.
  - Record LLM messages, tool schemas, request params, response content, response tool calls, and thinking content.
  - Record tool arguments, result content, and metadata.
  - Keep basic safety handling: secret-key redaction, binary/blob omission, large string truncation, and traceback capture on failed spans.
  - Document richer trace details in the trace monitor docs.
- Non-goals:
  - No config toggle for detail capture.
  - No UI layout redesign; existing Attributes panel surfaces the new fields.
  - No new trace DB schema migration.

## Invariants (Must Not Regress)

- [x] Tracing remains opt-in via `--trace`.
- [x] Exporter failures remain best-effort.
- [x] Secret-looking keys are still redacted.
- [x] Image/base64/blob-like fields are omitted.
- [x] Large strings are still truncated.

## Acceptance Criteria

- [x] Run completed span includes full task and final answer.
- [x] LLM span includes messages, tool schemas, request params, and response details.
- [x] Tool span includes arguments, result content, and metadata.
- [x] Failed span attributes include traceback details.
- [x] Blob/image attributes are omitted in sanitizer tests.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/core/test_agent_tracing.py test/core/test_tracing.py`
- [x] `./scripts/dev.sh precommit`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck`
- [x] `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] Not run; real LLM smoke would incur provider cost. Unit tests cover captured payloads deterministically.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Trace payload size and sanitizer behavior; covered by tracing tests and full suite.
- Worst-case input/output size? More attributes are persisted; large strings are truncated to the tracing max string length.
- Any secrets/logging risks? Keys like API keys/tokens/passwords/authorization are redacted, and blob/image fields are omitted. User prompt/tool output content is intentionally captured when tracing is enabled.
- Any async/blocking I/O added on hot paths? No new I/O beyond existing opt-in trace export.
- What error message does the user see on failure? No change; tracing remains best-effort.

## Docs / Compatibility

- [x] Updated `docs/trace-monitor.md`.
- [x] No secrets committed; no generated artifacts (`.venv/`, `dist/`, `build/`, `*.egg-info/`).

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)
