### PR TITLE
Auto-scroll trace tree to latest span

### DIFF
--- a/ouro/interfaces/trace_web/static/app.js
+++ b/ouro/interfaces/trace_web/static/app.js
@@ -23,6 +23,15 @@ function shortId(value) {
   return value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
 }
 
+function isScrolledNearBottom(element) {
+  const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+  return distanceFromBottom < 80;
+}
+
+function scrollTreeToLatest() {
+  treeEl.scrollTop = treeEl.scrollHeight;
+}
+
 function duration(ms) {
   if (ms === null || ms === undefined) return 'running';
   if (ms < 1000) return `${ms}ms`;
@@ -94,8 +103,10 @@ async function loadRun(runId, resetDetail = true) {
   if (!res.ok) return;
   const data = await res.json();
   titleEl.textContent = `Trace · ${shortId(runId)}`;
+  const shouldFollowLatest = resetDetail || isScrolledNearBottom(treeEl);
   currentSpans = buildSpanModels(data.events);
   renderTree(currentSpans);
+  if (shouldFollowLatest) scrollTreeToLatest();
 
   if (selectedSpanId && currentSpans.has(selectedSpanId)) {
     selectedEvent = currentSpans.get(selectedSpanId);


### PR DESCRIPTION
## Summary

Keeps the trace tree focused on the newest spans while preserving manual scrollback.

## Scope

- Goals:
  - Auto-scroll the trace tree to the latest span when opening or switching runs.
  - Continue following new spans during live refresh only when the user is already near the bottom.
  - Avoid interrupting users who manually scroll up to inspect earlier spans.
- Non-goals:
  - No changes to trace event ordering, storage, or APIs.
  - No visual redesign beyond scroll behavior.

## Invariants (Must Not Regress)

- [x] Trace nodes remain ordered by stable write sequence.
- [x] Auto-refresh still updates the selected run.
- [x] Manual trace node selection still updates selected event details.
- [x] Raw JSON open-state preservation remains unchanged.

## Acceptance Criteria

- [x] Opening or switching to a run scrolls the trace tree to the bottom/latest span.
- [x] Live refresh keeps following latest spans when the tree is already near the bottom.
- [x] Live refresh does not force-scroll when the user has scrolled up.
- [x] Existing trace web monitor tests pass.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test test/test_trace_web_monitor.py -q`
- [x] `./scripts/dev.sh test -q` via `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [x] Local trace monitor smoke with sample trace DB and static/API requests.
- [ ] `python main.py --task "..." --verify` not run; this is a trace monitor static UI behavior fix.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Trace tree scroll position during refresh; mitigated by only following when near bottom or switching runs.
- Worst-case input/output size? Large trace trees still render client-side; this change only adjusts `scrollTop`.
- Any secrets/logging risks? No new logging or trace data exposure.
- Any async/blocking I/O added on hot paths? No server or Python hot-path changes.
- What error message does the user see on failure? Existing empty-state/API behavior remains unchanged.

## Docs / Compatibility

- [x] No docs needed for a small UI behavior fix.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)