### PR TITLE
Drop unsupported Codex max_output_tokens parameter

### DIFF
--- a/ouro/core/llm/openai_codex_adapter.py
+++ b/ouro/core/llm/openai_codex_adapter.py
@@ -88,8 +88,11 @@ class OpenAICodexAdapter:
             "tool_choice": "auto",
             "parallel_tool_calls": True,
         }
-        if max_tokens is not None:
-            body["max_output_tokens"] = max_tokens
+        # ChatGPT's subscription Codex endpoint rejects the Responses API
+        # `max_output_tokens` parameter even though the rest of the payload is
+        # Responses-shaped. Keep ouro's generic `max_tokens` argument best-effort
+        # for providers that support it, but do not forward it here.
+        kwargs.pop("max_output_tokens", None)
         if tools:
             body["tools"] = self._convert_tools(tools)
         if "temperature" in kwargs:

--- a/test/test_openai_codex_adapter.py
+++ b/test/test_openai_codex_adapter.py
@@ -76,7 +76,7 @@ def test_build_request_body_uses_responses_protocol() -> None:
     assert body["stream"] is True
     assert body["store"] is False
     assert body["instructions"] == "Be brief."
-    assert body["max_output_tokens"] == 123
+    assert "max_output_tokens" not in body
     assert body["input"] == [
         {"role": "user", "content": [{"type": "input_text", "text": "Call a tool."}]}
     ]
@@ -88,6 +88,18 @@ def test_build_request_body_uses_responses_protocol() -> None:
             "parameters": {"type": "object", "properties": {}},
         }
     ]
+
+
+def test_build_request_body_drops_unsupported_max_output_tokens_kwarg() -> None:
+    adapter = OpenAICodexAdapter("openai-codex/gpt-5.5")
+    body = adapter._build_request_body(
+        [LLMMessage(role="user", content="hello")],
+        tools=None,
+        max_tokens=None,
+        max_output_tokens=123,
+    )
+
+    assert "max_output_tokens" not in body
 
 
 def test_convert_response_events_extracts_text_tool_calls_and_usage() -> None:


### PR DESCRIPTION
## Summary

Fixes ChatGPT Codex subscription requests failing with HTTP 400 for the unsupported `max_output_tokens` parameter.

## Scope

- Goals:
  - Stop forwarding ouro's generic `max_tokens` limit as `max_output_tokens` for `openai-codex/*` models.
  - Drop explicit `max_output_tokens` kwargs before sending Codex request bodies.
  - Add regression coverage for the Codex request body.
- Non-goals:
  - No changes to LiteLLM providers or non-Codex model behavior.
  - No changes to Codex response parsing or OAuth login.

## Invariants (Must Not Regress)

- [x] Codex adapter still uses the Responses-shaped streaming payload.
- [x] Codex adapter still supports tools and reasoning options.
- [x] `openai-codex/*` models still do not require API keys in model config validation.
- [x] Non-Codex adapter routing remains unchanged.

## Acceptance Criteria

- [x] Codex request bodies no longer include `max_output_tokens` when `max_tokens` is supplied.
- [x] Explicit `max_output_tokens` kwargs are dropped for Codex requests.
- [x] Existing Codex adapter tests pass.
- [x] Full repo check passes.

## Test Plan

- [x] Targeted tests: `./scripts/dev.sh test -q test/test_openai_codex_adapter.py test/test_llm_adapter_factory.py test/test_model_manager_chatgpt.py`
- [x] `./scripts/dev.sh test -q` via `./scripts/dev.sh check`
- [x] `TYPECHECK_STRICT=1 ./scripts/dev.sh typecheck` via `./scripts/dev.sh check`

## Smoke Run (Real CLI)

- [ ] `python main.py --task "..." --verify` not run; this would require live ChatGPT/Codex OAuth network usage.

## Adversarial Review (Answer Briefly)

- What existing behavior could this break? Codex calls no longer receive an ouro-enforced output-token cap; this matches the endpoint's current supported parameters.
- Worst-case input/output size? Codex output length is now governed by the service/model defaults rather than `max_output_tokens`.
- Any secrets/logging risks? No new logging; OAuth token handling unchanged.
- Any async/blocking I/O added on hot paths? No new I/O.
- What error message does the user see on failure? Existing Codex HTTP/request error formatting remains unchanged, but the unsupported parameter 400 should be avoided.

## Docs / Compatibility

- [x] No docs needed for provider compatibility fix.
- [x] No secrets committed; no generated artifacts.

🤖 Generated with ouro (https://github.com/ouro-ai-labs/ouro)